### PR TITLE
chore: hide bots from contributors list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,7 @@
                                                 </categories>
                                                 <contributors>
                                                     <contributor>GitHub</contributor>
+                                                    <contributor>[bot]</contributor>
                                                 </contributors>
                                             </hide>
                                             <contributors>


### PR DESCRIPTION
Hide bot from the contributors list in changelog.

Uses same config as in the configuration example https://jreleaser.org/guide/latest/reference/release/changelog.html#_contributors