### PR TITLE
chore(actions): skip integration test during release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Staging artifacts
         run: |
-          mvn -V -ntp -Pdistribution,default-modules,it-tests -Drevision=${{ inputs.version }} -DaltDeploymentRepository=local::file:./target/staging-deploy deploy
+          mvn -V -ntp -Pdistribution,default-modules -Drevision=${{ inputs.version }} -DaltDeploymentRepository=local::file:./target/staging-deploy deploy
 
       - name: Run JReleaser
         env:


### PR DESCRIPTION
The Bootstrap test fails when Hilla executes maven to generate endpoints because then forked process is not aware of the release property and it seraches for wrong quarkus-hilla dependencies