### PR TITLE
chore: split build and test in validation worflow

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -43,7 +43,11 @@ jobs:
       - uses: browser-actions/setup-chrome@latest
         with:
           chrome-version: stable
-      - name: Build and Test
+      - name: Build
+        run: |
+          set -x -e -o pipefail
+          mvn -V -e -B -ntp -DskipTests -Dmaven.javadoc.skip=false install
+      - name: Test
         run: |
           set -x -e -o pipefail
           mvn -V -e -B -ntp verify -Dmaven.javadoc.skip=false -DtrimStackTrace=false


### PR DESCRIPTION
When running integration tests Hilla runs a maven goal as a forked process but it fails if the extension artifacts are not in the local maven repository.