### PR TITLE
chore(actions): add formatting check and auto-format PR jobs

### DIFF
--- a/.github/workflows/format-pr.yaml
+++ b/.github/workflows/format-pr.yaml
@@ -38,6 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          ssh-key: ${{ secrets.ACTIONS_GIT_KEY }}
           fetchref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Java
         uses: actions/setup-java@v3
@@ -76,3 +77,4 @@ jobs:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/format-pr.yaml
+++ b/.github/workflows/format-pr.yaml
@@ -1,6 +1,6 @@
 name: Format Pull Request
 on:
-  pull_request_target:
+  pull_request:
     types: ["labeled"]
 permissions:
   pull-requests: write

--- a/.github/workflows/format-pr.yaml
+++ b/.github/workflows/format-pr.yaml
@@ -59,14 +59,7 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
-            const labelToAdd = 'format:applied';
 
-            await github.rest.issues.addLabels({
-              owner,
-              repo,
-              issue_number: prNumber,
-              labels: [labelToAdd],
-            });
             await github.rest.issues.removeLabel({
               owner,
               repo,

--- a/.github/workflows/format-pr.yaml
+++ b/.github/workflows/format-pr.yaml
@@ -12,6 +12,29 @@ jobs:
     runs-on: ubuntu-latest
     name: Apply format
     steps:
+      - name: Remove format labels
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            
+            // Remove the label if it exists
+            const existingLabels = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: prNumber,
+            });
+            const labelsToRemove = existingLabels.data.map(label => label.name).filter( label => label.startsWith("format:") );
+            for (const labelToRemove of labelsToRemove) {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: prNumber,
+                name: labelToRemove,
+              });
+            }
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -28,7 +51,7 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "chore(auto-format): apply formatting"
-      - name: Add label to PR
+      - name: Update format labels to PR
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/format-pr.yaml
+++ b/.github/workflows/format-pr.yaml
@@ -1,6 +1,6 @@
 name: Format Pull Request
 on:
-  pull_request:
+  pull_request_target:
     types: ["labeled"]
 permissions:
   pull-requests: write

--- a/.github/workflows/format-pr.yaml
+++ b/.github/workflows/format-pr.yaml
@@ -52,7 +52,7 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "chore(auto-format): apply formatting"
-      - name: Update format labels to PR
+      - name: Update format labels on PR
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/format-pr.yaml
+++ b/.github/workflows/format-pr.yaml
@@ -1,0 +1,55 @@
+name: Format Pull Request
+on:
+  pull_request:
+    types: ["labeled"]
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  format-pr:
+    if: ${{ github.event.pull_request.merged == false && github.event.label.name == 'auto-format' }}
+    runs-on: ubuntu-latest
+    name: Apply format
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetchref: ${{ github.event.pull_request.head.sha }}
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          cache: maven
+      - name: Apply changes
+        run: |
+          mvn -V -e -B -ntp spotless:apply
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "chore(auto-format): apply formatting"
+      - name: Add label to PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const labelToAdd = 'format:applied';
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: prNumber,
+              labels: [labelToAdd],
+            });
+            await github.rest.issues.removeLabel({
+              owner,
+              repo,
+              issue_number: prNumber,
+              name: "auto-format",
+            });
+            
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -173,6 +173,21 @@ jobs:
               issue_number: prNumber,
               labels: ['format:required'],
             });
+      - name: Add format required label to PR
+        if: ${{ success() }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: prNumber,
+              labels: ['format:checked'],
+            });
 
           
 

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -100,19 +100,21 @@ jobs:
           _files=$(cat /tmp/unformatted.txt | wc -l)
           echo "### Format Checker Report" >> /tmp/message
           echo "" >> /tmp/message
-          echo "There are **${_files} files** with format errors" >> /tmp/message
+          echo "There are **${_files} files** with format errors." >> /tmp/message
           echo "" >> /tmp/message
           echo '* To fix the build, please run `mvn spotless:apply` in your branch and commit the changes.' >> /tmp/message 
-          echo '* In alternative apply the `automation/format` label to the PR.' >> /tmp/message
+          echo '* Alternatively, apply the `auto-format` label to the PR.' >> /tmp/message
           echo "" >> /tmp/message
           echo "" >> /tmp/message
-          echo "Here is the list of files with format issues in your PR:" >> /tmp/message
+          echo "<details>" >> /tmp/message
+          echo "  <summary>Files with format issues in this PR</summary>" >> /tmp/message
+          echo "" >> /tmp/message
           echo '```' >> /tmp/message
           cat /tmp/unformatted.txt  >> /tmp/message
           echo '```' >> /tmp/message
+          echo "</details>" >> /tmp/message
           echo "" >> /tmp/message
           echo "" >> /tmp/message
-          echo "And here the full diff: " >> /tmp/message
           echo "<details>" >> /tmp/message
           echo "  <summary>Full Diff</summary>" >> /tmp/message
           echo "" >> /tmp/message

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -75,6 +75,29 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-22.04
     steps:
+      - name: Remove format labels
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            
+            // Remove the label if it exists
+            const existingLabels = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: prNumber,
+            });
+            const labelsToRemove = existingLabels.data.map(label => label.name).filter( label => label.startsWith("format:") );
+            for (const labelToRemove of labelsToRemove) {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: prNumber,
+                name: labelToRemove,
+              });
+            }
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -135,6 +158,21 @@ jobs:
         with:
           filePath: /tmp/message
           comment_tag: formatting-check
+      - name: Add format required label to PR
+        if: ${{ failure() && steps.spotlessCheck.conclusion == 'failure' }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: prNumber,
+              labels: ['format:required'],
+            });
 
           
 

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -16,8 +16,7 @@ concurrency:
 env:
   JAVA_VERSION: 17
 jobs:
-  build-and-test:
-    timeout-minutes: 30
+  check-permissions:
     runs-on: ubuntu-22.04
     steps:
       - run: echo "Concurrency Group = ${{ github.head_ref || github.ref_name }}"
@@ -31,6 +30,11 @@ jobs:
         run: |
           echo "🚫 **${{ github.actor }}** is an external contributor, a **${{ github.repository }}** team member has to review this changes and re-run this build" \
             | tee -a $GITHUB_STEP_SUMMARY && exit 1
+  build-and-test:
+    needs: [check-permissions]
+    timeout-minutes: 30
+    runs-on: ubuntu-22.04
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -66,3 +70,33 @@ jobs:
         with:
           junit_files: "**/target/*-reports/TEST*.xml"
           check_run_annotations: all tests, skipped tests
+  checkstyle:
+    needs: [check-permissions]
+    timeout-minutes: 5
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
+          cache: maven
+      - name: Check
+        run: |
+          set -x -e -o pipefail
+          mvn -V -e -B -ntp spotless:check
+      - name: Prepare message
+        if: ${{ failure() }}
+        run: |
+          set -x -e -o pipefail
+          git-np diff --output=/tmp/full-diff.txt 
+          git-np diff --names-only --output=/tmp/unformatted.txt
+          echo "Formatt
+          
+          
+
+    

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -98,9 +98,9 @@ jobs:
           git diff --output=/tmp/full-diff.txt 
           git diff --name-only --output=/tmp/unformatted.txt
           _files=$(cat /tmp/unformatted.txt | wc -l)
-          echo "# Format Checker Report" >> /tmp/message
+          echo "### Format Checker Report" >> /tmp/message
           echo "" >> /tmp/message
-          echo "There are *${_files} files* with format errors" >> /tmp/message
+          echo "There are **${_files} files** with format errors" >> /tmp/message
           echo "" >> /tmp/message
           echo '* To fix the build, please run `mvn spotless:apply` in your branch and commit the changes.' >> /tmp/message 
           echo '* In alternative apply the `automation/format` label to the PR.' >> /tmp/message

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -94,6 +94,7 @@ jobs:
         if: ${{ failure() && steps.spotlessCheck.conclusion == 'failure' }}
         run: |
           set -x -e -o pipefail
+          mvn -V -e -B -ntp spotless:apply
           git diff --output=/tmp/full-diff.txt 
           git diff --name-only --output=/tmp/unformatted.txt
           _files=$(wc -l /tmp/unformatted.txt)

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -86,17 +86,52 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Check
+        id: spotlessCheck
         run: |
           set -x -e -o pipefail
           mvn -V -e -B -ntp spotless:check
-      - name: Prepare message
-        if: ${{ failure() }}
+      - name: Prepare failure message
+        if: ${{ failure() && steps.spotlessCheck.conclusion == 'failure' }}
         run: |
           set -x -e -o pipefail
           git-np diff --output=/tmp/full-diff.txt 
           git-np diff --names-only --output=/tmp/unformatted.txt
-          echo "Formatt
-          
+          _files=$(wc -l /tmp/unformatted.txt)
+          echo "# Format Checker Report" >> /tmp/message
+          echo "" >> /tmp/message
+          echo "There are *${_files} files* with format errors" >> /tmp/message
+          echo "" >> /tmp/message
+          echo '* To fix the build, please run `mvn spotless:apply` in your branch and commit the changes.' >> /tmp/message 
+          echo '* In alternative apply the `automation/format` label to the PR.' >> /tmp/message
+          echo "" >> /tmp/message
+          echo "" >> /tmp/message
+          echo "Here is the list of files with format issues in your PR:" >> /tmp/message
+          echo '```' >> /tmp/message
+          cat /tmp/unformatted.txt  >> /tmp/message
+          echo '```' >> /tmp/message
+          echo "" >> /tmp/message
+          echo "" >> /tmp/message
+          echo "And here the full diff: " >> /tmp/message
+          echo "<details>" >> /tmp/message
+          echo "  <summary>Full Diff</summary>" >> /tmp/message
+          echo "" >> /tmp/message
+          echo '```patch' >> /tmp/message
+          cat /tmp/full-diff.txt  >> /tmp/message
+          echo '```' >> /tmp/message
+          echo "</details>" >> /tmp/message
+      - name: Prepare success message
+        if: ${{ success() }}
+        run: |
+          set -x -e -o pipefail
+          echo "# Format Checker Report" >> /tmp/message
+          echo "" >> /tmp/message
+          echo "All files are correctly formatted" >> /tmp/message
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          filePath: /tmp/message
+          comment_tag: formatting-check
+
           
 
     

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -127,6 +127,7 @@ jobs:
           echo "" >> /tmp/message
           echo "All files are correctly formatted" >> /tmp/message
       - name: Comment PR
+        if: ${{ always() }}
         uses: thollander/actions-comment-pull-request@v2
         with:
           filePath: /tmp/message

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -94,8 +94,8 @@ jobs:
         if: ${{ failure() && steps.spotlessCheck.conclusion == 'failure' }}
         run: |
           set -x -e -o pipefail
-          git-np diff --output=/tmp/full-diff.txt 
-          git-np diff --names-only --output=/tmp/unformatted.txt
+          git diff --output=/tmp/full-diff.txt 
+          git diff --names-only --output=/tmp/unformatted.txt
           _files=$(wc -l /tmp/unformatted.txt)
           echo "# Format Checker Report" >> /tmp/message
           echo "" >> /tmp/message

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -97,7 +97,7 @@ jobs:
           mvn -V -e -B -ntp spotless:apply
           git diff --output=/tmp/full-diff.txt 
           git diff --name-only --output=/tmp/unformatted.txt
-          _files=$(wc -l /tmp/unformatted.txt)
+          _files=$(cat /tmp/unformatted.txt | wc -l)
           echo "# Format Checker Report" >> /tmp/message
           echo "" >> /tmp/message
           echo "There are *${_files} files* with format errors" >> /tmp/message

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -173,7 +173,7 @@ jobs:
               issue_number: prNumber,
               labels: ['format:required'],
             });
-      - name: Add format required label to PR
+      - name: Add format checked label to PR
         if: ${{ success() }}
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -95,7 +95,7 @@ jobs:
         run: |
           set -x -e -o pipefail
           git diff --output=/tmp/full-diff.txt 
-          git diff --names-only --output=/tmp/unformatted.txt
+          git diff --name-only --output=/tmp/unformatted.txt
           _files=$(wc -l /tmp/unformatted.txt)
           echo "# Format Checker Report" >> /tmp/message
           echo "" >> /tmp/message


### PR DESCRIPTION
A new job in validation workflow checks that formatting is ok, and if not, it prevents the PR from being merged.
If the code is not well formatted, the label `format:required` is applied to the PR and a comment reports the file that should be checked, a full diff and formatting instructions.
Otherwise, the `format:checked` label is applied.

Another workflow, triggered by the `auto-format` label, applies formatting to the PR and pushes the changes to the PR branch.
The push automatically triggers a new validation.

Closes #67
Closes #68