### PR TITLE
chore: help IntelliJ IDEA to handle hilla-shaded-deps module

### DIFF
--- a/hilla-shaded-deps/pom.xml
+++ b/hilla-shaded-deps/pom.xml
@@ -106,7 +106,7 @@
                 </executions>
             </plugin>
             <!--
-                This configuration is only here to help IntelliJ IDEA find the shaded module
+                This configuration is only here to help IntelliJ IDEA find the shaded module.
                 skipAttach property must be true
             -->
             <plugin>

--- a/hilla-shaded-deps/pom.xml
+++ b/hilla-shaded-deps/pom.xml
@@ -106,7 +106,7 @@
                 </executions>
             </plugin>
             <!--
-                This configuration is only here to make IntelliJ IDEA find the shaded module
+                This configuration is only here to help IntelliJ IDEA find the shaded module
                 skipAttach property must be true
             -->
             <plugin>

--- a/hilla-shaded-deps/pom.xml
+++ b/hilla-shaded-deps/pom.xml
@@ -106,13 +106,12 @@
                 </executions>
             </plugin>
             <!--
-                This configuration is here only to make IntellijIDEA find the shaded module
+                This configuration is only here to make IntelliJ IDEA find the shaded module
                 skipAttach property must be true
             -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-shade-jar</id>

--- a/hilla-shaded-deps/pom.xml
+++ b/hilla-shaded-deps/pom.xml
@@ -105,6 +105,34 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--
+                This configuration is here only to make IntellijIDEA find the shaded module
+                skipAttach property must be true
+            -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-shade-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.build.directory}/${project.build.finalName}.jar</file>
+                                    <type>jar</type>
+                                    <classifier>shaded</classifier>
+                                </artifact>
+                            </artifacts>
+                            <skipAttach>true</skipAttach>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <jandex-maven-plugin.version>1.2.3</jandex-maven-plugin.version>
         <jreleaser-maven-plugin.version>1.6.0</jreleaser-maven-plugin.version>
         <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
+        <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -188,6 +189,11 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
                     <version>${flatten-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>${build-helper-maven-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
IntelliJ IDEA fails to handle the hilla-shaded-deps module, causing compilation errors to be shown in the IDE.
This change adds a maven configuration to attach the same artifact to the maven project with a custom classifier, so that IDEA is able to correctly find the classes. However, the plugin execution is always skipped, so it does not affect the build process.