### PR TITLE
refactor: use Config to get form authentication settings

### DIFF
--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/AuthFormBuildItem.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/AuthFormBuildItem.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class AuthFormBuildItem extends SimpleBuildItem {
+
+    private final boolean enabled;
+
+    public AuthFormBuildItem(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+}


### PR DESCRIPTION
In the vertx-http snpashot version, the configuration classes have been migrated from a concrete class with public field to [at]ConfigMapping annotated interface. To allow the extension to work with both version, this change takes configuration values directly from the Config object.