### PR TITLE
chore: force downloaded chrome binary path (#171) (CP: 1.0)

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -66,6 +66,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - uses: browser-actions/setup-chrome@latest
+        id: setup-chrome
         with:
           chrome-version: stable
       - name: Build
@@ -102,6 +103,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - uses: browser-actions/setup-chrome@latest
+        id: setup-chrome
         with:
           chrome-version: stable
       - name: Build
@@ -111,7 +113,7 @@ jobs:
       - name: End-to-end Test (Development mode)
         run: |
           set -x -e -o pipefail
-          mvn -V -e -B -ntp verify -Dmaven.javadoc.skip=false -DtrimStackTrace=false -Pit-tests
+          mvn -V -e -B -ntp verify -Dmaven.javadoc.skip=false -DtrimStackTrace=false -Dselenide.browserBinary=${{ steps.setup-chrome.outputs.chrome-path }} -Pit-tests
       - name: Package test output files
         if: ${{ failure() || success() }}
         run: find . -name surefire-reports -o -name failsafe-reports -o -name error-screenshots | tar -czf tests-report-e2e-dev.tgz -T -
@@ -138,6 +140,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - uses: browser-actions/setup-chrome@latest
+        id: setup-chrome
         with:
           chrome-version: stable
       - name: Build
@@ -147,7 +150,7 @@ jobs:
       - name: End-to-end Test (Production mode)
         run: |
           set -x -e -o pipefail
-          mvn -V -e -B -ntp verify -Dmaven.javadoc.skip=false -DtrimStackTrace=false -Pit-tests,production
+          mvn -V -e -B -ntp verify -Dmaven.javadoc.skip=false -DtrimStackTrace=false -Dselenide.browserBinary=${{ steps.setup-chrome.outputs.chrome-path }} -Pit-tests,production
       - name: Package test output files
         if: ${{ failure() || success() }}
         run: find . -name surefire-reports -o -name failsafe-reports -o -name error-screenshots | tar -czf tests-report-e2e-prod.tgz -T -


### PR DESCRIPTION
Uses selenide system property to force the browser binary that should be used for integration test.