### PR TITLE
chore: configure dependabot for protected branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,15 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "maven"
+    directory: "/"
+    target-branch: "1.0"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "dev.hilla:*"
+        versions: [ ">= 2.0" ]
+      - dependency-name: "com.vaadin:vaadin-quarkus"
+        versions: [ ">= 2.0" ]
+      - dependency-name: "io.quarkus*:*"
+        versions: [ ">= 3.0" ]


### PR DESCRIPTION
This configuration prevents dependabot to create PR to upgrade quarkus, hilla and vaadin-quarkus with latest version for branch 1.0.

Fixes #42