### PR TITLE
chore: add code style formatting and license headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ artifacts.
 
 ```terminal
 mvn clean
-mvn -Pdistribution -Drevision=<version-to-release> -DskipTests -DaltDeploymentRepository=local::file:./target/staging-deploy deploy 
+mvn -Pdistribution -Drevision=<version-to-release> -DskipTests -DaltDeploymentRepository=local::file:./target/staging-deploy deploy
 mvn -N -Pdistribution -Drevision=<version-to-release> jreleaser:full-release
 ```
 

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
 import com.github.mcollovati.quarkus.hilla.HillaAtmosphereObjectFactory;

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
@@ -1,20 +1,18 @@
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import javax.annotation.security.DenyAll;
-import javax.annotation.security.PermitAll;
-import javax.annotation.security.RolesAllowed;
-import javax.inject.Singleton;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Predicate;
-
+import com.github.mcollovati.quarkus.hilla.HillaAtmosphereObjectFactory;
 import com.github.mcollovati.quarkus.hilla.HillaFormAuthenticationMechanism;
 import com.github.mcollovati.quarkus.hilla.HillaSecurityPolicy;
 import com.github.mcollovati.quarkus.hilla.HillaSecurityRecorder;
 import com.github.mcollovati.quarkus.hilla.QuarkusEndpointConfiguration;
+import com.github.mcollovati.quarkus.hilla.QuarkusEndpointController;
 import com.github.mcollovati.quarkus.hilla.QuarkusEndpointProperties;
+import com.github.mcollovati.quarkus.hilla.QuarkusViewAccessChecker;
 import com.github.mcollovati.quarkus.hilla.deployment.asm.EndpointTransferMapperClassVisitor;
 import com.github.mcollovati.quarkus.hilla.deployment.asm.PushEndpointClassVisitor;
+import com.github.mcollovati.quarkus.hilla.deployment.asm.SpringReplacementsClassVisitor;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.auth.AnonymousAllowed;
 import dev.hilla.Endpoint;
 import dev.hilla.EndpointInvoker;
 import dev.hilla.EndpointRegistry;
@@ -46,10 +44,13 @@ import io.quarkus.undertow.deployment.IgnoredServletContainerInitializerBuildIte
 import io.quarkus.undertow.deployment.ServletBuildItem;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
-import com.github.mcollovati.quarkus.hilla.HillaAtmosphereObjectFactory;
-import com.github.mcollovati.quarkus.hilla.QuarkusEndpointController;
-import com.github.mcollovati.quarkus.hilla.QuarkusViewAccessChecker;
-import com.github.mcollovati.quarkus.hilla.deployment.asm.SpringReplacementsClassVisitor;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Singleton;
 import org.atmosphere.client.TrackMessageSizeInterceptor;
 import org.atmosphere.cpr.ApplicationConfig;
 import org.atmosphere.cpr.AtmosphereServlet;
@@ -60,9 +61,6 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
-
-import com.vaadin.flow.router.Route;
-import com.vaadin.flow.server.auth.AnonymousAllowed;
 
 class QuarkusHillaExtensionProcessor {
 
@@ -77,8 +75,7 @@ class QuarkusHillaExtensionProcessor {
     // ignored
     @BuildStep
     IgnoredServletContainerInitializerBuildItem ignoreEndpointsValidator() {
-        return new IgnoredServletContainerInitializerBuildItem(
-                "dev.hilla.startup.EndpointsValidator");
+        return new IgnoredServletContainerInitializerBuildItem("dev.hilla.startup.EndpointsValidator");
     }
 
     // Configuring removed resources causes the index to be rebuilt, but the
@@ -86,135 +83,118 @@ class QuarkusHillaExtensionProcessor {
     // Adding a marker forces indexes to be build against Hilla artifacts.
     // Removed resources should also be configured for the endpoint artifact.
     @BuildStep
-    void addMarkersForHillaJars(
-            BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> producer) {
+    void addMarkersForHillaJars(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> producer) {
         producer.produce(new AdditionalApplicationArchiveMarkerBuildItem("dev/hilla"));
     }
 
     @BuildStep
-    void registerJaxrsApplicationToFixApplicationPath(
-            BuildProducer<AdditionalIndexedClassesBuildItem> producer) {
-        producer.produce(new AdditionalIndexedClassesBuildItem(
-                QuarkusEndpointController.class.getName()));
+    void registerJaxrsApplicationToFixApplicationPath(BuildProducer<AdditionalIndexedClassesBuildItem> producer) {
+        producer.produce(new AdditionalIndexedClassesBuildItem(QuarkusEndpointController.class.getName()));
     }
 
     @BuildStep
     void registerBeans(BuildProducer<AdditionalBeanBuildItem> beans) {
-        beans.produce(
-                new AdditionalBeanBuildItem(QuarkusEndpointProperties.class));
-        beans.produce(AdditionalBeanBuildItem.builder().addBeanClasses(
-                "com.github.mcollovati.quarkus.hilla.QuarkusEndpointControllerConfiguration")
-                .addBeanClasses(QuarkusEndpointConfiguration.class,
-                        QuarkusEndpointController.class)
+        beans.produce(new AdditionalBeanBuildItem(QuarkusEndpointProperties.class));
+        beans.produce(AdditionalBeanBuildItem.builder()
+                .addBeanClasses("com.github.mcollovati.quarkus.hilla.QuarkusEndpointControllerConfiguration")
+                .addBeanClasses(QuarkusEndpointConfiguration.class, QuarkusEndpointController.class)
                 .setDefaultScope(BuiltinScope.SINGLETON.getName())
-                .setUnremovable().build());
+                .setUnremovable()
+                .build());
 
         beans.produce(AdditionalBeanBuildItem.builder()
                 .addBeanClasses(PushEndpoint.class, PushMessageHandler.class)
                 .setDefaultScope(BuiltinScope.APPLICATION.getName())
-                .setUnremovable().build());
+                .setUnremovable()
+                .build());
     }
 
     @BuildStep
     void registerEndpoints(
             final BuildProducer<AdditionalBeanBuildItem> additionalBeanProducer,
             BuildProducer<BeanDefiningAnnotationBuildItem> additionalBeanDefiningAnnotationRegistry) {
-        additionalBeanDefiningAnnotationRegistry
-                .produce(new BeanDefiningAnnotationBuildItem(
-                        DotName.createSimple(Endpoint.class.getName()),
-                        BuiltinScope.SINGLETON.getName()));
+        additionalBeanDefiningAnnotationRegistry.produce(new BeanDefiningAnnotationBuildItem(
+                DotName.createSimple(Endpoint.class.getName()), BuiltinScope.SINGLETON.getName()));
     }
 
     @BuildStep
     void registerHillaPushServlet(
             BuildProducer<ServletBuildItem> servletProducer,
             BuildProducer<GeneratedResourceBuildItem> resourceProducer) {
-        servletProducer.produce(ServletBuildItem
-                .builder(AtmosphereServlet.class.getName(),
-                        AtmosphereServlet.class.getName())
-                .addMapping("/HILLA/push").setAsyncSupported(true)
-                .addInitParam(ApplicationConfig.JSR356_MAPPING_PATH,
-                        "/HILLA/push")
-                .addInitParam(ApplicationConfig.BROADCASTER_CLASS,
-                        SimpleBroadcaster.class.getName())
-                .addInitParam(ApplicationConfig.ATMOSPHERE_HANDLER,
-                        PushEndpoint.class.getName())
-                .addInitParam(ApplicationConfig.OBJECT_FACTORY,
-                        HillaAtmosphereObjectFactory.class.getName())
-                .addInitParam(ApplicationConfig.ATMOSPHERE_INTERCEPTORS,
-                        AtmosphereResourceLifecycleInterceptor.class.getName()
-                                + ","
-                                + TrackMessageSizeInterceptor.class.getName()
-                                + ","
-                                + SuspendTrackerInterceptor.class.getName())
-                .setLoadOnStartup(1).build());
+        servletProducer.produce(
+                ServletBuildItem.builder(AtmosphereServlet.class.getName(), AtmosphereServlet.class.getName())
+                        .addMapping("/HILLA/push")
+                        .setAsyncSupported(true)
+                        .addInitParam(ApplicationConfig.JSR356_MAPPING_PATH, "/HILLA/push")
+                        .addInitParam(ApplicationConfig.BROADCASTER_CLASS, SimpleBroadcaster.class.getName())
+                        .addInitParam(ApplicationConfig.ATMOSPHERE_HANDLER, PushEndpoint.class.getName())
+                        .addInitParam(ApplicationConfig.OBJECT_FACTORY, HillaAtmosphereObjectFactory.class.getName())
+                        .addInitParam(
+                                ApplicationConfig.ATMOSPHERE_INTERCEPTORS,
+                                AtmosphereResourceLifecycleInterceptor.class.getName()
+                                        + ","
+                                        + TrackMessageSizeInterceptor.class.getName()
+                                        + ","
+                                        + SuspendTrackerInterceptor.class.getName())
+                        .setLoadOnStartup(1)
+                        .build());
     }
 
     @BuildStep
     void replaceCallsToSpring(
-            BuildProducer<BytecodeTransformerBuildItem> producer,
-            final CombinedIndexBuildItem index) {
+            BuildProducer<BytecodeTransformerBuildItem> producer, final CombinedIndexBuildItem index) {
         producer.produce(new BytecodeTransformerBuildItem(
                 EndpointRegistry.class.getName(),
-                (s, classVisitor) -> new SpringReplacementsClassVisitor(
-                        classVisitor, "registerEndpoint")));
-        producer.produce(
-                new BytecodeTransformerBuildItem(PushEndpoint.class.getName(),
-                        (s, classVisitor) -> new PushEndpointClassVisitor(
-                                classVisitor)));
+                (s, classVisitor) -> new SpringReplacementsClassVisitor(classVisitor, "registerEndpoint")));
+        producer.produce(new BytecodeTransformerBuildItem(
+                PushEndpoint.class.getName(), (s, classVisitor) -> new PushEndpointClassVisitor(classVisitor)));
         producer.produce(new BytecodeTransformerBuildItem(
                 EndpointInvoker.class.getName(),
-                (s, classVisitor) -> new SpringReplacementsClassVisitor(
-                        classVisitor, "invokeVaadinEndpointMethod")));
+                (s, classVisitor) -> new SpringReplacementsClassVisitor(classVisitor, "invokeVaadinEndpointMethod")));
         producer.produce(new BytecodeTransformerBuildItem(
                 PushMessageHandler.class.getName(),
-                (s, classVisitor) -> new SpringReplacementsClassVisitor(
-                        classVisitor, "handleBrowserSubscribe")));
+                (s, classVisitor) -> new SpringReplacementsClassVisitor(classVisitor, "handleBrowserSubscribe")));
         producer.produce(new BytecodeTransformerBuildItem(
                 EndpointTransferMapper.class.getName(),
-                (s, classVisitor) -> new EndpointTransferMapperClassVisitor(
-                        classVisitor)));
+                (s, classVisitor) -> new EndpointTransferMapperClassVisitor(classVisitor)));
     }
 
     @BuildStep
-    void replaceFieldAutowiredAnnotations(
-            BuildProducer<AnnotationsTransformerBuildItem> producer) {
-        DotName autowiredAnnotation = DotName.createSimple(
-                "org.springframework.beans.factory.annotation.Autowired");
-        Predicate<AnnotationInstance> isAutowiredAnnotation = ann -> ann.name()
-                .equals(autowiredAnnotation);
+    void replaceFieldAutowiredAnnotations(BuildProducer<AnnotationsTransformerBuildItem> producer) {
+        DotName autowiredAnnotation = DotName.createSimple("org.springframework.beans.factory.annotation.Autowired");
+        Predicate<AnnotationInstance> isAutowiredAnnotation = ann -> ann.name().equals(autowiredAnnotation);
         Set<DotName> classesToTransform = Set.of(
                 DotName.createSimple("dev.hilla.push.PushEndpoint"),
                 DotName.createSimple("dev.hilla.push.PushMessageHandler"));
-        producer.produce(new AnnotationsTransformerBuildItem(
-                new AnnotationsTransformer() {
+        producer.produce(new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
 
-                    @Override
-                    public boolean appliesTo(AnnotationTarget.Kind kind) {
-                        return AnnotationTarget.Kind.FIELD == kind;
-                    }
+            @Override
+            public boolean appliesTo(AnnotationTarget.Kind kind) {
+                return AnnotationTarget.Kind.FIELD == kind;
+            }
 
-                    @Override
-                    public void transform(TransformationContext ctx) {
-                        FieldInfo fieldInfo = ctx.getTarget().asField();
-                        if (classesToTransform
-                                .contains(fieldInfo.declaringClass().name())
-                                && ctx.getAnnotations().stream()
-                                        .anyMatch(isAutowiredAnnotation)) {
-                            ctx.transform().remove(isAutowiredAnnotation)
-                                    .add(DotNames.INJECT).done();
-                        }
-                    }
-                }));
+            @Override
+            public void transform(TransformationContext ctx) {
+                FieldInfo fieldInfo = ctx.getTarget().asField();
+                if (classesToTransform.contains(fieldInfo.declaringClass().name())
+                        && ctx.getAnnotations().stream().anyMatch(isAutowiredAnnotation)) {
+                    ctx.transform()
+                            .remove(isAutowiredAnnotation)
+                            .add(DotNames.INJECT)
+                            .done();
+                }
+            }
+        }));
     }
 
     @BuildStep
-    void registerHillaSecurityPolicy(HttpBuildTimeConfig buildTimeConfig,
-            BuildProducer<AdditionalBeanBuildItem> beans) {
+    void registerHillaSecurityPolicy(
+            HttpBuildTimeConfig buildTimeConfig, BuildProducer<AdditionalBeanBuildItem> beans) {
         if (buildTimeConfig.auth.form.enabled) {
             beans.produce(AdditionalBeanBuildItem.builder()
                     .addBeanClasses(HillaSecurityPolicy.class)
-                    .setDefaultScope(DotNames.SINGLETON).setUnremovable()
+                    .setDefaultScope(DotNames.SINGLETON)
+                    .setUnremovable()
                     .build());
         }
     }
@@ -226,10 +206,11 @@ class QuarkusHillaExtensionProcessor {
             HillaSecurityRecorder recorder,
             BuildProducer<SyntheticBeanBuildItem> producer) {
         if (httpBuildTimeConfig.auth.form.enabled) {
-            producer.produce(SyntheticBeanBuildItem
-                    .configure(HillaFormAuthenticationMechanism.class)
-                    .types(HttpAuthenticationMechanism.class).setRuntimeInit()
-                    .scope(Singleton.class).alternativePriority(1)
+            producer.produce(SyntheticBeanBuildItem.configure(HillaFormAuthenticationMechanism.class)
+                    .types(HttpAuthenticationMechanism.class)
+                    .setRuntimeInit()
+                    .scope(Singleton.class)
+                    .alternativePriority(1)
                     .supplier(recorder.setupFormAuthenticationMechanism())
                     .done());
         }
@@ -238,25 +219,24 @@ class QuarkusHillaExtensionProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
-    void configureHillaSecurityComponents(HillaSecurityRecorder recorder,
-            BeanContainerBuildItem beanContainer) {
+    void configureHillaSecurityComponents(HillaSecurityRecorder recorder, BeanContainerBuildItem beanContainer) {
         recorder.configureHttpSecurityPolicy(beanContainer.getValue());
     }
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    void configureFlowViewAccessChecker(HillaSecurityRecorder recorder,
+    void configureFlowViewAccessChecker(
+            HillaSecurityRecorder recorder,
             BeanContainerBuildItem beanContainer,
             Optional<FlowViewAccessCheckerBuildItem> viewAccessCheckerBuildItem) {
         viewAccessCheckerBuildItem
                 .map(FlowViewAccessCheckerBuildItem::getLoginPath)
-                .ifPresent(loginPath -> recorder.configureFlowViewAccessChecker(
-                        beanContainer.getValue(), loginPath));
-
+                .ifPresent(loginPath -> recorder.configureFlowViewAccessChecker(beanContainer.getValue(), loginPath));
     }
 
     @BuildStep
-    void registerViewAccessChecker(HttpBuildTimeConfig buildTimeConfig,
+    void registerViewAccessChecker(
+            HttpBuildTimeConfig buildTimeConfig,
             CombinedIndexBuildItem index,
             BuildProducer<AdditionalBeanBuildItem> beans,
             BuildProducer<FlowViewAccessCheckerBuildItem> loginProducer) {
@@ -266,33 +246,34 @@ class QuarkusHillaExtensionProcessor {
                 DotName.createSimple(AnonymousAllowed.class.getName()),
                 DotName.createSimple(RolesAllowed.class.getName()),
                 DotName.createSimple(PermitAll.class.getName()));
-        boolean hasSecuredRoutes = index.getComputingIndex()
-                .getAnnotations(DotName.createSimple(Route.class.getName()))
-                .stream()
-                .flatMap(route -> route.target().annotations().stream()
-                        .map(AnnotationInstance::name))
-                .anyMatch(securityAnnotations::contains);
+        boolean hasSecuredRoutes =
+                index.getComputingIndex().getAnnotations(DotName.createSimple(Route.class.getName())).stream()
+                        .flatMap(route -> route.target().annotations().stream().map(AnnotationInstance::name))
+                        .anyMatch(securityAnnotations::contains);
 
         if (buildTimeConfig.auth.form.enabled) {
             beans.produce(AdditionalBeanBuildItem.builder()
                     .addBeanClasses(HillaSecurityPolicy.class)
-                    .setDefaultScope(DotNames.SINGLETON).setUnremovable()
+                    .setDefaultScope(DotNames.SINGLETON)
+                    .setUnremovable()
                     .build());
 
             if (hasSecuredRoutes) {
                 beans.produce(AdditionalBeanBuildItem.builder()
-                        .addBeanClasses(QuarkusViewAccessChecker.class,
-                                QuarkusViewAccessChecker.Installer.class)
-                        .setUnremovable().build());
-                buildTimeConfig.auth.form.loginPage
+                        .addBeanClasses(QuarkusViewAccessChecker.class, QuarkusViewAccessChecker.Installer.class)
+                        .setUnremovable()
+                        .build());
+                buildTimeConfig
+                        .auth
+                        .form
+                        .loginPage
                         .map(FlowViewAccessCheckerBuildItem::new)
                         .ifPresent(loginProducer::produce);
             }
         }
     }
 
-    public static final class FlowViewAccessCheckerBuildItem
-            extends SimpleBuildItem {
+    public static final class FlowViewAccessCheckerBuildItem extends SimpleBuildItem {
 
         private final String loginPath;
 
@@ -304,5 +285,4 @@ class QuarkusHillaExtensionProcessor {
             return loginPath;
         }
     }
-
 }

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/AsmUtils.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/AsmUtils.java
@@ -4,14 +4,15 @@ import org.objectweb.asm.tree.MethodInsnNode;
 
 public class AsmUtils {
 
-
     public static boolean hasMethodInsnSignature(MethodSignature srcMethod, MethodInsnNode methodNode) {
         return hasMethodInsnSignature(srcMethod, methodNode.owner, methodNode.name, methodNode.desc);
     }
-    public static boolean hasMethodInsnSignature(MethodSignature srcMethod, String owner, String name, String descriptor) {
+
+    public static boolean hasMethodInsnSignature(
+            MethodSignature srcMethod, String owner, String name, String descriptor) {
         return srcMethod.getOwner().equals(owner)
                 && srcMethod.getName().equals(name)
-                && (srcMethod.getDescriptor() == null || srcMethod.getDescriptor().equals(descriptor));
+                && (srcMethod.getDescriptor() == null
+                        || srcMethod.getDescriptor().equals(descriptor));
     }
-
 }

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/AsmUtils.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/AsmUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
 import org.objectweb.asm.tree.MethodInsnNode;

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/DropInitStatementMethodNode.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/DropInitStatementMethodNode.java
@@ -1,17 +1,30 @@
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
 import io.quarkus.gizmo.Gizmo;
+import java.util.Set;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.TypeInsnNode;
 
-import java.util.Set;
-
 public class DropInitStatementMethodNode extends DropStatementMethodNode {
 
-    public DropInitStatementMethodNode(int access, String name, String desc,
-                                       String signature, String[] exceptions, MethodVisitor mv, Set<String> classNames) {
-        super(Gizmo.ASM_API_VERSION, access, name, desc, signature, exceptions, mv, (node) -> isTypeInsn(node, classNames));
+    public DropInitStatementMethodNode(
+            int access,
+            String name,
+            String desc,
+            String signature,
+            String[] exceptions,
+            MethodVisitor mv,
+            Set<String> classNames) {
+        super(
+                Gizmo.ASM_API_VERSION,
+                access,
+                name,
+                desc,
+                signature,
+                exceptions,
+                mv,
+                (node) -> isTypeInsn(node, classNames));
     }
 
     private static boolean isTypeInsn(AbstractInsnNode instruction, Set<String> classNames) {

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/DropInitStatementMethodNode.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/DropInitStatementMethodNode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
 import io.quarkus.gizmo.Gizmo;

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/DropStatementMethodNode.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/DropStatementMethodNode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
 import java.util.ListIterator;

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/DropStatementMethodNode.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/DropStatementMethodNode.java
@@ -1,17 +1,24 @@
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
+import java.util.ListIterator;
+import java.util.function.Predicate;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.MethodNode;
 
-import java.util.ListIterator;
-import java.util.function.Predicate;
-
 public class DropStatementMethodNode extends MethodNode {
     protected Predicate<AbstractInsnNode> dropPredicate;
 
-    public DropStatementMethodNode(int api, int access, String name, String descriptor, String signature, String[] exceptions, MethodVisitor mv, Predicate<AbstractInsnNode> dropPredicate) {
+    public DropStatementMethodNode(
+            int api,
+            int access,
+            String name,
+            String descriptor,
+            String signature,
+            String[] exceptions,
+            MethodVisitor mv,
+            Predicate<AbstractInsnNode> dropPredicate) {
         super(api, access, name, descriptor, signature, exceptions);
         this.dropPredicate = dropPredicate;
         this.mv = mv;
@@ -22,12 +29,10 @@ public class DropStatementMethodNode extends MethodNode {
         var iter = instructions.iterator();
         while (iter.hasNext()) {
             var instruction = findNextDropInstruction(iter);
-            if(instruction == null)
-                break;
+            if (instruction == null) break;
             iter.remove();
             // If we match against a label, then there is no previous instruction to remove
-            if (!(instruction instanceof LabelNode))
-                removeUntilPreviousLabel(iter);
+            if (!(instruction instanceof LabelNode)) removeUntilPreviousLabel(iter);
             removeUntilNextLabel(iter);
         }
         accept(mv);

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/EndpointTransferMapperClassVisitor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/EndpointTransferMapperClassVisitor.java
@@ -1,10 +1,9 @@
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
 import io.quarkus.gizmo.Gizmo;
+import java.util.Set;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
-
-import java.util.Set;
 
 public class EndpointTransferMapperClassVisitor extends ClassVisitor {
     private final String methodName = "<init>";
@@ -14,16 +13,20 @@ public class EndpointTransferMapperClassVisitor extends ClassVisitor {
     }
 
     @Override
-    public MethodVisitor visitMethod(int access, String name,
-                                     String descriptor, String signature, String[] exceptions) {
-        MethodVisitor superVisitor = super.visitMethod(access, name,
-                descriptor, signature, exceptions);
+    public MethodVisitor visitMethod(
+            int access, String name, String descriptor, String signature, String[] exceptions) {
+        MethodVisitor superVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
         if (methodName.equals(name)) {
-            return new DropInitStatementMethodNode(access, name, descriptor,
-                    signature, exceptions, superVisitor, Set.of(
-                    "dev/hilla/endpointransfermapper/PageMapper",
-                    "dev/hilla/endpointransfermapper/PageableMapper"
-            ));
+            return new DropInitStatementMethodNode(
+                    access,
+                    name,
+                    descriptor,
+                    signature,
+                    exceptions,
+                    superVisitor,
+                    Set.of(
+                            "dev/hilla/endpointransfermapper/PageMapper",
+                            "dev/hilla/endpointransfermapper/PageableMapper"));
         }
         return superVisitor;
     }

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/EndpointTransferMapperClassVisitor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/EndpointTransferMapperClassVisitor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
 import io.quarkus.gizmo.Gizmo;

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/MethodRedirectVisitor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/MethodRedirectVisitor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
 import io.quarkus.gizmo.Gizmo;

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/MethodRedirectVisitor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/MethodRedirectVisitor.java
@@ -7,7 +7,6 @@ import org.objectweb.asm.Type;
 
 class MethodRedirectVisitor extends MethodVisitor {
 
-
     private final MethodSignature srcMethod;
     private final MethodSignature targetMethod;
 
@@ -18,8 +17,7 @@ class MethodRedirectVisitor extends MethodVisitor {
     }
 
     @Override
-    public void visitMethodInsn(int opcode, String owner, String name,
-                                String descriptor, boolean isInterface) {
+    public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
         if (Opcodes.INVOKESTATIC == opcode && AsmUtils.hasMethodInsnSignature(srcMethod, owner, name, descriptor)) {
             // DROP CALL
             if (targetMethod.equals(MethodSignature.DROP_METHOD)) {
@@ -28,11 +26,11 @@ class MethodRedirectVisitor extends MethodVisitor {
                 for (int i = 0; i < paramAmount; i++) {
                     super.visitInsn(Opcodes.POP);
                 }
-            }
-            else {
+            } else {
                 // REDIRECT CALL
                 var targetDescriptor = targetMethod.getDescriptor() == null ? descriptor : targetMethod.getDescriptor();
-                super.visitMethodInsn(Opcodes.INVOKESTATIC, targetMethod.getOwner(), targetMethod.getName(), targetDescriptor, false);
+                super.visitMethodInsn(
+                        Opcodes.INVOKESTATIC, targetMethod.getOwner(), targetMethod.getName(), targetDescriptor, false);
             }
 
             return;

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/MethodSignature.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/MethodSignature.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
 import java.util.Objects;

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/MethodSignature.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/MethodSignature.java
@@ -41,7 +41,9 @@ public class MethodSignature {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MethodSignature that = (MethodSignature) o;
-        return Objects.equals(methodOwner, that.methodOwner) && Objects.equals(methodName, that.methodName) && Objects.equals(methodDescriptor, that.methodDescriptor);
+        return Objects.equals(methodOwner, that.methodOwner)
+                && Objects.equals(methodName, that.methodName)
+                && Objects.equals(methodDescriptor, that.methodDescriptor);
     }
 
     @Override

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/PushEndpointClassVisitor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/PushEndpointClassVisitor.java
@@ -8,31 +8,47 @@ import org.objectweb.asm.tree.MethodInsnNode;
 
 public class PushEndpointClassVisitor extends ClassVisitor {
     private final String methodName = "onMessageRequest";
-    private final MethodSignature setContextSignature = MethodSignature.of("org/springframework/security/core/context/SecurityContextHolder", "setContext");
-    private final MethodSignature clearContextSignature = MethodSignature.of("org/springframework/security/core/context/SecurityContextHolder", "clearContext");
+    private final MethodSignature setContextSignature =
+            MethodSignature.of("org/springframework/security/core/context/SecurityContextHolder", "setContext");
+    private final MethodSignature clearContextSignature =
+            MethodSignature.of("org/springframework/security/core/context/SecurityContextHolder", "clearContext");
 
     public PushEndpointClassVisitor(ClassVisitor classVisitor) {
         super(Gizmo.ASM_API_VERSION, classVisitor);
     }
 
     @Override
-    public MethodVisitor visitMethod(int access, String name,
-                                     String descriptor, String signature, String[] exceptions) {
-        MethodVisitor superVisitor = super.visitMethod(access, name,
-                descriptor, signature, exceptions);
+    public MethodVisitor visitMethod(
+            int access, String name, String descriptor, String signature, String[] exceptions) {
+        MethodVisitor superVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
         if (methodName.equals(name)) {
             return buildMethodVisitorChain(access, name, descriptor, signature, exceptions, superVisitor);
         }
         return superVisitor;
     }
 
-    private DropStatementMethodNode buildMethodVisitorChain(int access, String name, String descriptor, String signature, String[] exceptions, MethodVisitor superVisitor) {
-        var clearCtxVisitor = new MethodRedirectVisitor(superVisitor, clearContextSignature, MethodSignature.DROP_METHOD);
-        return new DropStatementMethodNode(Gizmo.ASM_API_VERSION, access, name, descriptor,
-                signature, exceptions, clearCtxVisitor, this::isDropMethodCall);
+    private DropStatementMethodNode buildMethodVisitorChain(
+            int access,
+            String name,
+            String descriptor,
+            String signature,
+            String[] exceptions,
+            MethodVisitor superVisitor) {
+        var clearCtxVisitor =
+                new MethodRedirectVisitor(superVisitor, clearContextSignature, MethodSignature.DROP_METHOD);
+        return new DropStatementMethodNode(
+                Gizmo.ASM_API_VERSION,
+                access,
+                name,
+                descriptor,
+                signature,
+                exceptions,
+                clearCtxVisitor,
+                this::isDropMethodCall);
     }
 
     private boolean isDropMethodCall(AbstractInsnNode instruction) {
-        return instruction instanceof MethodInsnNode && AsmUtils.hasMethodInsnSignature(setContextSignature, (MethodInsnNode) instruction);
+        return instruction instanceof MethodInsnNode
+                && AsmUtils.hasMethodInsnSignature(setContextSignature, (MethodInsnNode) instruction);
     }
 }

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/PushEndpointClassVisitor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/PushEndpointClassVisitor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
 import io.quarkus.gizmo.Gizmo;

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/SpringReplacementsClassVisitor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/SpringReplacementsClassVisitor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
 import io.quarkus.gizmo.Gizmo;

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/SpringReplacementsClassVisitor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/SpringReplacementsClassVisitor.java
@@ -8,15 +8,14 @@ public class SpringReplacementsClassVisitor extends ClassVisitor {
 
     private final String methodName;
 
-    public SpringReplacementsClassVisitor(ClassVisitor classVisitor,
-                                          String methodName) {
+    public SpringReplacementsClassVisitor(ClassVisitor classVisitor, String methodName) {
         super(Gizmo.ASM_API_VERSION, classVisitor);
         this.methodName = methodName;
     }
 
     @Override
-    public MethodVisitor visitMethod(int access, String name,
-                                     String descriptor, String signature, String[] exceptions) {
+    public MethodVisitor visitMethod(
+            int access, String name, String descriptor, String signature, String[] exceptions) {
         MethodVisitor superVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
         if (methodName.equals(name)) {
             return new SpringReplacementsRedirectMethodVisitor(superVisitor);

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/SpringReplacementsRedirectMethodVisitor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/SpringReplacementsRedirectMethodVisitor.java
@@ -1,9 +1,8 @@
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
 import io.quarkus.gizmo.Gizmo;
-import org.objectweb.asm.MethodVisitor;
-
 import java.util.Map;
+import org.objectweb.asm.MethodVisitor;
 
 class SpringReplacementsRedirectMethodVisitor extends MethodVisitor {
 
@@ -16,11 +15,18 @@ class SpringReplacementsRedirectMethodVisitor extends MethodVisitor {
                 MethodSignature.DROP_METHOD,
                 MethodSignature.of("org/springframework/util/ClassUtils", "getUserClass"),
                 MethodSignature.of("com/github/mcollovati/quarkus/hilla/SpringReplacements", "classUtils_getUserClass"),
-                MethodSignature.of("dev/hilla/AuthenticationUtil", "getSecurityHolderAuthentication", "()Lorg/springframework/security/core/Authentication;"),
-                MethodSignature.of("com/github/mcollovati/quarkus/hilla/SpringReplacements", "authenticationUtil_getSecurityHolderAuthentication", "()Ljava/security/Principal;"),
+                MethodSignature.of(
+                        "dev/hilla/AuthenticationUtil",
+                        "getSecurityHolderAuthentication",
+                        "()Lorg/springframework/security/core/Authentication;"),
+                MethodSignature.of(
+                        "com/github/mcollovati/quarkus/hilla/SpringReplacements",
+                        "authenticationUtil_getSecurityHolderAuthentication",
+                        "()Ljava/security/Principal;"),
                 MethodSignature.of("dev/hilla/AuthenticationUtil", "getSecurityHolderRoleChecker"),
-                MethodSignature.of("com/github/mcollovati/quarkus/hilla/SpringReplacements", "authenticationUtil_getSecurityHolderRoleChecker")
-        );
+                MethodSignature.of(
+                        "com/github/mcollovati/quarkus/hilla/SpringReplacements",
+                        "authenticationUtil_getSecurityHolderRoleChecker"));
         redirectVisitors = buildVisitorChain(mv, redirects);
     }
 
@@ -33,8 +39,7 @@ class SpringReplacementsRedirectMethodVisitor extends MethodVisitor {
     }
 
     @Override
-    public void visitMethodInsn(int opcode, String owner, String name,
-                                String descriptor, boolean isInterface) {
+    public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
         redirectVisitors.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
     }
 }

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/SpringReplacementsRedirectMethodVisitor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/SpringReplacementsRedirectMethodVisitor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
 import io.quarkus.gizmo.Gizmo;

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointControllerTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointControllerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.givenEndpointRequest;

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointControllerTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointControllerTest.java
@@ -1,5 +1,9 @@
 package com.github.mcollovati.quarkus.hilla.deployment;
 
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.givenEndpointRequest;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+
 import com.github.mcollovati.quarkus.hilla.deployment.TestUtils.Parameters;
 import com.github.mcollovati.quarkus.hilla.deployment.endpoints.TestEndpoint;
 import dev.hilla.exception.EndpointValidationException;
@@ -12,69 +16,85 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.givenEndpointRequest;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-
 class EndpointControllerTest {
 
-    private static final String ENDPOINT_NAME = TestEndpoint.class
-            .getSimpleName();
+    private static final String ENDPOINT_NAME = TestEndpoint.class.getSimpleName();
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestUtils.class, TestEndpoint.class));
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class).addClasses(TestUtils.class, TestEndpoint.class));
 
     @Test
     void invokeEndpoint_singleSimpleParameter() {
         String msg = "A text message";
-        givenEndpointRequest(ENDPOINT_NAME, "echo",
-                Parameters.param("message", msg)).then().assertThat()
-                .statusCode(200).and().body(equalTo("\"" + msg + "\""));
+        givenEndpointRequest(ENDPOINT_NAME, "echo", Parameters.param("message", msg))
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body(equalTo("\"" + msg + "\""));
     }
 
     @Test
     void invokeEndpoint_singleComplexParameter() {
         String msg = "A text message";
         TestEndpoint.Pojo pojo = new TestEndpoint.Pojo(10, msg);
-        givenEndpointRequest(ENDPOINT_NAME, "pojo",
-                Parameters.param("pojo", pojo)).then().assertThat()
-                .statusCode(200).and().body("number", equalTo(100)).and()
+        givenEndpointRequest(ENDPOINT_NAME, "pojo", Parameters.param("pojo", pojo))
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body("number", equalTo(100))
+                .and()
                 .body("text", equalTo(msg + msg));
     }
 
     @Test
     void invokeEndpoint_multipleParameters() {
-        givenEndpointRequest(ENDPOINT_NAME, "calculate",
-                Parameters.param("operator", "+").add("a", 10).add("b", 20))
-                .then().assertThat().statusCode(200).and().body(equalTo("30"));
+        givenEndpointRequest(
+                        ENDPOINT_NAME,
+                        "calculate",
+                        Parameters.param("operator", "+").add("a", 10).add("b", 20))
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body(equalTo("30"));
     }
 
     @Test
     void invokeEndpoint_wrongParametersOrder_badRequest() {
-        givenEndpointRequest(ENDPOINT_NAME, "calculate",
-                Parameters.param("a", 10).add("operator", "+").add("b", 20))
-                .then().assertThat().statusCode(400).and()
-                .body("type",
-                        equalTo(EndpointValidationException.class.getName()))
+        givenEndpointRequest(
+                        ENDPOINT_NAME,
+                        "calculate",
+                        Parameters.param("a", 10).add("operator", "+").add("b", 20))
+                .then()
+                .assertThat()
+                .statusCode(400)
                 .and()
-                .body("message",
-                        CoreMatchers.allOf(containsString("Validation error"),
+                .body("type", equalTo(EndpointValidationException.class.getName()))
+                .and()
+                .body(
+                        "message",
+                        CoreMatchers.allOf(
+                                containsString("Validation error"),
                                 containsString("'TestEndpoint'"),
                                 containsString("'calculate'")))
-                .body("validationErrorData[0].parameterName",
-                        equalTo("operator"));
+                .body("validationErrorData[0].parameterName", equalTo("operator"));
     }
 
     @Test
     void invokeEndpoint_wrongNumberOfParameters_badRequest() {
-        givenEndpointRequest(ENDPOINT_NAME, "calculate",
-                Parameters.param("operator", "+")).then().assertThat()
-                .statusCode(400).and().body("message",
+        givenEndpointRequest(ENDPOINT_NAME, "calculate", Parameters.param("operator", "+"))
+                .then()
+                .assertThat()
+                .statusCode(400)
+                .and()
+                .body(
+                        "message",
                         CoreMatchers.allOf(
-                                containsString(
-                                        "Incorrect number of parameters"),
+                                containsString("Incorrect number of parameters"),
                                 containsString("'TestEndpoint'"),
                                 containsString("'calculate'"),
                                 containsString("expected: 3, got: 1")));
@@ -82,31 +102,39 @@ class EndpointControllerTest {
 
     @Test
     void invokeEndpoint_wrongEndpointName_notFound() {
-        givenEndpointRequest("NotExistingTestEndpoint", "calculate",
-                Parameters.param("operator", "+")).then().assertThat()
+        givenEndpointRequest("NotExistingTestEndpoint", "calculate", Parameters.param("operator", "+"))
+                .then()
+                .assertThat()
                 .statusCode(404);
     }
 
     @Test
     void invokeEndpoint_wrongMethodName_notFound() {
-        givenEndpointRequest(ENDPOINT_NAME, "notExistingMethod",
-                Parameters.param("operator", "+")).then().assertThat()
+        givenEndpointRequest(ENDPOINT_NAME, "notExistingMethod", Parameters.param("operator", "+"))
+                .then()
+                .assertThat()
                 .statusCode(404);
     }
 
     @Test
     void invokeEndpoint_emptyMethodName_notFound() {
-        givenEndpointRequest(ENDPOINT_NAME, "",
-                Parameters.param("operator", "+")).then().assertThat()
+        givenEndpointRequest(ENDPOINT_NAME, "", Parameters.param("operator", "+"))
+                .then()
+                .assertThat()
                 .statusCode(404);
     }
 
     @Test
     void invokeEndpoint_missingMethodName_notFound() {
-        RestAssured.given().contentType(ContentType.JSON)
+        RestAssured.given()
+                .contentType(ContentType.JSON)
                 .cookie("csrfToken", "CSRF_TOKEN")
-                .header("X-CSRF-Token", "CSRF_TOKEN").basePath("/connect")
-                .when().post(ENDPOINT_NAME).then().assertThat().statusCode(404);
+                .header("X-CSRF-Token", "CSRF_TOKEN")
+                .basePath("/connect")
+                .when()
+                .post(ENDPOINT_NAME)
+                .then()
+                .assertThat()
+                .statusCode(404);
     }
-
 }

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointSecurityTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointSecurityTest.java
@@ -1,21 +1,5 @@
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import java.util.function.UnaryOperator;
-import java.util.stream.Stream;
-
-import io.quarkus.security.test.utils.TestIdentityController;
-import io.quarkus.security.test.utils.TestIdentityProvider;
-import io.quarkus.test.QuarkusUnitTest;
-import io.restassured.specification.RequestSpecification;
-import com.github.mcollovati.quarkus.hilla.deployment.TestUtils.User;
-import com.github.mcollovati.quarkus.hilla.deployment.endpoints.SecureEndpoint;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.GUEST;
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
@@ -23,17 +7,31 @@ import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.givenEndp
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 
+import com.github.mcollovati.quarkus.hilla.deployment.TestUtils.User;
+import com.github.mcollovati.quarkus.hilla.deployment.endpoints.SecureEndpoint;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.specification.RequestSpecification;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 class EndpointSecurityTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestIdentityProvider.class,
-                            TestIdentityController.class, TestUtils.class,
-                            SecureEndpoint.class)
-                    .addAsResource(new StringAsset(
-                            "quarkus.http.auth.basic=true\nquarkus.http.auth.proactive=true\n"),
-                            "application.properties"));
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(
+                    JavaArchive.class)
+            .addClasses(TestIdentityProvider.class, TestIdentityController.class, TestUtils.class, SecureEndpoint.class)
+            .addAsResource(
+                    new StringAsset("quarkus.http.auth.basic=true\nquarkus.http.auth.proactive=true\n"),
+                    "application.properties"));
+
     public static final String SECURE_ENDPOINT = "SecureEndpoint";
 
     @BeforeAll
@@ -47,13 +45,18 @@ class EndpointSecurityTest {
     @Test
     void securedEndpoint_permitAll_authenticatedUsersAllowed() {
         Stream.of(USER, GUEST)
-                .forEach(user -> givenEndpointRequest(SECURE_ENDPOINT,
-                        "authenticated", authenticate(user)).then().assertThat()
-                        .statusCode(200).and()
+                .forEach(user -> givenEndpointRequest(SECURE_ENDPOINT, "authenticated", authenticate(user))
+                        .then()
+                        .assertThat()
+                        .statusCode(200)
+                        .and()
                         .body(equalTo("\"AUTHENTICATED\"")));
 
-        givenEndpointRequest(SECURE_ENDPOINT, "authenticated").then()
-                .assertThat().statusCode(401).and()
+        givenEndpointRequest(SECURE_ENDPOINT, "authenticated")
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .and()
                 .body("message", containsString(SECURE_ENDPOINT))
                 .body("message", containsString("reason: 'Access denied'"));
     }
@@ -61,19 +64,25 @@ class EndpointSecurityTest {
     @Test
     void securedEndpoint_adminOnly_onlyAdminAllowed() {
         givenEndpointRequest(SECURE_ENDPOINT, "adminOnly", authenticate(ADMIN))
-                .then().assertThat().statusCode(200).and()
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
                 .body(equalTo("\"ADMIN\""));
 
-        Stream.of(USER, GUEST)
-                .forEach(user -> givenEndpointRequest(SECURE_ENDPOINT,
-                        "adminOnly", authenticate(user)).then().assertThat()
-                        .statusCode(401).and()
-                        .body("message", containsString(SECURE_ENDPOINT))
-                        .body("message",
-                                containsString("reason: 'Access denied'")));
+        Stream.of(USER, GUEST).forEach(user -> givenEndpointRequest(SECURE_ENDPOINT, "adminOnly", authenticate(user))
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .and()
+                .body("message", containsString(SECURE_ENDPOINT))
+                .body("message", containsString("reason: 'Access denied'")));
 
-        givenEndpointRequest(SECURE_ENDPOINT, "adminOnly").then().assertThat()
-                .statusCode(401).and()
+        givenEndpointRequest(SECURE_ENDPOINT, "adminOnly")
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .and()
                 .body("message", containsString(SECURE_ENDPOINT))
                 .body("message", containsString("reason: 'Access denied'"));
     }
@@ -81,53 +90,70 @@ class EndpointSecurityTest {
     @Test
     void securedEndpoint_userOnly_onlyUserAllowed() {
         givenEndpointRequest(SECURE_ENDPOINT, "userOnly", authenticate(USER))
-                .then().assertThat().statusCode(200).and()
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
                 .body(equalTo("\"USER\""));
 
-        Stream.of(ADMIN, GUEST)
-                .forEach(user -> givenEndpointRequest(SECURE_ENDPOINT,
-                        "userOnly", authenticate(user)).then().assertThat()
-                        .statusCode(401).and()
-                        .body("message", containsString(SECURE_ENDPOINT))
-                        .body("message",
-                                containsString("reason: 'Access denied'")));
+        Stream.of(ADMIN, GUEST).forEach(user -> givenEndpointRequest(SECURE_ENDPOINT, "userOnly", authenticate(user))
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .and()
+                .body("message", containsString(SECURE_ENDPOINT))
+                .body("message", containsString("reason: 'Access denied'")));
 
-        givenEndpointRequest(SECURE_ENDPOINT, "userOnly").then().assertThat()
-                .statusCode(401).and()
+        givenEndpointRequest(SECURE_ENDPOINT, "userOnly")
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .and()
                 .body("message", containsString(SECURE_ENDPOINT))
                 .body("message", containsString("reason: 'Access denied'"));
     }
 
     @Test
     void securedEndpoint_adminAndUserOnly_onlyAdminAndUserAllowed() {
-        Stream.of(ADMIN, USER)
-                .forEach(user -> givenEndpointRequest(SECURE_ENDPOINT,
-                        "userAndAdmin", authenticate(user)).then().assertThat()
-                        .statusCode(200).and()
-                        .body(equalTo("\"USER AND ADMIN\"")));
+        Stream.of(ADMIN, USER).forEach(user -> givenEndpointRequest(SECURE_ENDPOINT, "userAndAdmin", authenticate(user))
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body(equalTo("\"USER AND ADMIN\"")));
 
-        givenEndpointRequest(SECURE_ENDPOINT, "userAndAdmin",
-                authenticate(GUEST)).then().assertThat().statusCode(401).and()
+        givenEndpointRequest(SECURE_ENDPOINT, "userAndAdmin", authenticate(GUEST))
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .and()
                 .body("message", containsString(SECURE_ENDPOINT))
                 .body("message", containsString("reason: 'Access denied'"));
 
-        givenEndpointRequest(SECURE_ENDPOINT, "userAndAdmin").then()
-                .assertThat().statusCode(401).and()
+        givenEndpointRequest(SECURE_ENDPOINT, "userAndAdmin")
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .and()
                 .body("message", containsString(SECURE_ENDPOINT))
                 .body("message", containsString("reason: 'Access denied'"));
     }
 
     @Test
     void securedEndpoint_deny_notAllowed() {
-        Stream.of(ADMIN, USER, GUEST)
-                .forEach(user -> givenEndpointRequest(SECURE_ENDPOINT, "deny",
-                        authenticate(user)).then().assertThat().statusCode(401)
-                        .and().body("message", containsString(SECURE_ENDPOINT))
-                        .body("message",
-                                containsString("reason: 'Access denied'")));
+        Stream.of(ADMIN, USER, GUEST).forEach(user -> givenEndpointRequest(SECURE_ENDPOINT, "deny", authenticate(user))
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .and()
+                .body("message", containsString(SECURE_ENDPOINT))
+                .body("message", containsString("reason: 'Access denied'")));
 
-        givenEndpointRequest(SECURE_ENDPOINT, "deny").then().assertThat()
-                .statusCode(401).and()
+        givenEndpointRequest(SECURE_ENDPOINT, "deny")
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .and()
                 .body("message", containsString(SECURE_ENDPOINT))
                 .body("message", containsString("reason: 'Access denied'"));
     }
@@ -135,15 +161,19 @@ class EndpointSecurityTest {
     @Test
     void securedEndpoint_notAnnotatedMethod_denyAll() {
         Stream.of(ADMIN, USER, GUEST)
-                .forEach(user -> givenEndpointRequest(SECURE_ENDPOINT,
-                        "denyByDefault", authenticate(user)).then().assertThat()
-                        .statusCode(401).and()
+                .forEach(user -> givenEndpointRequest(SECURE_ENDPOINT, "denyByDefault", authenticate(user))
+                        .then()
+                        .assertThat()
+                        .statusCode(401)
+                        .and()
                         .body("message", containsString(SECURE_ENDPOINT))
-                        .body("message",
-                                containsString("reason: 'Access denied'")));
+                        .body("message", containsString("reason: 'Access denied'")));
 
-        givenEndpointRequest(SECURE_ENDPOINT, "denyByDefault").then()
-                .assertThat().statusCode(401).and()
+        givenEndpointRequest(SECURE_ENDPOINT, "denyByDefault")
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .and()
                 .body("message", containsString(SECURE_ENDPOINT))
                 .body("message", containsString("reason: 'Access denied'"));
     }

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointSecurityTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointSecurityTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/HillaPushClient.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/HillaPushClient.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/HillaPushClient.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/HillaPushClient.java
@@ -1,10 +1,10 @@
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import javax.websocket.CloseReason;
-import javax.websocket.Endpoint;
-import javax.websocket.EndpointConfig;
-import javax.websocket.MessageHandler;
-import javax.websocket.Session;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
@@ -18,22 +18,19 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.websocket.CloseReason;
+import javax.websocket.Endpoint;
+import javax.websocket.EndpointConfig;
+import javax.websocket.MessageHandler;
+import javax.websocket.Session;
 import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
+public class HillaPushClient extends Endpoint implements MessageHandler.Whole<String> {
 
-public class HillaPushClient extends Endpoint
-        implements MessageHandler.Whole<String> {
-
-    private static final Logger LOGGER = LoggerFactory
-            .getLogger(HillaPushClient.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HillaPushClient.class);
     private static final AtomicInteger CLIENT_ID_GEN = new AtomicInteger();
 
     final LinkedBlockingDeque<String> messages = new LinkedBlockingDeque<>();
@@ -46,8 +43,7 @@ public class HillaPushClient extends Endpoint
 
     private Session session;
 
-    public HillaPushClient(String endpointName, String methodName,
-            Object... parameters) {
+    public HillaPushClient(String endpointName, String methodName, Object... parameters) {
         this.id = Integer.toString(CLIENT_ID_GEN.getAndIncrement());
         this.endpointName = endpointName;
         this.methodName = methodName;
@@ -65,8 +61,7 @@ public class HillaPushClient extends Endpoint
 
     @Override
     public void onClose(Session session, CloseReason closeReason) {
-        LOGGER.trace("Session closed for client {} with reason {}", id,
-                closeReason);
+        LOGGER.trace("Session closed for client {} with reason {}", id, closeReason);
         messages.add("CLOSED: " + closeReason.toString());
         session.removeMessageHandler(this);
         this.session = null;
@@ -101,8 +96,7 @@ public class HillaPushClient extends Endpoint
     }
 
     public void subscribe() {
-        LOGGER.trace("Subscribing client {} :: {}/{} ({})", id, endpointName,
-                methodName, parameters);
+        LOGGER.trace("Subscribing client {} :: {}/{} ({})", id, endpointName, methodName, parameters);
         if (session != null) {
             try {
                 session.getBasicRemote().sendText(createSubscribeMessage());
@@ -114,8 +108,7 @@ public class HillaPushClient extends Endpoint
         }
     }
 
-    public String pollMessage(long timeout, TimeUnit unit)
-            throws InterruptedException {
+    public String pollMessage(long timeout, TimeUnit unit) throws InterruptedException {
         String message = messages.poll(timeout, unit);
         if (message != null) {
             // remove atmosphere internal identifier, to get only the
@@ -125,14 +118,12 @@ public class HillaPushClient extends Endpoint
         return message;
     }
 
-    public void assertMessageReceived(long timeout, TimeUnit unit,
-            String expected) throws InterruptedException {
+    public void assertMessageReceived(long timeout, TimeUnit unit, String expected) throws InterruptedException {
         String msg = pollMessage(timeout, unit);
         Assertions.assertEquals(expected, msg);
     }
 
-    public void assertMessageReceived(long timeout, TimeUnit unit,
-            Consumer<AbstractStringAssert<?>> consumer)
+    public void assertMessageReceived(long timeout, TimeUnit unit, Consumer<AbstractStringAssert<?>> consumer)
             throws InterruptedException {
         String msg = pollMessage(timeout, unit);
         AbstractStringAssert<?> stringAssert = assertThat(msg).isNotNull();
@@ -165,14 +156,13 @@ public class HillaPushClient extends Endpoint
     }
 
     static URI createPUSHConnectURI(URI baseURI) {
-        String contentType = URLEncoder
-                .encode("application/json; charset=UTF-8", UTF_8);
+        String contentType = URLEncoder.encode("application/json; charset=UTF-8", UTF_8);
         return URI.create(baseURI.toASCIIString() + //
-                "?X-Atmosphere-tracking-id=" + UUID.randomUUID() //
+                "?X-Atmosphere-tracking-id="
+                + UUID.randomUUID() //
                 + "&X-Atmosphere-Transport=websocket" //
                 + "&X-Atmosphere-TrackMessageSize=true" //
                 + "&Content-Type=" + contentType //
                 + "&X-atmo-protocol=true&X-CSRF-Token=" + UUID.randomUUID());
     }
-
 }

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveEndpointTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveEndpointTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
 import com.github.mcollovati.quarkus.hilla.deployment.endpoints.ReactiveEndpoint;

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveEndpointTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveEndpointTest.java
@@ -1,18 +1,17 @@
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import javax.enterprise.context.control.ActivateRequestContext;
-import javax.websocket.ContainerProvider;
-import javax.websocket.Session;
-import java.net.URI;
-import java.util.LinkedHashMap;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-
 import com.github.mcollovati.quarkus.hilla.deployment.endpoints.ReactiveEndpoint;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.websocket.ContainerProvider;
+import javax.websocket.Session;
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -21,16 +20,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class ReactiveEndpointTest {
-    private static final String ENDPOINT_NAME = ReactiveEndpoint.class
-            .getSimpleName();
+    private static final String ENDPOINT_NAME = ReactiveEndpoint.class.getSimpleName();
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(ReactiveEndpoint.class, HillaPushClient.class)
-                    .add(new StringAsset(
-                            "com.vaadin.experimental.hillaPush=true"),
-                            "vaadin-featureflags.properties"));
+                    .add(new StringAsset("com.vaadin.experimental.hillaPush=true"), "vaadin-featureflags.properties"));
 
     @TestHTTPResource("/HILLA/push")
     URI uri;
@@ -40,10 +36,8 @@ class ReactiveEndpointTest {
     void reactiveEndpoint_messagesPushedToTheClient() throws Exception {
         URI connectURI = HillaPushClient.createPUSHConnectURI(uri);
         String counterName = UUID.randomUUID().toString();
-        HillaPushClient client = new HillaPushClient(ENDPOINT_NAME, "count",
-                counterName);
-        try (Session ignored = ContainerProvider.getWebSocketContainer()
-                .connectToServer(client, null, connectURI)) {
+        HillaPushClient client = new HillaPushClient(ENDPOINT_NAME, "count", counterName);
+        try (Session ignored = ContainerProvider.getWebSocketContainer().connectToServer(client, null, connectURI)) {
             assertThatClientIsConnected(client);
             for (int i = 1; i < 10; i++) {
                 assertThatPushUpdateHasBeenReceived(client, i);
@@ -56,14 +50,11 @@ class ReactiveEndpointTest {
 
     @Test
     @ActivateRequestContext
-    void cancelableReactiveEndpoint_clientCancel_serverUnsubscribeCallBackInvoked()
-            throws Exception {
+    void cancelableReactiveEndpoint_clientCancel_serverUnsubscribeCallBackInvoked() throws Exception {
         URI connectURI = HillaPushClient.createPUSHConnectURI(uri);
         String counterName = UUID.randomUUID().toString();
-        HillaPushClient client = new HillaPushClient(ENDPOINT_NAME,
-                "cancelableCount", counterName);
-        try (Session ignored = ContainerProvider.getWebSocketContainer()
-                .connectToServer(client, null, connectURI)) {
+        HillaPushClient client = new HillaPushClient(ENDPOINT_NAME, "cancelableCount", counterName);
+        try (Session ignored = ContainerProvider.getWebSocketContainer().connectToServer(client, null, connectURI)) {
             assertThatClientIsConnected(client);
             for (int i = 1; i < 10; i++) {
                 assertThatPushUpdateHasBeenReceived(client, i);
@@ -76,14 +67,11 @@ class ReactiveEndpointTest {
 
     @Test
     @ActivateRequestContext
-    void cancelableReactiveEndpoint_clientDisconnectWithoutCancel_serverUnsubscribeCallBackInvoked()
-            throws Exception {
+    void cancelableReactiveEndpoint_clientDisconnectWithoutCancel_serverUnsubscribeCallBackInvoked() throws Exception {
         URI connectURI = HillaPushClient.createPUSHConnectURI(uri);
         String counterName = UUID.randomUUID().toString();
-        HillaPushClient client = new HillaPushClient(ENDPOINT_NAME,
-                "cancelableCount", counterName);
-        try (Session ignored = ContainerProvider.getWebSocketContainer()
-                .connectToServer(client, null, connectURI)) {
+        HillaPushClient client = new HillaPushClient(ENDPOINT_NAME, "cancelableCount", counterName);
+        try (Session ignored = ContainerProvider.getWebSocketContainer().connectToServer(client, null, connectURI)) {
             assertThatClientIsConnected(client);
             for (int i = 1; i < 10; i++) {
                 assertThatPushUpdateHasBeenReceived(client, i);
@@ -96,14 +84,11 @@ class ReactiveEndpointTest {
 
     @Test
     @ActivateRequestContext
-    void cancelableReactiveEndpoint_subscribeAfterCancel_connectionNotClosedAndMessagesPushed()
-            throws Exception {
+    void cancelableReactiveEndpoint_subscribeAfterCancel_connectionNotClosedAndMessagesPushed() throws Exception {
         URI connectURI = HillaPushClient.createPUSHConnectURI(uri);
         String counterName = UUID.randomUUID().toString();
-        HillaPushClient client = new HillaPushClient(ENDPOINT_NAME,
-                "cancelableCount", counterName);
-        try (Session ignored = ContainerProvider.getWebSocketContainer()
-                .connectToServer(client, null, connectURI)) {
+        HillaPushClient client = new HillaPushClient(ENDPOINT_NAME, "cancelableCount", counterName);
+        try (Session ignored = ContainerProvider.getWebSocketContainer().connectToServer(client, null, connectURI)) {
             assertThatClientIsConnected(client);
             for (int i = 1; i < 5; i++) {
                 assertThatPushUpdateHasBeenReceived(client, i);
@@ -117,39 +102,36 @@ class ReactiveEndpointTest {
             }
             client.cancel();
             assertCounterValue(counterName, -1);
-
         }
         assertThatConnectionHasBeenClosed(client);
     }
 
-    private static void assertThatClientIsConnected(HillaPushClient client)
-            throws InterruptedException {
+    private static void assertThatClientIsConnected(HillaPushClient client) throws InterruptedException {
         client.assertMessageReceived(10, TimeUnit.SECONDS, "CONNECT");
     }
 
-    private static void assertThatConnectionHasBeenClosed(
-            HillaPushClient client) throws InterruptedException {
-        client.assertMessageReceived(1, TimeUnit.SECONDS,
-                message -> message.isNotNull().startsWith("CLOSED: "));
+    private static void assertThatConnectionHasBeenClosed(HillaPushClient client) throws InterruptedException {
+        client.assertMessageReceived(
+                1, TimeUnit.SECONDS, message -> message.isNotNull().startsWith("CLOSED: "));
     }
 
-    private static void assertThatPushUpdateHasBeenReceived(
-            HillaPushClient client, int i) throws InterruptedException {
-        client.assertMessageReceived(1, TimeUnit.SECONDS,
-                message -> message.as("Message %d", i).isEqualTo(
-                        "{\"@type\":\"update\",\"id\":\"%s\",\"item\":%s}",
-                        client.id, i));
+    private static void assertThatPushUpdateHasBeenReceived(HillaPushClient client, int i) throws InterruptedException {
+        client.assertMessageReceived(1, TimeUnit.SECONDS, message -> message.as("Message %d", i)
+                .isEqualTo("{\"@type\":\"update\",\"id\":\"%s\",\"item\":%s}", client.id, i));
     }
 
     private static void assertCounterValue(String counterName, int expected) {
         LinkedHashMap<String, Object> orderedParams = new LinkedHashMap<>();
         orderedParams.put("counterName", counterName);
-        RestAssured.given().contentType(ContentType.JSON)
+        RestAssured.given()
+                .contentType(ContentType.JSON)
                 .cookie("csrfToken", "CSRF_TOKEN")
-                .header("X-CSRF-Token", "CSRF_TOKEN").body(orderedParams)
-                .basePath("/connect").when()
-                .post("/{endpointName}/counterValue", ENDPOINT_NAME).then()
+                .header("X-CSRF-Token", "CSRF_TOKEN")
+                .body(orderedParams)
+                .basePath("/connect")
+                .when()
+                .post("/{endpointName}/counterValue", ENDPOINT_NAME)
+                .then()
                 .body(Matchers.equalTo(Integer.toString(expected)));
     }
-
 }

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveSecureEndpointTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveSecureEndpointTest.java
@@ -1,16 +1,10 @@
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import javax.enterprise.context.control.ActivateRequestContext;
-import javax.websocket.ClientEndpointConfig;
-import javax.websocket.ContainerProvider;
-import javax.websocket.Session;
-import java.net.URI;
-import java.util.Base64;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-import java.util.stream.Stream;
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ANONYMOUS;
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.GUEST;
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.github.mcollovati.quarkus.hilla.deployment.endpoints.ReactiveSecureEndpoint;
 import io.quarkus.security.test.utils.TestIdentityController;
@@ -18,6 +12,17 @@ import io.quarkus.security.test.utils.TestIdentityProvider;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.vertx.core.http.HttpHeaders;
+import java.net.URI;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.websocket.ClientEndpointConfig;
+import javax.websocket.ContainerProvider;
+import javax.websocket.Session;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -27,28 +32,22 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ANONYMOUS;
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.GUEST;
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 class ReactiveSecureEndpointTest {
-    private static final String ENDPOINT_NAME = ReactiveSecureEndpoint.class
-            .getSimpleName();
+    private static final String ENDPOINT_NAME = ReactiveSecureEndpoint.class.getSimpleName();
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestIdentityProvider.class,
-                            TestIdentityController.class, TestUtils.class,
-                            ReactiveSecureEndpoint.class, HillaPushClient.class)
-                    .addAsResource(new StringAsset(
-                            "quarkus.http.auth.basic=true\nquarkus.http.auth.proactive=true\n"),
+                    .addClasses(
+                            TestIdentityProvider.class,
+                            TestIdentityController.class,
+                            TestUtils.class,
+                            ReactiveSecureEndpoint.class,
+                            HillaPushClient.class)
+                    .addAsResource(
+                            new StringAsset("quarkus.http.auth.basic=true\nquarkus.http.auth.proactive=true\n"),
                             "application.properties")
-                    .add(new StringAsset(
-                            "com.vaadin.experimental.hillaPush=true"),
-                            "vaadin-featureflags.properties"));
+                    .add(new StringAsset("com.vaadin.experimental.hillaPush=true"), "vaadin-featureflags.properties"));
 
     @BeforeAll
     public static void setupUsers() {
@@ -64,70 +63,58 @@ class ReactiveSecureEndpointTest {
     @Test
     @ActivateRequestContext
     void securedEndpoint_permitAll_authenticatedUsersAllowed() {
-        Stream.of(ADMIN, USER, GUEST)
-                .forEach(user -> pushConnection(user, "authenticated").accept(
-                        msg -> msg.contains("\"item\":\"AUTHENTICATED\"")));
-        pushConnection(ANONYMOUS, "authenticated")
-                .accept(assertAccessDenied("authenticated"));
+        Stream.of(ADMIN, USER, GUEST).forEach(user -> pushConnection(user, "authenticated")
+                .accept(msg -> msg.contains("\"item\":\"AUTHENTICATED\"")));
+        pushConnection(ANONYMOUS, "authenticated").accept(assertAccessDenied("authenticated"));
     }
 
     @Test
     @ActivateRequestContext
     void securedEndpoint_adminOnly_onlyAdminAllowed() {
-        pushConnection(ADMIN, "adminOnly")
-                .accept(msg -> msg.contains("\"item\":\"ADMIN\""));
+        pushConnection(ADMIN, "adminOnly").accept(msg -> msg.contains("\"item\":\"ADMIN\""));
         Stream.of(ANONYMOUS, USER, GUEST)
-                .forEach(user -> pushConnection(user, "adminOnly")
-                        .accept(assertAccessDenied("adminOnly")));
+                .forEach(user -> pushConnection(user, "adminOnly").accept(assertAccessDenied("adminOnly")));
     }
 
     @Test
     @ActivateRequestContext
     void securedEndpoint_userOnly_onlyUserAllowed() {
-        pushConnection(USER, "userOnly")
-                .accept(msg -> msg.contains("\"item\":\"USER\""));
+        pushConnection(USER, "userOnly").accept(msg -> msg.contains("\"item\":\"USER\""));
         Stream.of(ANONYMOUS, ADMIN, GUEST)
-                .forEach(user -> pushConnection(user, "userOnly")
-                        .accept(assertAccessDenied("userOnly")));
+                .forEach(user -> pushConnection(user, "userOnly").accept(assertAccessDenied("userOnly")));
     }
 
     @Test
     @ActivateRequestContext
     void securedEndpoint_adminAndUserOnly_onlyAdminAndUserAllowed() {
-        Stream.of(ADMIN, USER)
-                .forEach(user -> pushConnection(user, "userAndAdmin").accept(
-                        msg -> msg.contains("\"item\":\"USER AND ADMIN\"")));
+        Stream.of(ADMIN, USER).forEach(user -> pushConnection(user, "userAndAdmin")
+                .accept(msg -> msg.contains("\"item\":\"USER AND ADMIN\"")));
         Stream.of(ANONYMOUS, GUEST)
-                .forEach(user -> pushConnection(user, "userAndAdmin")
-                        .accept(assertAccessDenied("userAndAdmin")));
+                .forEach(user -> pushConnection(user, "userAndAdmin").accept(assertAccessDenied("userAndAdmin")));
     }
 
     @Test
     @ActivateRequestContext
     void securedEndpoint_deny_notAllowed() {
         Stream.of(ANONYMOUS, ADMIN, USER, GUEST)
-                .forEach(user -> pushConnection(user, "deny")
-                        .accept(assertAccessDenied("deny")));
+                .forEach(user -> pushConnection(user, "deny").accept(assertAccessDenied("deny")));
     }
 
     @Test
     @ActivateRequestContext
     void securedEndpoint_notAnnotatedMethod_denyAll() {
         Stream.of(ANONYMOUS, ADMIN, USER, GUEST)
-                .forEach(user -> pushConnection(user, "denyByDefault")
-                        .accept(assertAccessDenied("denyByDefault")));
+                .forEach(user -> pushConnection(user, "denyByDefault").accept(assertAccessDenied("denyByDefault")));
     }
 
-    private Consumer<Consumer<AbstractStringAssert<?>>> pushConnection(
-            TestUtils.User user, String methodName) {
+    private Consumer<Consumer<AbstractStringAssert<?>>> pushConnection(TestUtils.User user, String methodName) {
         return asserter -> {
             URI connectURI = HillaPushClient.createPUSHConnectURI(uri);
-            HillaPushClient client = new HillaPushClient(ENDPOINT_NAME,
-                    methodName);
+            HillaPushClient client = new HillaPushClient(ENDPOINT_NAME, methodName);
             ClientEndpointConfig cec = ClientEndpointConfig.Builder.create()
-                    .configurator(new BasicAuthConfigurator(user)).build();
-            try (Session ignored = ContainerProvider.getWebSocketContainer()
-                    .connectToServer(client, cec, connectURI)) {
+                    .configurator(new BasicAuthConfigurator(user))
+                    .build();
+            try (Session ignored = ContainerProvider.getWebSocketContainer().connectToServer(client, cec, connectURI)) {
                 client.assertMessageReceived(10, TimeUnit.SECONDS, "CONNECT");
                 client.assertMessageReceived(1, TimeUnit.SECONDS, asserter);
             } catch (Exception e) {
@@ -136,15 +123,13 @@ class ReactiveSecureEndpointTest {
         };
     }
 
-    private Consumer<AbstractStringAssert<?>> assertAccessDenied(
-            String method) {
+    private Consumer<AbstractStringAssert<?>> assertAccessDenied(String method) {
         return msg -> msg.contains("Access denied")
                 .containsSequence("Endpoint '", ENDPOINT_NAME, "'")
                 .contains(String.format("method '%s'", method));
     }
 
-    private static class BasicAuthConfigurator
-            extends ClientEndpointConfig.Configurator {
+    private static class BasicAuthConfigurator extends ClientEndpointConfig.Configurator {
 
         private final TestUtils.User user;
 
@@ -156,12 +141,9 @@ class ReactiveSecureEndpointTest {
         public void beforeRequest(Map<String, List<String>> headers) {
             if (user.username != null && user.pwd != null) {
                 String credentials = user.username + ":" + user.pwd;
-                String authHeader = "Basic " + Base64.getEncoder()
-                        .encodeToString(credentials.getBytes(UTF_8));
-                headers.put(HttpHeaders.AUTHORIZATION.toString(),
-                        List.of(authHeader));
+                String authHeader = "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(UTF_8));
+                headers.put(HttpHeaders.AUTHORIZATION.toString(), List.of(authHeader));
             }
         }
     }
-
 }

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveSecureEndpointTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveSecureEndpointTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringReplacementsTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringReplacementsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringReplacementsTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringReplacementsTest.java
@@ -1,10 +1,8 @@
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import java.security.Principal;
-import java.util.Set;
-import java.util.function.Function;
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.mcollovati.quarkus.hilla.SpringReplacements;
 import io.quarkus.security.test.utils.AuthData;
@@ -12,6 +10,11 @@ import io.quarkus.security.test.utils.IdentityMock;
 import io.quarkus.security.test.utils.TestIdentityController;
 import io.quarkus.security.test.utils.TestIdentityProvider;
 import io.quarkus.test.QuarkusUnitTest;
+import java.security.Principal;
+import java.util.Set;
+import java.util.function.Function;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -19,23 +22,16 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
-import static org.assertj.core.api.Assertions.assertThat;
-
 class SpringReplacementsTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestIdentityProvider.class, IdentityMock.class,
-                            TestIdentityController.class, TestUtils.class)
-                    .addAsResource(new StringAsset(
-                            "quarkus.http.auth.basic=true\nquarkus.http.auth.proactive=true\n"),
-                            "application.properties")
-                    .add(new StringAsset(
-                            "com.vaadin.experimental.hillaPush=true"),
-                            "vaadin-featureflags.properties"));
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(
+                    JavaArchive.class)
+            .addClasses(TestIdentityProvider.class, IdentityMock.class, TestIdentityController.class, TestUtils.class)
+            .addAsResource(
+                    new StringAsset("quarkus.http.auth.basic=true\nquarkus.http.auth.proactive=true\n"),
+                    "application.properties")
+            .add(new StringAsset("com.vaadin.experimental.hillaPush=true"), "vaadin-featureflags.properties"));
 
     @Inject
     MyBean bean;
@@ -50,30 +46,24 @@ class SpringReplacementsTest {
     @Test
     void authenticationUtil_getSecurityHolderAuthentication_anonymous_returnsNull() {
         IdentityMock.setUpAuth(IdentityMock.ANONYMOUS);
-        Principal principal = SpringReplacements
-                .authenticationUtil_getSecurityHolderAuthentication();
+        Principal principal = SpringReplacements.authenticationUtil_getSecurityHolderAuthentication();
         assertThat(principal).isNull();
     }
 
     @Test
     void authenticationUtil_getSecurityHolderAuthentication_authenticated_returnsPrincipal() {
         IdentityMock.setUpAuth(IdentityMock.ADMIN);
-        Principal principal = SpringReplacements
-                .authenticationUtil_getSecurityHolderAuthentication();
-        assertThat(principal).isNotNull().extracting(Principal::getName)
-                .isEqualTo("admin");
+        Principal principal = SpringReplacements.authenticationUtil_getSecurityHolderAuthentication();
+        assertThat(principal).isNotNull().extracting(Principal::getName).isEqualTo("admin");
     }
 
     @Test
     void authenticationUtil_getSecurityHolderRoleChecker_authenticated_checksRoles() {
-        IdentityMock.setUpAuth(
-                new AuthData(Set.of("ADMIN", "SUPERUSER"), false, "admin"));
-        Function<String, Boolean> checker = SpringReplacements
-                .authenticationUtil_getSecurityHolderRoleChecker();
+        IdentityMock.setUpAuth(new AuthData(Set.of("ADMIN", "SUPERUSER"), false, "admin"));
+        Function<String, Boolean> checker = SpringReplacements.authenticationUtil_getSecurityHolderRoleChecker();
         assertThat(checker).isNotNull();
         assertThat(checker.apply("ADMIN")).as("Check for ADMIN role").isTrue();
-        assertThat(checker.apply("SUPERUSER")).as("Check for SUPERUSER role")
-                .isTrue();
+        assertThat(checker.apply("SUPERUSER")).as("Check for SUPERUSER role").isTrue();
         assertThat(checker.apply("GUEST")).as("Check for GUEST role").isFalse();
         assertThat(checker.apply("")).as("Check for blank role").isFalse();
         assertThat(checker.apply(null)).as("Check for null role").isFalse();
@@ -82,23 +72,19 @@ class SpringReplacementsTest {
     @Test
     void authenticationUtil_getSecurityHolderRoleChecker_anonymous_checkIsAlwaysFalse() {
         IdentityMock.setUpAuth(IdentityMock.ANONYMOUS);
-        Function<String, Boolean> checker = SpringReplacements
-                .authenticationUtil_getSecurityHolderRoleChecker();
+        Function<String, Boolean> checker = SpringReplacements.authenticationUtil_getSecurityHolderRoleChecker();
         assertThat(checker).isNotNull();
         assertThat(checker.apply("ADMIN")).as("Check for ADMIN role").isFalse();
-        assertThat(checker.apply("SUPERUSER")).as("Check for SUPERUSER role")
-                .isFalse();
+        assertThat(checker.apply("SUPERUSER")).as("Check for SUPERUSER role").isFalse();
         assertThat(checker.apply("GUEST")).as("Check for GUEST role").isFalse();
-        assertThat(checker.apply("ANONYMOUS")).as("Check for ANONYMOUS role")
-                .isFalse();
+        assertThat(checker.apply("ANONYMOUS")).as("Check for ANONYMOUS role").isFalse();
         assertThat(checker.apply("")).as("Check for blank role").isFalse();
         assertThat(checker.apply(null)).as("Check for null role").isFalse();
     }
 
     @Test
     void classUtils_getUserClass_proxiedObject_returnRawClass() {
-        Class<?> userClass = SpringReplacements
-                .classUtils_getUserClass(bean.getClass());
+        Class<?> userClass = SpringReplacements.classUtils_getUserClass(bean.getClass());
         assertThat(userClass).isEqualTo(MyBean.class);
 
         userClass = SpringReplacements.classUtils_getUserClass(new MyBean());
@@ -106,7 +92,5 @@ class SpringReplacementsTest {
     }
 
     @ApplicationScoped
-    public static class MyBean {
-
-    }
+    public static class MyBean {}
 }

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/TestUtils.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/TestUtils.java
@@ -1,12 +1,11 @@
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import java.util.LinkedHashMap;
-import java.util.function.UnaryOperator;
-
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
+import java.util.LinkedHashMap;
+import java.util.function.UnaryOperator;
 
 final class TestUtils {
 
@@ -15,34 +14,32 @@ final class TestUtils {
     static final User USER = new User("user", "user");
     static final User GUEST = new User("guest", "guest");
 
-    static Response givenEndpointRequest(String endpointName,
-            String methodName) {
-        return givenEndpointRequest(endpointName, methodName, new Parameters(),
-                UnaryOperator.identity());
+    static Response givenEndpointRequest(String endpointName, String methodName) {
+        return givenEndpointRequest(endpointName, methodName, new Parameters(), UnaryOperator.identity());
     }
 
-    static Response givenEndpointRequest(String endpointName, String methodName,
-            UnaryOperator<RequestSpecification> customizer) {
-        return givenEndpointRequest(endpointName, methodName, new Parameters(),
-                customizer);
+    static Response givenEndpointRequest(
+            String endpointName, String methodName, UnaryOperator<RequestSpecification> customizer) {
+        return givenEndpointRequest(endpointName, methodName, new Parameters(), customizer);
     }
 
-    static Response givenEndpointRequest(String endpointName, String methodName,
-            Parameters parameters) {
-        return givenEndpointRequest(endpointName, methodName, parameters,
-                UnaryOperator.identity());
+    static Response givenEndpointRequest(String endpointName, String methodName, Parameters parameters) {
+        return givenEndpointRequest(endpointName, methodName, parameters, UnaryOperator.identity());
     }
 
-    static Response givenEndpointRequest(String endpointName, String methodName,
+    static Response givenEndpointRequest(
+            String endpointName,
+            String methodName,
             Parameters parameters,
             UnaryOperator<RequestSpecification> customizer) {
         RequestSpecification specs = RestAssured.given()
-                .contentType(ContentType.JSON).cookie("csrfToken", "CSRF_TOKEN")
-                .header("X-CSRF-Token", "CSRF_TOKEN").body(parameters.params)
+                .contentType(ContentType.JSON)
+                .cookie("csrfToken", "CSRF_TOKEN")
+                .header("X-CSRF-Token", "CSRF_TOKEN")
+                .body(parameters.params)
                 .basePath("/connect");
         specs = customizer.apply(specs);
-        return specs.when().post("{endpointName}/{methodName}", endpointName,
-                methodName);
+        return specs.when().post("{endpointName}/{methodName}", endpointName, methodName);
     }
 
     public static class Parameters {
@@ -70,5 +67,4 @@ final class TestUtils {
             this.pwd = pwd;
         }
     }
-
 }

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/TestUtils.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/TestUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
 import io.restassured.RestAssured;

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/ReactiveEndpoint.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/ReactiveEndpoint.java
@@ -1,14 +1,12 @@
 package com.github.mcollovati.quarkus.hilla.deployment.endpoints;
 
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+import dev.hilla.Endpoint;
+import dev.hilla.EndpointSubscription;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import dev.hilla.Endpoint;
-import dev.hilla.EndpointSubscription;
 import reactor.core.publisher.Flux;
-
-import com.vaadin.flow.server.auth.AnonymousAllowed;
 
 @Endpoint
 @AnonymousAllowed
@@ -17,11 +15,9 @@ public class ReactiveEndpoint {
     private final ConcurrentHashMap<String, AtomicInteger> counters = new ConcurrentHashMap<>();
 
     public Flux<Integer> count(String counterName) {
-        return Flux.interval(Duration.ofMillis(200)).onBackpressureDrop()
-                .map(_interval -> counters
-                        .computeIfAbsent(counterName,
-                                unused -> new AtomicInteger())
-                        .incrementAndGet());
+        return Flux.interval(Duration.ofMillis(200)).onBackpressureDrop().map(_interval -> counters.computeIfAbsent(
+                        counterName, unused -> new AtomicInteger())
+                .incrementAndGet());
     }
 
     public EndpointSubscription<Integer> cancelableCount(String counterName) {

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/ReactiveEndpoint.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/ReactiveEndpoint.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment.endpoints;
 
 import com.vaadin.flow.server.auth.AnonymousAllowed;

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/ReactiveSecureEndpoint.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/ReactiveSecureEndpoint.java
@@ -1,10 +1,9 @@
 package com.github.mcollovati.quarkus.hilla.deployment.endpoints;
 
+import dev.hilla.Endpoint;
 import javax.annotation.security.DenyAll;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
-
-import dev.hilla.Endpoint;
 import reactor.core.publisher.Flux;
 
 @Endpoint
@@ -20,7 +19,7 @@ public class ReactiveSecureEndpoint {
         return Flux.just("USER");
     }
 
-    @RolesAllowed({ "USER", "ADMIN" })
+    @RolesAllowed({"USER", "ADMIN"})
     public Flux<String> userAndAdmin() {
         return Flux.just("USER AND ADMIN");
     }
@@ -31,13 +30,11 @@ public class ReactiveSecureEndpoint {
     }
 
     public Flux<String> denyByDefault() {
-        throw new IllegalArgumentException(
-                "Method should be denied by default");
+        throw new IllegalArgumentException("Method should be denied by default");
     }
 
     @DenyAll
     public Flux<String> deny() {
         throw new IllegalArgumentException("Method denied");
     }
-
 }

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/ReactiveSecureEndpoint.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/ReactiveSecureEndpoint.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment.endpoints;
 
 import dev.hilla.Endpoint;

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/SecureEndpoint.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/SecureEndpoint.java
@@ -1,10 +1,9 @@
 package com.github.mcollovati.quarkus.hilla.deployment.endpoints;
 
+import dev.hilla.Endpoint;
 import javax.annotation.security.DenyAll;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
-
-import dev.hilla.Endpoint;
 
 @Endpoint
 public class SecureEndpoint {
@@ -19,7 +18,7 @@ public class SecureEndpoint {
         return "USER";
     }
 
-    @RolesAllowed({ "USER", "ADMIN" })
+    @RolesAllowed({"USER", "ADMIN"})
     public String userAndAdmin() {
         return "USER AND ADMIN";
     }
@@ -30,13 +29,11 @@ public class SecureEndpoint {
     }
 
     public String denyByDefault() {
-        throw new IllegalArgumentException(
-                "Method should be denied by default");
+        throw new IllegalArgumentException("Method should be denied by default");
     }
 
     @DenyAll
     public String deny() {
         throw new IllegalArgumentException("Method denied");
     }
-
 }

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/SecureEndpoint.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/SecureEndpoint.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment.endpoints;
 
 import dev.hilla.Endpoint;

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/TestEndpoint.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/TestEndpoint.java
@@ -1,12 +1,10 @@
 package com.github.mcollovati.quarkus.hilla.deployment.endpoints;
 
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import dev.hilla.Endpoint;
-
 import com.vaadin.flow.server.auth.AnonymousAllowed;
+import dev.hilla.Endpoint;
+import java.util.Objects;
 
 @Endpoint
 @AnonymousAllowed
@@ -19,14 +17,14 @@ public class TestEndpoint {
     public int calculate(String operator, int a, int b) {
         int result;
         switch (operator) {
-        case "+":
-            result = a + b;
-            break;
-        case "*":
-            result = a * b;
-            break;
-        default:
-            throw new IllegalArgumentException("Invalid operation");
+            case "+":
+                result = a + b;
+                break;
+            case "*":
+                result = a * b;
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid operation");
         }
         return result;
     }
@@ -50,10 +48,8 @@ public class TestEndpoint {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o)
-                return true;
-            if (o == null || getClass() != o.getClass())
-                return false;
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
             Pojo pojo = (Pojo) o;
             return number == pojo.number && Objects.equals(text, pojo.text);
         }
@@ -63,5 +59,4 @@ public class TestEndpoint {
             return Objects.hash(number, text);
         }
     }
-
 }

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/TestEndpoint.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/TestEndpoint.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla.deployment.endpoints;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/etc/java-license-header
+++ b/etc/java-license-header
@@ -1,0 +1,15 @@
+/*
+ * Copyright $YEAR Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/integration-tests/smoke-tests/README.md
+++ b/integration-tests/smoke-tests/README.md
@@ -33,12 +33,12 @@ The application, packaged as an _über-jar_, is now runnable using `java -jar ta
 
 ## Creating a native executable
 
-You can create a native executable using: 
+You can create a native executable using:
 ```shell script
 ./mvnw package -Pnative
 ```
 
-Or, if you don't have GraalVM installed, you can run the native executable build in a container using: 
+Or, if you don't have GraalVM installed, you can run the native executable build in a container using:
 ```shell script
 ./mvnw package -Pnative -Dquarkus.native.container-build=true
 ```
@@ -48,4 +48,3 @@ You can then execute your native executable with: `./target/code-with-quarkus-1.
 If you want to learn more about building native executables, please consult https://quarkus.io/guides/maven-tooling.
 
 ## Related Guides
-

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/Application.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/Application.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.application;
 
 import com.vaadin.flow.component.page.AppShellConfigurator;

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/Application.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/Application.java
@@ -11,9 +11,6 @@ import com.vaadin.flow.theme.Theme;
  * and some desktop browsers.
  *
  */
-
 @Theme(value = "my-hilla-app")
 @Push
-public class Application implements AppShellConfigurator {
-
-}
+public class Application implements AppShellConfigurator {}

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/ClockService.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/ClockService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.application;
 
 import dev.hilla.Nonnull;

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/ClockService.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/ClockService.java
@@ -1,12 +1,11 @@
 package com.example.application;
 
-import javax.enterprise.context.ApplicationScoped;
+import dev.hilla.Nonnull;
+import io.quarkus.security.identity.SecurityIdentity;
 import java.time.Duration;
 import java.util.Date;
 import java.util.UUID;
-
-import dev.hilla.Nonnull;
-import io.quarkus.security.identity.SecurityIdentity;
+import javax.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.context.ThreadContext;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/HelloWorldEndpoint.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/HelloWorldEndpoint.java
@@ -1,18 +1,15 @@
 package com.example.application.endpoints.helloworld;
 
-import javax.annotation.security.PermitAll;
-import javax.annotation.security.RolesAllowed;
-
 import com.example.application.ClockService;
 import com.example.application.entities.UserPOJO;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.auth.AnonymousAllowed;
 import dev.hilla.Endpoint;
 import dev.hilla.EndpointSubscription;
 import dev.hilla.Nonnull;
-import io.smallrye.common.annotation.NonBlocking;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
 import reactor.core.publisher.Flux;
-
-import com.vaadin.flow.server.VaadinRequest;
-import com.vaadin.flow.server.auth.AnonymousAllowed;
 
 @Endpoint
 @AnonymousAllowed
@@ -41,7 +38,6 @@ public class HelloWorldEndpoint {
         } else {
             return "Hello from new methods " + name + "!";
         }
-
     }
 
     @Nonnull
@@ -70,7 +66,7 @@ public class HelloWorldEndpoint {
 
     @RolesAllowed("ADMIN")
     public EndpointSubscription<@Nonnull String> getClockCancellable() {
-        return EndpointSubscription.of(getClock(), () -> System.getLogger("TESTME").log(System.Logger.Level.INFO, "Subscription has been cancelled"));
+        return EndpointSubscription.of(getClock(), () -> System.getLogger("TESTME")
+                .log(System.Logger.Level.INFO, "Subscription has been cancelled"));
     }
-
 }

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/HelloWorldEndpoint.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/HelloWorldEndpoint.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.application.endpoints.helloworld;
 
 import com.example.application.ClockService;

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/TestResource.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/TestResource.java
@@ -1,9 +1,8 @@
 package com.example.application.endpoints.helloworld;
 
-import org.jboss.resteasy.reactive.RestResponse;
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import org.jboss.resteasy.reactive.RestResponse;
 
 @Path("test")
 public class TestResource {
@@ -12,5 +11,4 @@ public class TestResource {
     public RestResponse<String> test() {
         return RestResponse.ok("test");
     }
-
 }

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/TestResource.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/TestResource.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.application.endpoints.helloworld;
 
 import javax.ws.rs.GET;

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/UserInfoEndpoint.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/UserInfoEndpoint.java
@@ -1,13 +1,11 @@
 package com.example.application.endpoints.helloworld;
 
-import javax.annotation.security.PermitAll;
-
 import com.example.application.entities.UserInfo;
+import com.vaadin.flow.server.auth.AnonymousAllowed;
 import dev.hilla.Endpoint;
 import dev.hilla.Nonnull;
 import io.quarkus.security.identity.SecurityIdentity;
-
-import com.vaadin.flow.server.auth.AnonymousAllowed;
+import javax.annotation.security.PermitAll;
 
 @Endpoint
 @PermitAll
@@ -27,5 +25,4 @@ public class UserInfoEndpoint {
         }
         return new UserInfo(securityIdentity);
     }
-
 }

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/UserInfoEndpoint.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/UserInfoEndpoint.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.application.endpoints.helloworld;
 
 import com.example.application.entities.UserInfo;

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/entities/UserInfo.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/entities/UserInfo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.application.entities;
 
 import dev.hilla.Nonnull;

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/entities/UserInfo.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/entities/UserInfo.java
@@ -1,15 +1,15 @@
 package com.example.application.entities;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import dev.hilla.Nonnull;
 import io.quarkus.security.identity.SecurityIdentity;
+import java.util.HashSet;
+import java.util.Set;
 
 public class UserInfo {
 
     @Nonnull
     private final String name;
+
     @Nonnull
     private final Set<String> roles;
 

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/entities/UserPOJO.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/entities/UserPOJO.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.application.entities;
 
 public class UserPOJO {

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/entities/UserPOJO.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/entities/UserPOJO.java
@@ -5,8 +5,6 @@ public class UserPOJO {
     private String name;
     private String surname;
 
-
-
     public UserPOJO(String name, String surname) {
         this.name = name;
         this.surname = surname;

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/flow/FlowView.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/flow/FlowView.java
@@ -1,14 +1,12 @@
 package com.example.application.flow;
 
-import javax.annotation.security.RolesAllowed;
-
 import com.example.application.ClockService;
-import reactor.core.Disposable;
-
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
+import javax.annotation.security.RolesAllowed;
+import reactor.core.Disposable;
 
 @Route("flow-view")
 @RolesAllowed({"ADMIN", "ROLE_ADMIN"})

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/flow/FlowView.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/flow/FlowView.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.application.flow;
 
 import com.example.application.ClockService;

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <jreleaser-maven-plugin.version>1.6.0</jreleaser-maven-plugin.version>
         <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
         <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
+        <spotless-maven-plugin.version>2.37.0</spotless-maven-plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -223,6 +224,36 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless-maven-plugin.version}</version>
+                <configuration>
+                    <java>
+                        <palantirJavaFormat>
+                            <style>PALANTIR</style>
+                        </palantirJavaFormat>
+                        <removeUnusedImports/>
+                        <formatAnnotations/>
+                        <toggleOffOn />
+                        <trimTrailingWhitespace />
+                        <endWithNewline />
+                    </java>
+                    <formats>
+                        <format>
+                            <includes>
+                                <include>*.md</include>
+                            </includes>
+                            <trimTrailingWhitespace/>
+                            <endWithNewline/>
+                            <indent>
+                                <spaces>true</spaces>
+                                <spacesPerTab>2</spacesPerTab>
+                            </indent>
+                        </format>
+                    </formats>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <repositories>
@@ -366,7 +397,9 @@
                                             <maven-central>
                                                 <active>${release.mavencentral.active}</active>
                                                 <url>https://oss.sonatype.org/service/local</url>
-                                                <snapshotUrl>https://s01.oss.sonatype.org/content/repositories/snapshots/</snapshotUrl>
+                                                <snapshotUrl>
+                                                    https://s01.oss.sonatype.org/content/repositories/snapshots/
+                                                </snapshotUrl>
                                                 <closeRepository>false</closeRepository>
                                                 <releaseRepository>false</releaseRepository>
                                                 <stagingRepositories>target/staging-deploy</stagingRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,9 @@
                         <toggleOffOn />
                         <trimTrailingWhitespace />
                         <endWithNewline />
+                        <licenseHeader>
+                            <file>${maven.multiModuleProjectDirectory}/etc/java-license-header</file>
+                        </licenseHeader>
                     </java>
                     <formats>
                         <format>

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaAtmosphereObjectFactory.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaAtmosphereObjectFactory.java
@@ -1,8 +1,7 @@
 package com.github.mcollovati.quarkus.hilla;
 
-import javax.enterprise.inject.spi.CDI;
-
 import dev.hilla.push.PushEndpoint;
+import javax.enterprise.inject.spi.CDI;
 import org.atmosphere.cpr.AtmosphereConfig;
 import org.atmosphere.inject.InjectableObjectFactory;
 
@@ -16,16 +15,14 @@ public class HillaAtmosphereObjectFactory extends InjectableObjectFactory {
     }
 
     @Override
-    public <T, U extends T> U newClassInstance(Class<T> classType,
-            Class<U> defaultType)
+    public <T, U extends T> U newClassInstance(Class<T> classType, Class<U> defaultType)
             throws InstantiationException, IllegalAccessException {
         if (PushEndpoint.class.equals(defaultType)) {
-            U instance = defaultType.cast(QuarkusApplicationContext.getBean(
-                    CDI.current().getBeanManager(), PushEndpoint.class));
+            U instance = defaultType.cast(
+                    QuarkusApplicationContext.getBean(CDI.current().getBeanManager(), PushEndpoint.class));
             injectInjectable(instance, defaultType, config.framework());
             applyMethods(instance, defaultType);
             return instance;
-
         }
         return super.newClassInstance(classType, defaultType);
     }

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaAtmosphereObjectFactory.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaAtmosphereObjectFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla;
 
 import dev.hilla.push.PushEndpoint;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaFormAuthenticationMechanism.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaFormAuthenticationMechanism.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla;
 
 import io.quarkus.security.identity.IdentityProviderManager;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaFormAuthenticationMechanism.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaFormAuthenticationMechanism.java
@@ -1,9 +1,5 @@
 package com.github.mcollovati.quarkus.hilla;
 
-import javax.inject.Inject;
-import java.util.Optional;
-import java.util.Set;
-
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.AuthenticationRequest;
@@ -13,25 +9,24 @@ import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.Cookie;
 import io.vertx.ext.web.RoutingContext;
+import java.util.Optional;
+import java.util.Set;
 
-public class HillaFormAuthenticationMechanism
-        implements HttpAuthenticationMechanism {
+public class HillaFormAuthenticationMechanism implements HttpAuthenticationMechanism {
     private String logoutPath;
     private String cookieName;
 
     FormAuthenticationMechanism delegate;
 
     public HillaFormAuthenticationMechanism(
-            FormAuthenticationMechanism delegate, String cookieName,
-            String logoutPath) {
+            FormAuthenticationMechanism delegate, String cookieName, String logoutPath) {
         this.delegate = delegate;
         this.logoutPath = logoutPath;
         this.cookieName = cookieName;
     }
 
     @Override
-    public Uni<SecurityIdentity> authenticate(RoutingContext context,
-            IdentityProviderManager identityProviderManager) {
+    public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
         if (context.normalizedPath().equals(logoutPath)) {
             logout(context);
             return Uni.createFrom().optional(Optional.empty());
@@ -59,5 +54,4 @@ public class HillaFormAuthenticationMechanism
         }
         ctx.response().removeCookie(cookieName);
     }
-
 }

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaSecurityPolicy.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaSecurityPolicy.java
@@ -1,23 +1,5 @@
 package com.github.mcollovati.quarkus.hilla;
 
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.function.UnaryOperator;
-
-import io.quarkus.runtime.Startup;
-import io.quarkus.security.identity.SecurityIdentity;
-import io.quarkus.vertx.http.runtime.FormAuthConfig;
-import io.quarkus.vertx.http.runtime.security.AuthenticatedHttpSecurityPolicy;
-import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy;
-import io.quarkus.vertx.http.runtime.security.PathMatcher;
-import io.smallrye.mutiny.Uni;
-import io.vertx.ext.web.RoutingContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.Router;
 import com.vaadin.flow.router.internal.NavigationRouteTarget;
@@ -27,6 +9,22 @@ import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.auth.AccessAnnotationChecker;
+import io.quarkus.runtime.Startup;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.FormAuthConfig;
+import io.quarkus.vertx.http.runtime.security.AuthenticatedHttpSecurityPolicy;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy;
+import io.quarkus.vertx.http.runtime.security.PathMatcher;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Startup
 public class HillaSecurityPolicy implements HttpSecurityPolicy {
@@ -42,35 +40,29 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
     public HillaSecurityPolicy() {
         authenticatedHttpSecurityPolicy = new AuthenticatedHttpSecurityPolicy();
         pathMatcher = new PathMatcher<>();
-        Arrays.stream(
-                HandlerHelper.getPublicResourcesRequiringSecurityContext())
+        Arrays.stream(HandlerHelper.getPublicResourcesRequiringSecurityContext())
                 .forEach(this::addPathMatcher);
         addPathMatcher("/HILLA/**");
         addPathMatcher("/connect/**");
-        Arrays.stream(HandlerHelper.getPublicResources())
-                .forEach(this::addPathMatcher);
+        Arrays.stream(HandlerHelper.getPublicResources()).forEach(this::addPathMatcher);
     }
 
     @Override
-    public Uni<CheckResult> checkPermission(RoutingContext request,
-            Uni<SecurityIdentity> identity,
-            AuthorizationRequestContext requestContext) {
-        Boolean permittedPath = pathMatcher.match(request.request().path())
-                .getValue();
+    public Uni<CheckResult> checkPermission(
+            RoutingContext request, Uni<SecurityIdentity> identity, AuthorizationRequestContext requestContext) {
+        Boolean permittedPath = pathMatcher.match(request.request().path()).getValue();
         Class<? extends Component> maybeRoot = detectRoute(request);
         if ((permittedPath != null && permittedPath)
                 || isFrameworkInternalRequest(request)
                 || isAnonymousRoute(maybeRoot, request.normalizedPath())) {
             return Uni.createFrom().item(CheckResult.PERMIT);
         }
-        return authenticatedHttpSecurityPolicy.checkPermission(request,
-                identity, requestContext);
+        return authenticatedHttpSecurityPolicy.checkPermission(request, identity, requestContext);
     }
 
     void withFormLogin(FormAuthConfig formLogin) {
         Set<String> paths = new HashSet<>();
-        UnaryOperator<String> removeQueryString = path -> path
-                .replaceFirst("\\?.*", "");
+        UnaryOperator<String> removeQueryString = path -> path.replaceFirst("\\?.*", "");
 
         formLogin.loginPage.map(removeQueryString).ifPresent(paths::add);
         formLogin.errorPage.map(removeQueryString).ifPresent(paths::add);
@@ -80,8 +72,7 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
 
     private void addPathMatcher(String path) {
         if (path.endsWith("/") || path.endsWith("/**")) {
-            pathMatcher.addPrefixPath(path.replaceFirst("/(\\*\\*)?$", ""),
-                    true);
+            pathMatcher.addPrefixPath(path.replaceFirst("/(\\*\\*)?$", ""), true);
         } else {
             pathMatcher.addExactPath(path, true);
         }
@@ -104,17 +95,13 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
     public boolean isFrameworkInternalRequest(RoutingContext request) {
         // String vaadinMapping = configurationProperties.getUrlMapping();
         String vaadinMapping = "/*";
-        return QuarkusHandlerHelper.isFrameworkInternalRequest(vaadinMapping,
-                request);
+        return QuarkusHandlerHelper.isFrameworkInternalRequest(vaadinMapping, request);
     }
 
-    private boolean isAnonymousRoute(Class<? extends Component> routeClass,
-            String path) {
+    private boolean isAnonymousRoute(Class<? extends Component> routeClass, String path) {
 
         if (vaadinService == null) {
-            getLogger().warn(
-                    "VaadinService not set. Cannot determine server route for {}",
-                    path);
+            getLogger().warn("VaadinService not set. Cannot determine server route for {}", path);
             return true;
         }
         if (routeClass == null) {
@@ -122,8 +109,7 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
             return true;
         }
 
-        boolean result = accessAnnotationChecker.hasAccess(routeClass, null,
-                role -> false);
+        boolean result = accessAnnotationChecker.hasAccess(routeClass, null, role -> false);
         if (result) {
             getLogger().debug("{} refers to a public view", path);
         }
@@ -133,8 +119,7 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
     private Class<? extends Component> detectRoute(RoutingContext request) {
 
         String vaadinMapping = "/*";
-        String requestedPath = QuarkusHandlerHelper
-                .getRequestPathInsideContext(request);
+        String requestedPath = QuarkusHandlerHelper.getRequestPathInsideContext(request);
         if (vaadinService == null) {
             return null;
         }
@@ -142,8 +127,7 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
         Router router = vaadinService.getRouter();
         RouteRegistry routeRegistry = router.getRegistry();
 
-        return HandlerHelper
-                .getPathIfInsideServlet(vaadinMapping, requestedPath)
+        return HandlerHelper.getPathIfInsideServlet(vaadinMapping, requestedPath)
                 .map(path -> {
                     if (path.startsWith("/")) {
                         // Requested path includes a beginning "/" but route
@@ -152,9 +136,11 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
                         path = path.substring(1);
                     }
                     return path;
-                }).map(routeRegistry::getNavigationRouteTarget)
+                })
+                .map(routeRegistry::getNavigationRouteTarget)
                 .map(NavigationRouteTarget::getRouteTarget)
-                .map(RouteTarget::getTarget).orElse(null);
+                .map(RouteTarget::getTarget)
+                .orElse(null);
     }
 
     private Logger getLogger() {

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaSecurityPolicy.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaSecurityPolicy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla;
 
 import com.vaadin.flow.component.Component;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaSecurityRecorder.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaSecurityRecorder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla;
 
 import io.quarkus.arc.Arc;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaSecurityRecorder.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaSecurityRecorder.java
@@ -1,13 +1,12 @@
 package com.github.mcollovati.quarkus.hilla;
 
-import java.util.function.Supplier;
-
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.FormAuthConfig;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.security.FormAuthenticationMechanism;
+import java.util.function.Supplier;
 
 @Recorder
 public class HillaSecurityRecorder {
@@ -20,26 +19,22 @@ public class HillaSecurityRecorder {
     public Supplier<HillaFormAuthenticationMechanism> setupFormAuthenticationMechanism() {
         FormAuthConfig formConfig = buildTimeConfig.auth.form;
         return () -> {
-            FormAuthenticationMechanism delegate = Arc.container()
-                    .instance(FormAuthenticationMechanism.class).get();
-            return new HillaFormAuthenticationMechanism(delegate,
-                    formConfig.cookieName, "/logout");
+            FormAuthenticationMechanism delegate =
+                    Arc.container().instance(FormAuthenticationMechanism.class).get();
+            return new HillaFormAuthenticationMechanism(delegate, formConfig.cookieName, "/logout");
         };
     }
 
     public void configureHttpSecurityPolicy(BeanContainer container) {
         FormAuthConfig formConfig = buildTimeConfig.auth.form;
         if (formConfig.enabled) {
-            HillaSecurityPolicy policy = container
-                    .beanInstance(HillaSecurityPolicy.class);
+            HillaSecurityPolicy policy = container.beanInstance(HillaSecurityPolicy.class);
             policy.withFormLogin(formConfig);
         }
     }
 
-    public void configureFlowViewAccessChecker(BeanContainer container,
-            String loginPath) {
-        QuarkusViewAccessChecker accessChecker = container
-                .beanInstance(QuarkusViewAccessChecker.class);
+    public void configureFlowViewAccessChecker(BeanContainer container, String loginPath) {
+        QuarkusViewAccessChecker accessChecker = container.beanInstance(QuarkusViewAccessChecker.class);
         accessChecker.setLoginView(loginPath);
         accessChecker.enable();
     }

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusApplicationContext.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusApplicationContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla;
 
 import com.vaadin.quarkus.AnyLiteral;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusApplicationContext.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusApplicationContext.java
@@ -1,16 +1,16 @@
 package com.github.mcollovati.quarkus.hilla;
 
-import javax.enterprise.context.spi.CreationalContext;
-import javax.enterprise.inject.AmbiguousResolutionException;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
+import com.vaadin.quarkus.AnyLiteral;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.AmbiguousResolutionException;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -24,19 +24,16 @@ import org.springframework.core.ResolvableType;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
 
-import com.vaadin.quarkus.AnyLiteral;
-
 class QuarkusApplicationContext implements ApplicationContext {
 
     private final BeanManager beanManager;
+
     QuarkusApplicationContext(BeanManager beanManager) {
         this.beanManager = beanManager;
     }
 
-    private static <T> T beanReference(BeanManager beanManager, Bean<?> bean,
-            Class<T> requiredType) {
-        final CreationalContext<?> ctx = beanManager
-                .createCreationalContext(bean);
+    private static <T> T beanReference(BeanManager beanManager, Bean<?> bean, Class<T> requiredType) {
+        final CreationalContext<?> ctx = beanManager.createCreationalContext(bean);
         // noinspection unchecked
         return (T) beanManager.getReference(bean, requiredType, ctx);
     }
@@ -47,8 +44,7 @@ class QuarkusApplicationContext implements ApplicationContext {
     }
 
     static <T> T getBean(BeanManager beanManager, Class<T> requiredType) {
-        Set<Bean<?>> beans = beanManager.getBeans(requiredType,
-                new AnyLiteral());
+        Set<Bean<?>> beans = beanManager.getBeans(requiredType, new AnyLiteral());
         if (beans.isEmpty()) {
             throw new NoSuchBeanDefinitionException(requiredType);
         }
@@ -56,25 +52,24 @@ class QuarkusApplicationContext implements ApplicationContext {
         try {
             bean = beanManager.resolve(beans);
         } catch (final AmbiguousResolutionException e) {
-            throw new NoUniqueBeanDefinitionException(requiredType, beans
-                    .stream().map(Bean::getName).collect(Collectors.toList()));
+            throw new NoUniqueBeanDefinitionException(
+                    requiredType, beans.stream().map(Bean::getName).collect(Collectors.toList()));
         }
         return beanReference(beanManager, bean, requiredType);
     }
 
     @Override
-    public Map<String, Object> getBeansWithAnnotation(
-            Class<? extends Annotation> annotationType) throws BeansException {
-        return beanManager.getBeans(Object.class, new AnyLiteral())
+    public Map<String, Object> getBeansWithAnnotation(Class<? extends Annotation> annotationType)
+            throws BeansException {
+        return beanManager
+                .getBeans(Object.class, new AnyLiteral())
                 // return beanManager.getBeans(Object.class, new
                 // EndpointLiteral())
                 .stream()
-                .filter(b -> b.getBeanClass()
-                        .isAnnotationPresent(annotationType))
+                .filter(b -> b.getBeanClass().isAnnotationPresent(annotationType))
                 .collect(Collectors.toMap(
                         QuarkusApplicationContext::computeBeanName,
-                        bean -> beanReference(beanManager, bean,
-                                bean.getBeanClass())));
+                        bean -> beanReference(beanManager, bean, bean.getBeanClass())));
     }
 
     private static String computeBeanName(Bean<?> bean) {
@@ -90,8 +85,7 @@ class QuarkusApplicationContext implements ApplicationContext {
     }
 
     @Override
-    public <T> T getBean(Class<T> requiredType, Object... args)
-            throws BeansException {
+    public <T> T getBean(Class<T> requiredType, Object... args) throws BeansException {
         return throwUnsupported();
     }
 
@@ -121,8 +115,7 @@ class QuarkusApplicationContext implements ApplicationContext {
     }
 
     @Override
-    public AutowireCapableBeanFactory getAutowireCapableBeanFactory()
-            throws IllegalStateException {
+    public AutowireCapableBeanFactory getAutowireCapableBeanFactory() throws IllegalStateException {
         return throwUnsupported();
     }
 
@@ -132,20 +125,17 @@ class QuarkusApplicationContext implements ApplicationContext {
     }
 
     @Override
-    public String getMessage(String code, Object[] args, String defaultMessage,
-            Locale locale) {
+    public String getMessage(String code, Object[] args, String defaultMessage, Locale locale) {
         return throwUnsupported();
     }
 
     @Override
-    public String getMessage(String code, Object[] args, Locale locale)
-            throws NoSuchMessageException {
+    public String getMessage(String code, Object[] args, Locale locale) throws NoSuchMessageException {
         return throwUnsupported();
     }
 
     @Override
-    public String getMessage(MessageSourceResolvable resolvable, Locale locale)
-            throws NoSuchMessageException {
+    public String getMessage(MessageSourceResolvable resolvable, Locale locale) throws NoSuchMessageException {
         return throwUnsupported();
     }
 
@@ -185,8 +175,7 @@ class QuarkusApplicationContext implements ApplicationContext {
     }
 
     @Override
-    public <T> ObjectProvider<T> getBeanProvider(ResolvableType resolvableType,
-            boolean b) {
+    public <T> ObjectProvider<T> getBeanProvider(ResolvableType resolvableType, boolean b) {
         return throwUnsupported();
     }
 
@@ -196,8 +185,7 @@ class QuarkusApplicationContext implements ApplicationContext {
     }
 
     @Override
-    public String[] getBeanNamesForType(ResolvableType resolvableType,
-            boolean b, boolean b1) {
+    public String[] getBeanNamesForType(ResolvableType resolvableType, boolean b, boolean b1) {
         return throwUnsupported();
     }
 
@@ -207,38 +195,34 @@ class QuarkusApplicationContext implements ApplicationContext {
     }
 
     @Override
-    public String[] getBeanNamesForType(Class<?> aClass, boolean b,
-            boolean b1) {
+    public String[] getBeanNamesForType(Class<?> aClass, boolean b, boolean b1) {
         return throwUnsupported();
     }
 
     @Override
-    public <T> Map<String, T> getBeansOfType(Class<T> aClass)
-            throws BeansException {
+    public <T> Map<String, T> getBeansOfType(Class<T> aClass) throws BeansException {
         return throwUnsupported();
     }
 
     @Override
-    public <T> Map<String, T> getBeansOfType(Class<T> aClass, boolean b,
-            boolean b1) throws BeansException {
+    public <T> Map<String, T> getBeansOfType(Class<T> aClass, boolean b, boolean b1) throws BeansException {
         return throwUnsupported();
     }
 
     @Override
-    public String[] getBeanNamesForAnnotation(
-            Class<? extends Annotation> aClass) {
+    public String[] getBeanNamesForAnnotation(Class<? extends Annotation> aClass) {
         return throwUnsupported();
     }
 
     @Override
-    public <A extends Annotation> A findAnnotationOnBean(String s,
-            Class<A> aClass) throws NoSuchBeanDefinitionException {
+    public <A extends Annotation> A findAnnotationOnBean(String s, Class<A> aClass)
+            throws NoSuchBeanDefinitionException {
         return throwUnsupported();
     }
 
     @Override
-    public <A extends Annotation> A findAnnotationOnBean(String s,
-            Class<A> aClass, boolean b) throws NoSuchBeanDefinitionException {
+    public <A extends Annotation> A findAnnotationOnBean(String s, Class<A> aClass, boolean b)
+            throws NoSuchBeanDefinitionException {
         return throwUnsupported();
     }
 
@@ -263,8 +247,7 @@ class QuarkusApplicationContext implements ApplicationContext {
     }
 
     @Override
-    public <T> ObjectProvider<T> getBeanProvider(
-            ResolvableType resolvableType) {
+    public <T> ObjectProvider<T> getBeanProvider(ResolvableType resolvableType) {
         return throwUnsupported();
     }
 
@@ -284,14 +267,12 @@ class QuarkusApplicationContext implements ApplicationContext {
     }
 
     @Override
-    public boolean isTypeMatch(String s, ResolvableType resolvableType)
-            throws NoSuchBeanDefinitionException {
+    public boolean isTypeMatch(String s, ResolvableType resolvableType) throws NoSuchBeanDefinitionException {
         return throwUnsupported();
     }
 
     @Override
-    public boolean isTypeMatch(String s, Class<?> aClass)
-            throws NoSuchBeanDefinitionException {
+    public boolean isTypeMatch(String s, Class<?> aClass) throws NoSuchBeanDefinitionException {
         return throwUnsupported();
     }
 
@@ -301,8 +282,7 @@ class QuarkusApplicationContext implements ApplicationContext {
     }
 
     @Override
-    public Class<?> getType(String s, boolean b)
-            throws NoSuchBeanDefinitionException {
+    public Class<?> getType(String s, boolean b) throws NoSuchBeanDefinitionException {
         return throwUnsupported();
     }
 

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointConfiguration.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointConfiguration.java
@@ -13,13 +13,10 @@ import io.smallrye.config.WithName;
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public interface QuarkusEndpointConfiguration {
 
-
     /**
      * prefix
      */
     @WithName("prefix")
     @WithDefault("/connect")
     String getEndpointPrefix();
-
-
 }

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointConfiguration.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla;
 
 import io.quarkus.runtime.annotations.ConfigPhase;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointController.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointController.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointController.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointController.java
@@ -1,5 +1,10 @@
 package com.github.mcollovati.quarkus.hilla;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.hilla.EndpointController;
+import dev.hilla.EndpointInvoker;
+import dev.hilla.EndpointRegistry;
+import dev.hilla.auth.CsrfChecker;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.POST;
@@ -9,15 +14,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import dev.hilla.EndpointController;
-import dev.hilla.EndpointInvoker;
-import dev.hilla.EndpointRegistry;
-import dev.hilla.auth.CsrfChecker;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.ResponseEntity;
-
 
 @Path("")
 public class QuarkusEndpointController {
@@ -35,8 +33,12 @@ public class QuarkusEndpointController {
      * @param endpointInvoker  then end point invoker
      * @param csrfChecker      the csrf checker to use
      */
-    //@Inject
-    public QuarkusEndpointController(ApplicationContext context, EndpointRegistry endpointRegistry, EndpointInvoker endpointInvoker, CsrfChecker csrfChecker) {
+    // @Inject
+    public QuarkusEndpointController(
+            ApplicationContext context,
+            EndpointRegistry endpointRegistry,
+            EndpointInvoker endpointInvoker,
+            CsrfChecker csrfChecker) {
         delegate = new EndpointController(context, endpointRegistry, endpointInvoker, csrfChecker);
     }
 
@@ -62,5 +64,4 @@ public class QuarkusEndpointController {
         }
         return builder.build();
     }
-
 }

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointControllerConfiguration.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointControllerConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointControllerConfiguration.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointControllerConfiguration.java
@@ -1,14 +1,9 @@
 package com.github.mcollovati.quarkus.hilla;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.inject.Singleton;
-import javax.servlet.ServletContext;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vaadin.flow.server.auth.AccessAnnotationChecker;
 import dev.hilla.ByteArrayModule;
 import dev.hilla.EndpointController;
 import dev.hilla.EndpointInvoker;
@@ -21,9 +16,12 @@ import dev.hilla.auth.EndpointAccessChecker;
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.runtime.Startup;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Singleton;
+import javax.servlet.ServletContext;
 import org.springframework.context.ApplicationContext;
-
-import com.vaadin.flow.server.auth.AccessAnnotationChecker;
 
 @Unremovable
 class QuarkusEndpointControllerConfiguration {
@@ -45,8 +43,7 @@ class QuarkusEndpointControllerConfiguration {
     @Produces
     @Singleton
     @DefaultBean
-    EndpointAccessChecker accessChecker(
-            AccessAnnotationChecker accessAnnotationChecker) {
+    EndpointAccessChecker accessChecker(AccessAnnotationChecker accessAnnotationChecker) {
         return new EndpointAccessChecker(accessAnnotationChecker);
     }
 
@@ -81,7 +78,6 @@ class QuarkusEndpointControllerConfiguration {
      *
      * @return the explicit nullable type checker
      */
-
     @Produces
     @Singleton
     @DefaultBean
@@ -116,15 +112,16 @@ class QuarkusEndpointControllerConfiguration {
 
     @Produces
     @ApplicationScoped
-    EndpointInvoker endpointInvoker(ApplicationContext applicationContext,
+    EndpointInvoker endpointInvoker(
+            ApplicationContext applicationContext,
             ObjectMapper objectMapper,
             ExplicitNullableTypeChecker explicitNullableTypeChecker,
-            ServletContext servletContext, EndpointRegistry endpointRegistry) {
-        objectMapper.setVisibility(PropertyAccessor.ALL,
-                JsonAutoDetect.Visibility.ANY);
+            ServletContext servletContext,
+            EndpointRegistry endpointRegistry) {
+        objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
         objectMapper.registerModule(new ByteArrayModule());
-        return new EndpointInvoker(applicationContext, objectMapper,
-                explicitNullableTypeChecker, servletContext, endpointRegistry);
+        return new EndpointInvoker(
+                applicationContext, objectMapper, explicitNullableTypeChecker, servletContext, endpointRegistry);
     }
 
     @Produces
@@ -137,11 +134,11 @@ class QuarkusEndpointControllerConfiguration {
     @Produces
     @ApplicationScoped
     @Startup
-    EndpointController endpointController(ApplicationContext context,
-            EndpointRegistry endpointRegistry, EndpointInvoker endpointInvoker,
+    EndpointController endpointController(
+            ApplicationContext context,
+            EndpointRegistry endpointRegistry,
+            EndpointInvoker endpointInvoker,
             CsrfChecker csrfChecker) {
-        return new EndpointController(context, endpointRegistry,
-                endpointInvoker, csrfChecker);
+        return new EndpointController(context, endpointRegistry, endpointInvoker, csrfChecker);
     }
-
 }

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointProperties.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointProperties.java
@@ -1,9 +1,8 @@
 package com.github.mcollovati.quarkus.hilla;
 
+import dev.hilla.EndpointProperties;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-
-import dev.hilla.EndpointProperties;
 
 @ApplicationScoped
 public class QuarkusEndpointProperties extends EndpointProperties {
@@ -15,5 +14,4 @@ public class QuarkusEndpointProperties extends EndpointProperties {
     public String getEndpointPrefix() {
         return endpointConfiguration.getEndpointPrefix();
     }
-
 }

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointProperties.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointProperties.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla;
 
 import dev.hilla.EndpointProperties;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusHandlerHelper.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusHandlerHelper.java
@@ -1,15 +1,13 @@
 package com.github.mcollovati.quarkus.hilla;
 
-import java.io.Serializable;
-import java.util.Optional;
-
-import io.vertx.ext.web.RoutingContext;
+import static com.vaadin.flow.server.HandlerHelper.getPathIfInsideServlet;
 
 import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.communication.StreamRequestHandler;
 import com.vaadin.flow.shared.ApplicationConstants;
-
-import static com.vaadin.flow.server.HandlerHelper.getPathIfInsideServlet;
+import io.vertx.ext.web.RoutingContext;
+import java.io.Serializable;
+import java.util.Optional;
 
 public class QuarkusHandlerHelper implements Serializable {
 
@@ -30,15 +28,15 @@ public class QuarkusHandlerHelper implements Serializable {
      * @return {@code true} if the request is Vaadin internal, {@code false}
      *         otherwise
      */
-    public static boolean isFrameworkInternalRequest(String servletMappingPath,
-            RoutingContext request) {
-        return isFrameworkInternalRequest(servletMappingPath,
-                getRequestPathInsideContext(request), request.request()
-                        .getParam(ApplicationConstants.REQUEST_TYPE_PARAMETER));
+    public static boolean isFrameworkInternalRequest(String servletMappingPath, RoutingContext request) {
+        return isFrameworkInternalRequest(
+                servletMappingPath,
+                getRequestPathInsideContext(request),
+                request.request().getParam(ApplicationConstants.REQUEST_TYPE_PARAMETER));
     }
 
-    private static boolean isFrameworkInternalRequest(String servletMappingPath,
-            String requestedPath, String requestTypeParameter) {
+    private static boolean isFrameworkInternalRequest(
+            String servletMappingPath, String requestedPath, String requestTypeParameter) {
         /*
          * According to the spec, pathInfo should be null but not all servers
          * implement it like that...
@@ -49,13 +47,10 @@ public class QuarkusHandlerHelper implements Serializable {
          */
 
         // This is only an internal request if it is for the Vaadin servlet
-        Optional<String> requestedPathWithoutServletMapping = getPathIfInsideServlet(
-                servletMappingPath, requestedPath);
+        Optional<String> requestedPathWithoutServletMapping = getPathIfInsideServlet(servletMappingPath, requestedPath);
         if (!requestedPathWithoutServletMapping.isPresent()) {
             return false;
-        } else if (isInternalRequestInsideServlet(
-                requestedPathWithoutServletMapping.get(),
-                requestTypeParameter)) {
+        } else if (isInternalRequestInsideServlet(requestedPathWithoutServletMapping.get(), requestTypeParameter)) {
             return true;
         } else if (isUploadRequest(requestedPathWithoutServletMapping.get())) {
             return true;
@@ -91,8 +86,7 @@ public class QuarkusHandlerHelper implements Serializable {
     }
 
     static boolean isInternalRequestInsideServlet(
-            String requestedPathWithoutServletMapping,
-            String requestTypeParameter) {
+            String requestedPathWithoutServletMapping, String requestTypeParameter) {
         if (requestedPathWithoutServletMapping == null
                 || requestedPathWithoutServletMapping.isEmpty()
                 || "/".equals(requestedPathWithoutServletMapping)) {
@@ -101,12 +95,10 @@ public class QuarkusHandlerHelper implements Serializable {
         return false;
     }
 
-    private static boolean isUploadRequest(
-            String requestedPathWithoutServletMapping) {
+    private static boolean isUploadRequest(String requestedPathWithoutServletMapping) {
         // First key is uiId
         // Second key is security key
-        return requestedPathWithoutServletMapping
-                .matches(StreamRequestHandler.DYN_RES_PREFIX
-                        + "(\\d+)/([0-9a-z-]*)/upload");
+        return requestedPathWithoutServletMapping.matches(
+                StreamRequestHandler.DYN_RES_PREFIX + "(\\d+)/([0-9a-z-]*)/upload");
     }
 }

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusHandlerHelper.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusHandlerHelper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla;
 
 import static com.vaadin.flow.server.HandlerHelper.getPathIfInsideServlet;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusViewAccessChecker.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusViewAccessChecker.java
@@ -1,18 +1,15 @@
 package com.github.mcollovati.quarkus.hilla;
 
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.auth.AccessAnnotationChecker;
+import com.vaadin.flow.server.auth.ViewAccessChecker;
+import io.quarkus.security.identity.SecurityIdentity;
+import java.security.Principal;
+import java.util.function.Function;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.security.Principal;
-import java.util.function.Function;
-
-import io.quarkus.security.identity.SecurityIdentity;
-
-import com.vaadin.flow.server.ServiceInitEvent;
-import com.vaadin.flow.server.VaadinRequest;
-import com.vaadin.flow.server.VaadinServiceInitListener;
-import com.vaadin.flow.server.auth.AccessAnnotationChecker;
-import com.vaadin.flow.server.auth.ViewAccessChecker;
 
 @Singleton
 public class QuarkusViewAccessChecker extends ViewAccessChecker {
@@ -21,8 +18,7 @@ public class QuarkusViewAccessChecker extends ViewAccessChecker {
     private final AccessAnnotationChecker annotationChecker;
 
     @Inject
-    public QuarkusViewAccessChecker(SecurityIdentity securityIdentity,
-            AccessAnnotationChecker annotationChecker) {
+    public QuarkusViewAccessChecker(SecurityIdentity securityIdentity, AccessAnnotationChecker annotationChecker) {
         this.securityIdentity = securityIdentity;
         this.annotationChecker = annotationChecker;
     }
@@ -54,8 +50,8 @@ public class QuarkusViewAccessChecker extends ViewAccessChecker {
         }
 
         void installViewAccessChecker(@Observes ServiceInitEvent event) {
-            event.getSource().addUIInitListener(uiInitEvent -> uiInitEvent
-                    .getUI().addBeforeEnterListener(viewAccessChecker));
+            event.getSource()
+                    .addUIInitListener(uiInitEvent -> uiInitEvent.getUI().addBeforeEnterListener(viewAccessChecker));
         }
     }
 }

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusViewAccessChecker.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusViewAccessChecker.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla;
 
 import com.vaadin.flow.server.ServiceInitEvent;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/SpringReplacements.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/SpringReplacements.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.mcollovati.quarkus.hilla;
 
 import io.quarkus.security.identity.CurrentIdentityAssociation;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/SpringReplacements.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/SpringReplacements.java
@@ -1,10 +1,9 @@
 package com.github.mcollovati.quarkus.hilla;
 
-import java.security.Principal;
-import java.util.function.Function;
-
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
+import java.security.Principal;
+import java.util.function.Function;
 
 public class SpringReplacements {
 


### PR DESCRIPTION
Adds the spotless maven plugin and applies the [palantir java format](https://github.com/palantir/palantir-java-format) together with a license header to all files.

Closes #25