### PR TITLE
fix(actions): skip validation check for ignored paths (#119) (CP: 1.0)

### DIFF
--- a/.github/workflows/validation-not-required.yaml
+++ b/.github/workflows/validation-not-required.yaml
@@ -1,0 +1,16 @@
+name: Quarkus Hilla Validation
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+    paths:
+      - README.md
+      - LICENSE
+      - .gitignore
+      - etc/**
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Skip validation for ignored paths"
+        run: |
+          echo "✅ Pull request contains changes on files ignored by validation workflow" | tee -a $GITHUB_STEP_SUMMARY && exit 0


### PR DESCRIPTION
If a PR contains only changes to files ignored by the validation workflow, the build and test job is not executed and its status is pending, preventing the PR to being merged.

This change introduces an additional workflow that marks as good PR that contains changes to ignored files.

See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks\#handling-skipped-but-required-checks for more information.