### PR TITLE
chore: set import order for spotless plugin

### DIFF
--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
@@ -15,18 +15,14 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import com.github.mcollovati.quarkus.hilla.HillaAtmosphereObjectFactory;
-import com.github.mcollovati.quarkus.hilla.HillaFormAuthenticationMechanism;
-import com.github.mcollovati.quarkus.hilla.HillaSecurityPolicy;
-import com.github.mcollovati.quarkus.hilla.HillaSecurityRecorder;
-import com.github.mcollovati.quarkus.hilla.QuarkusEndpointConfiguration;
-import com.github.mcollovati.quarkus.hilla.QuarkusEndpointController;
-import com.github.mcollovati.quarkus.hilla.QuarkusEndpointProperties;
-import com.github.mcollovati.quarkus.hilla.QuarkusViewAccessChecker;
-import com.github.mcollovati.quarkus.hilla.deployment.asm.EndpointTransferMapperClassVisitor;
-import com.github.mcollovati.quarkus.hilla.deployment.asm.PushEndpointClassVisitor;
-import com.github.mcollovati.quarkus.hilla.deployment.asm.SpringReplacementsClassVisitor;
-import com.github.mcollovati.quarkus.hilla.deployment.asm.TransferTypesPluginClassVisitor;
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Singleton;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import dev.hilla.Endpoint;
@@ -62,13 +58,6 @@ import io.quarkus.undertow.deployment.IgnoredServletContainerInitializerBuildIte
 import io.quarkus.undertow.deployment.ServletBuildItem;
 import io.quarkus.vertx.http.deployment.RequireBodyHandlerBuildItem;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
-import jakarta.annotation.security.DenyAll;
-import jakarta.annotation.security.PermitAll;
-import jakarta.annotation.security.RolesAllowed;
-import jakarta.inject.Singleton;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Predicate;
 import org.atmosphere.client.TrackMessageSizeInterceptor;
 import org.atmosphere.cpr.ApplicationConfig;
 import org.atmosphere.cpr.AtmosphereServlet;
@@ -80,6 +69,19 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
+
+import com.github.mcollovati.quarkus.hilla.HillaAtmosphereObjectFactory;
+import com.github.mcollovati.quarkus.hilla.HillaFormAuthenticationMechanism;
+import com.github.mcollovati.quarkus.hilla.HillaSecurityPolicy;
+import com.github.mcollovati.quarkus.hilla.HillaSecurityRecorder;
+import com.github.mcollovati.quarkus.hilla.QuarkusEndpointConfiguration;
+import com.github.mcollovati.quarkus.hilla.QuarkusEndpointController;
+import com.github.mcollovati.quarkus.hilla.QuarkusEndpointProperties;
+import com.github.mcollovati.quarkus.hilla.QuarkusViewAccessChecker;
+import com.github.mcollovati.quarkus.hilla.deployment.asm.EndpointTransferMapperClassVisitor;
+import com.github.mcollovati.quarkus.hilla.deployment.asm.PushEndpointClassVisitor;
+import com.github.mcollovati.quarkus.hilla.deployment.asm.SpringReplacementsClassVisitor;
+import com.github.mcollovati.quarkus.hilla.deployment.asm.TransferTypesPluginClassVisitor;
 
 class QuarkusHillaExtensionProcessor {
 

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaStandAloneProcessor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaStandAloneProcessor.java
@@ -15,8 +15,6 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import com.github.mcollovati.quarkus.hilla.EnableWebsockets;
-import com.github.mcollovati.quarkus.hilla.WebsocketHttpSessionAttachRecorder;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -27,6 +25,9 @@ import io.quarkus.undertow.deployment.ServletDeploymentManagerBuildItem;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.websockets.client.deployment.ServerWebSocketContainerBuildItem;
 import io.quarkus.websockets.client.deployment.WebSocketDeploymentInfoBuildItem;
+
+import com.github.mcollovati.quarkus.hilla.EnableWebsockets;
+import com.github.mcollovati.quarkus.hilla.WebsocketHttpSessionAttachRecorder;
 
 /**
  * A Quarkus processor that configure Vaadin minimal requirements when the Vaadin Quarkus extension is not available.

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/DropInitStatementMethodNode.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/DropInitStatementMethodNode.java
@@ -15,8 +15,9 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
-import io.quarkus.gizmo.Gizmo;
 import java.util.Set;
+
+import io.quarkus.gizmo.Gizmo;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.TypeInsnNode;

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/DropLdcStatementMethodNode.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/DropLdcStatementMethodNode.java
@@ -15,8 +15,9 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
-import io.quarkus.gizmo.Gizmo;
 import java.util.Set;
+
+import io.quarkus.gizmo.Gizmo;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.LdcInsnNode;

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/DropStatementMethodNode.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/DropStatementMethodNode.java
@@ -17,6 +17,7 @@ package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
 import java.util.ListIterator;
 import java.util.function.Predicate;
+
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.LabelNode;

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/EndpointTransferMapperClassVisitor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/EndpointTransferMapperClassVisitor.java
@@ -15,8 +15,9 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
-import io.quarkus.gizmo.Gizmo;
 import java.util.Set;
+
+import io.quarkus.gizmo.Gizmo;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/SpringReplacementsRedirectMethodVisitor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/SpringReplacementsRedirectMethodVisitor.java
@@ -15,8 +15,9 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
-import io.quarkus.gizmo.Gizmo;
 import java.util.Map;
+
+import io.quarkus.gizmo.Gizmo;
 import org.objectweb.asm.MethodVisitor;
 
 class SpringReplacementsRedirectMethodVisitor extends MethodVisitor {

--- a/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/TransferTypesPluginClassVisitor.java
+++ b/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/TransferTypesPluginClassVisitor.java
@@ -15,8 +15,9 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
-import io.quarkus.gizmo.Gizmo;
 import java.util.Set;
+
+import io.quarkus.gizmo.Gizmo;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointControllerTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointControllerTest.java
@@ -28,9 +28,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.github.mcollovati.quarkus.hilla.deployment.TestUtils.Parameters;
 import com.github.mcollovati.quarkus.hilla.deployment.endpoints.TestEndpoint;
 
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.givenEndpointRequest;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.givenEndpointRequest;
 
 class EndpointControllerTest {
 

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointControllerTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointControllerTest.java
@@ -15,12 +15,6 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.givenEndpointRequest;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-
-import com.github.mcollovati.quarkus.hilla.deployment.TestUtils.Parameters;
-import com.github.mcollovati.quarkus.hilla.deployment.endpoints.TestEndpoint;
 import dev.hilla.exception.EndpointValidationException;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
@@ -30,6 +24,13 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.mcollovati.quarkus.hilla.deployment.TestUtils.Parameters;
+import com.github.mcollovati.quarkus.hilla.deployment.endpoints.TestEndpoint;
+
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.givenEndpointRequest;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 class EndpointControllerTest {
 

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointSecurityTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointSecurityTest.java
@@ -15,27 +15,29 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.GUEST;
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.givenEndpointRequest;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 
-import com.github.mcollovati.quarkus.hilla.deployment.TestUtils.User;
-import com.github.mcollovati.quarkus.hilla.deployment.endpoints.SecureEndpoint;
 import io.quarkus.security.test.utils.TestIdentityController;
 import io.quarkus.security.test.utils.TestIdentityProvider;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.specification.RequestSpecification;
-import java.util.function.UnaryOperator;
-import java.util.stream.Stream;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.mcollovati.quarkus.hilla.deployment.TestUtils.User;
+import com.github.mcollovati.quarkus.hilla.deployment.endpoints.SecureEndpoint;
+
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.GUEST;
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.givenEndpointRequest;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 class EndpointSecurityTest {
 

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointSecurityTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointSecurityTest.java
@@ -32,12 +32,13 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.github.mcollovati.quarkus.hilla.deployment.TestUtils.User;
 import com.github.mcollovati.quarkus.hilla.deployment.endpoints.SecureEndpoint;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.GUEST;
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.givenEndpointRequest;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
 
 class EndpointSecurityTest {
 

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/HillaPushClient.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/HillaPushClient.java
@@ -15,11 +15,6 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.websocket.CloseReason;
 import jakarta.websocket.Endpoint;
 import jakarta.websocket.EndpointConfig;
@@ -38,10 +33,16 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HillaPushClient extends Endpoint implements MessageHandler.Whole<String> {
 

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/HillaPushClient.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/HillaPushClient.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class HillaPushClient extends Endpoint implements MessageHandler.Whole<String> {

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveEndpointTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveEndpointTest.java
@@ -15,11 +15,6 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import com.github.mcollovati.quarkus.hilla.deployment.endpoints.ReactiveEndpoint;
-import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.http.TestHTTPResource;
-import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.websocket.ContainerProvider;
 import jakarta.websocket.Session;
@@ -27,12 +22,19 @@ import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.mcollovati.quarkus.hilla.deployment.endpoints.ReactiveEndpoint;
 
 class ReactiveEndpointTest {
     private static final String ENDPOINT_NAME = ReactiveEndpoint.class.getSimpleName();

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveSecureEndpointTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveSecureEndpointTest.java
@@ -43,11 +43,12 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.github.mcollovati.quarkus.hilla.deployment.endpoints.ReactiveSecureEndpoint;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ANONYMOUS;
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.GUEST;
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 class ReactiveSecureEndpointTest {
     private static final String ENDPOINT_NAME = ReactiveSecureEndpoint.class.getSimpleName();

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveSecureEndpointTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveSecureEndpointTest.java
@@ -15,18 +15,6 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ANONYMOUS;
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.GUEST;
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import com.github.mcollovati.quarkus.hilla.deployment.endpoints.ReactiveSecureEndpoint;
-import io.quarkus.security.test.utils.TestIdentityController;
-import io.quarkus.security.test.utils.TestIdentityProvider;
-import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.test.common.http.TestHTTPResource;
-import io.vertx.core.http.HttpHeaders;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.websocket.ClientEndpointConfig;
 import jakarta.websocket.ContainerProvider;
@@ -38,6 +26,12 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.http.HttpHeaders;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -46,6 +40,14 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.mcollovati.quarkus.hilla.deployment.endpoints.ReactiveSecureEndpoint;
+
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ANONYMOUS;
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.GUEST;
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 class ReactiveSecureEndpointTest {
     private static final String ENDPOINT_NAME = ReactiveSecureEndpoint.class.getSimpleName();

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringReplacementsTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringReplacementsTest.java
@@ -35,9 +35,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.github.mcollovati.quarkus.hilla.SpringReplacements;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;
 import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
-import static org.assertj.core.api.Assertions.assertThat;
 
 class SpringReplacementsTest {
 

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringReplacementsTest.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringReplacementsTest.java
@@ -15,27 +15,29 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;
-import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.github.mcollovati.quarkus.hilla.SpringReplacements;
-import io.quarkus.security.test.utils.AuthData;
-import io.quarkus.security.test.utils.IdentityMock;
-import io.quarkus.security.test.utils.TestIdentityController;
-import io.quarkus.security.test.utils.TestIdentityProvider;
-import io.quarkus.test.QuarkusUnitTest;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.security.Principal;
 import java.util.Set;
 import java.util.function.Function;
+
+import io.quarkus.security.test.utils.AuthData;
+import io.quarkus.security.test.utils.IdentityMock;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.mcollovati.quarkus.hilla.SpringReplacements;
+
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.ADMIN;
+import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class SpringReplacementsTest {
 

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/TestUtils.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/TestUtils.java
@@ -15,12 +15,13 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
+import java.util.LinkedHashMap;
+import java.util.function.UnaryOperator;
+
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
-import java.util.LinkedHashMap;
-import java.util.function.UnaryOperator;
 
 final class TestUtils {
 

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/ReactiveEndpoint.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/ReactiveEndpoint.java
@@ -15,12 +15,13 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.endpoints;
 
-import com.vaadin.flow.server.auth.AnonymousAllowed;
-import dev.hilla.Endpoint;
-import dev.hilla.EndpointSubscription;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+import dev.hilla.Endpoint;
+import dev.hilla.EndpointSubscription;
 import reactor.core.publisher.Flux;
 
 @Endpoint

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/ReactiveSecureEndpoint.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/ReactiveSecureEndpoint.java
@@ -15,10 +15,11 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.endpoints;
 
-import dev.hilla.Endpoint;
 import jakarta.annotation.security.DenyAll;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
+
+import dev.hilla.Endpoint;
 import reactor.core.publisher.Flux;
 
 @Endpoint

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/SecureEndpoint.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/SecureEndpoint.java
@@ -15,10 +15,11 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.endpoints;
 
-import dev.hilla.Endpoint;
 import jakarta.annotation.security.DenyAll;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
+
+import dev.hilla.Endpoint;
 
 @Endpoint
 public class SecureEndpoint {

--- a/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/TestEndpoint.java
+++ b/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/TestEndpoint.java
@@ -15,11 +15,12 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.endpoints;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import dev.hilla.Endpoint;
-import java.util.Objects;
 
 @Endpoint
 @AnonymousAllowed

--- a/integration-tests/hybrid-smoke-tests/src/main/java/com/example/application/ClockService.java
+++ b/integration-tests/hybrid-smoke-tests/src/main/java/com/example/application/ClockService.java
@@ -15,12 +15,13 @@
  */
 package com.example.application;
 
-import dev.hilla.Nonnull;
-import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.time.Duration;
 import java.util.Date;
 import java.util.UUID;
+
+import dev.hilla.Nonnull;
+import io.quarkus.security.identity.SecurityIdentity;
 import org.eclipse.microprofile.context.ThreadContext;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;

--- a/integration-tests/hybrid-smoke-tests/src/main/java/com/example/application/endpoints/helloworld/HelloWorldEndpoint.java
+++ b/integration-tests/hybrid-smoke-tests/src/main/java/com/example/application/endpoints/helloworld/HelloWorldEndpoint.java
@@ -15,6 +15,9 @@
  */
 package com.example.application.endpoints.helloworld;
 
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+
 import com.example.application.ClockService;
 import com.example.application.entities.UserPOJO;
 import com.vaadin.flow.server.VaadinRequest;
@@ -22,8 +25,6 @@ import com.vaadin.flow.server.auth.AnonymousAllowed;
 import dev.hilla.Endpoint;
 import dev.hilla.EndpointSubscription;
 import dev.hilla.Nonnull;
-import jakarta.annotation.security.PermitAll;
-import jakarta.annotation.security.RolesAllowed;
 import reactor.core.publisher.Flux;
 
 @Endpoint

--- a/integration-tests/hybrid-smoke-tests/src/main/java/com/example/application/endpoints/helloworld/TestResource.java
+++ b/integration-tests/hybrid-smoke-tests/src/main/java/com/example/application/endpoints/helloworld/TestResource.java
@@ -17,6 +17,7 @@ package com.example.application.endpoints.helloworld;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+
 import org.jboss.resteasy.reactive.RestResponse;
 
 @Path("test")

--- a/integration-tests/hybrid-smoke-tests/src/main/java/com/example/application/endpoints/helloworld/UserInfoEndpoint.java
+++ b/integration-tests/hybrid-smoke-tests/src/main/java/com/example/application/endpoints/helloworld/UserInfoEndpoint.java
@@ -15,12 +15,13 @@
  */
 package com.example.application.endpoints.helloworld;
 
+import jakarta.annotation.security.PermitAll;
+
 import com.example.application.entities.UserInfo;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import dev.hilla.Endpoint;
 import dev.hilla.Nonnull;
 import io.quarkus.security.identity.SecurityIdentity;
-import jakarta.annotation.security.PermitAll;
 
 @Endpoint
 @PermitAll

--- a/integration-tests/hybrid-smoke-tests/src/main/java/com/example/application/entities/UserInfo.java
+++ b/integration-tests/hybrid-smoke-tests/src/main/java/com/example/application/entities/UserInfo.java
@@ -15,10 +15,11 @@
  */
 package com.example.application.entities;
 
-import dev.hilla.Nonnull;
-import io.quarkus.security.identity.SecurityIdentity;
 import java.util.HashSet;
 import java.util.Set;
+
+import dev.hilla.Nonnull;
+import io.quarkus.security.identity.SecurityIdentity;
 
 public class UserInfo {
 

--- a/integration-tests/hybrid-smoke-tests/src/main/java/com/example/application/flow/FlowView.java
+++ b/integration-tests/hybrid-smoke-tests/src/main/java/com/example/application/flow/FlowView.java
@@ -15,13 +15,14 @@
  */
 package com.example.application.flow;
 
+import jakarta.annotation.security.RolesAllowed;
+
 import com.example.application.ClockService;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
-import jakarta.annotation.security.RolesAllowed;
 import reactor.core.Disposable;
 
 @Route("flow-view")

--- a/integration-tests/hybrid-smoke-tests/src/test/java/com/example/application/BootstrapTest.java
+++ b/integration-tests/hybrid-smoke-tests/src/test/java/com/example/application/BootstrapTest.java
@@ -15,18 +15,20 @@
  */
 package com.example.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.github.mcollovati.quarkus.testing.HillaCleaner;
-import com.github.mcollovati.quarkus.testing.HillaFrontendGenerated;
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.QuarkusTest;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.testing.HillaCleaner;
+import com.github.mcollovati.quarkus.testing.HillaFrontendGenerated;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @QuarkusTestResource(HillaCleaner.class)

--- a/integration-tests/hybrid-smoke-tests/src/test/java/com/example/application/PushTest.java
+++ b/integration-tests/hybrid-smoke-tests/src/test/java/com/example/application/PushTest.java
@@ -15,17 +15,19 @@
  */
 package com.example.application;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.codeborne.selenide.Condition;
+import io.quarkus.test.junit.QuarkusTest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.testing.AbstractTest;
+
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static org.awaitility.Awaitility.await;
-
-import com.codeborne.selenide.Condition;
-import com.github.mcollovati.quarkus.testing.AbstractTest;
-import io.quarkus.test.junit.QuarkusTest;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 class PushTest extends AbstractTest {

--- a/integration-tests/hybrid-smoke-tests/src/test/java/com/example/application/SmokeTest.java
+++ b/integration-tests/hybrid-smoke-tests/src/test/java/com/example/application/SmokeTest.java
@@ -15,19 +15,21 @@
  */
 package com.example.application;
 
-import static com.codeborne.selenide.Condition.text;
-import static com.codeborne.selenide.Condition.visible;
-import static com.codeborne.selenide.Selenide.$;
-import static com.codeborne.selenide.Selenide.$$;
+import java.time.Duration;
 
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Selectors;
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideElement;
-import com.github.mcollovati.quarkus.testing.AbstractTest;
 import io.quarkus.test.junit.QuarkusTest;
-import java.time.Duration;
 import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.testing.AbstractTest;
+
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$$;
 
 @QuarkusTest
 class SmokeTest extends AbstractTest {

--- a/integration-tests/hybrid-smoke-tests/src/test/java/com/github/mcollovati/quarkus/testing/AbstractTest.java
+++ b/integration-tests/hybrid-smoke-tests/src/test/java/com/github/mcollovati/quarkus/testing/AbstractTest.java
@@ -15,7 +15,9 @@
  */
 package com.github.mcollovati.quarkus.testing;
 
-import static com.codeborne.selenide.Selenide.$;
+import java.lang.management.ManagementFactory;
+import java.time.Duration;
+import java.util.function.Supplier;
 
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Configuration;
@@ -24,11 +26,10 @@ import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.junit5.BrowserPerTestStrategyExtension;
 import io.quarkus.test.common.http.TestHTTPResource;
-import java.lang.management.ManagementFactory;
-import java.time.Duration;
-import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import static com.codeborne.selenide.Selenide.$;
 
 @ExtendWith({BrowserPerTestStrategyExtension.class})
 public abstract class AbstractTest {

--- a/integration-tests/hybrid-smoke-tests/src/test/java/com/github/mcollovati/quarkus/testing/HillaCleaner.java
+++ b/integration-tests/hybrid-smoke-tests/src/test/java/com/github/mcollovati/quarkus/testing/HillaCleaner.java
@@ -15,7 +15,6 @@
  */
 package com.github.mcollovati.quarkus.testing;
 
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -25,6 +24,8 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.junit.jupiter.api.Assertions;
 
 public class HillaCleaner implements QuarkusTestResourceLifecycleManager {

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/ClockService.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/ClockService.java
@@ -15,12 +15,13 @@
  */
 package com.example.application;
 
-import dev.hilla.Nonnull;
-import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.time.Duration;
 import java.util.Date;
 import java.util.UUID;
+
+import dev.hilla.Nonnull;
+import io.quarkus.security.identity.SecurityIdentity;
 import org.eclipse.microprofile.context.ThreadContext;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/HelloWorldEndpoint.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/HelloWorldEndpoint.java
@@ -15,6 +15,9 @@
  */
 package com.example.application.endpoints.helloworld;
 
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+
 import com.example.application.ClockService;
 import com.example.application.entities.UserPOJO;
 import com.vaadin.flow.server.VaadinRequest;
@@ -22,8 +25,6 @@ import com.vaadin.flow.server.auth.AnonymousAllowed;
 import dev.hilla.Endpoint;
 import dev.hilla.EndpointSubscription;
 import dev.hilla.Nonnull;
-import jakarta.annotation.security.PermitAll;
-import jakarta.annotation.security.RolesAllowed;
 import reactor.core.publisher.Flux;
 
 @Endpoint

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/TestResource.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/TestResource.java
@@ -17,6 +17,7 @@ package com.example.application.endpoints.helloworld;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+
 import org.jboss.resteasy.reactive.RestResponse;
 
 @Path("test")

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/UserInfoEndpoint.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/endpoints/helloworld/UserInfoEndpoint.java
@@ -15,12 +15,13 @@
  */
 package com.example.application.endpoints.helloworld;
 
+import jakarta.annotation.security.PermitAll;
+
 import com.example.application.entities.UserInfo;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import dev.hilla.Endpoint;
 import dev.hilla.Nonnull;
 import io.quarkus.security.identity.SecurityIdentity;
-import jakarta.annotation.security.PermitAll;
 
 @Endpoint
 @PermitAll

--- a/integration-tests/smoke-tests/src/main/java/com/example/application/entities/UserInfo.java
+++ b/integration-tests/smoke-tests/src/main/java/com/example/application/entities/UserInfo.java
@@ -15,10 +15,11 @@
  */
 package com.example.application.entities;
 
-import dev.hilla.Nonnull;
-import io.quarkus.security.identity.SecurityIdentity;
 import java.util.HashSet;
 import java.util.Set;
+
+import dev.hilla.Nonnull;
+import io.quarkus.security.identity.SecurityIdentity;
 
 public class UserInfo {
 

--- a/integration-tests/smoke-tests/src/test/java/com/example/application/BootstrapTest.java
+++ b/integration-tests/smoke-tests/src/test/java/com/example/application/BootstrapTest.java
@@ -15,18 +15,20 @@
  */
 package com.example.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.github.mcollovati.quarkus.testing.HillaCleaner;
-import com.github.mcollovati.quarkus.testing.HillaFrontendGenerated;
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.QuarkusTest;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.testing.HillaCleaner;
+import com.github.mcollovati.quarkus.testing.HillaFrontendGenerated;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @QuarkusTestResource(HillaCleaner.class)

--- a/integration-tests/smoke-tests/src/test/java/com/example/application/PushTest.java
+++ b/integration-tests/smoke-tests/src/test/java/com/example/application/PushTest.java
@@ -15,17 +15,19 @@
  */
 package com.example.application;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.codeborne.selenide.Condition;
+import io.quarkus.test.junit.QuarkusTest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.testing.AbstractTest;
+
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static org.awaitility.Awaitility.await;
-
-import com.codeborne.selenide.Condition;
-import com.github.mcollovati.quarkus.testing.AbstractTest;
-import io.quarkus.test.junit.QuarkusTest;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 class PushTest extends AbstractTest {

--- a/integration-tests/smoke-tests/src/test/java/com/example/application/SmokeTest.java
+++ b/integration-tests/smoke-tests/src/test/java/com/example/application/SmokeTest.java
@@ -15,16 +15,17 @@
  */
 package com.example.application;
 
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.SelenideElement;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.testing.AbstractTest;
+
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
-
-import com.codeborne.selenide.Condition;
-import com.codeborne.selenide.SelenideElement;
-import com.github.mcollovati.quarkus.testing.AbstractTest;
-import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 class SmokeTest extends AbstractTest {

--- a/integration-tests/smoke-tests/src/test/java/com/github/mcollovati/quarkus/testing/AbstractTest.java
+++ b/integration-tests/smoke-tests/src/test/java/com/github/mcollovati/quarkus/testing/AbstractTest.java
@@ -15,7 +15,9 @@
  */
 package com.github.mcollovati.quarkus.testing;
 
-import static com.codeborne.selenide.Selenide.$;
+import java.lang.management.ManagementFactory;
+import java.time.Duration;
+import java.util.function.Supplier;
 
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Configuration;
@@ -24,11 +26,10 @@ import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.junit5.BrowserPerTestStrategyExtension;
 import io.quarkus.test.common.http.TestHTTPResource;
-import java.lang.management.ManagementFactory;
-import java.time.Duration;
-import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import static com.codeborne.selenide.Selenide.$;
 
 @ExtendWith({BrowserPerTestStrategyExtension.class})
 public abstract class AbstractTest {

--- a/integration-tests/smoke-tests/src/test/java/com/github/mcollovati/quarkus/testing/HillaCleaner.java
+++ b/integration-tests/smoke-tests/src/test/java/com/github/mcollovati/quarkus/testing/HillaCleaner.java
@@ -15,7 +15,6 @@
  */
 package com.github.mcollovati.quarkus.testing;
 
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -25,6 +24,8 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.junit.jupiter.api.Assertions;
 
 public class HillaCleaner implements QuarkusTestResourceLifecycleManager {

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
                             <style>PALANTIR</style>
                         </palantirJavaFormat>
                         <importOrder>
-                            <order>jakarta|java|javax,,com.github.mcollovati,\#</order>
+                            <order>jakarta|java|javax,,com.github.mcollovati,\#jakarta|\#java|\#javax,\#,\#com.github.mcollovati</order>
                         </importOrder>
                         <removeUnusedImports/>
                         <formatAnnotations/>

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,9 @@
                         <palantirJavaFormat>
                             <style>PALANTIR</style>
                         </palantirJavaFormat>
+                        <importOrder>
+                            <order>jakarta|java|javax,,com.github.mcollovati,\#</order>
+                        </importOrder>
                         <removeUnusedImports/>
                         <formatAnnotations/>
                         <toggleOffOn/>

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaAtmosphereObjectFactory.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaAtmosphereObjectFactory.java
@@ -15,8 +15,9 @@
  */
 package com.github.mcollovati.quarkus.hilla;
 
-import dev.hilla.push.PushEndpoint;
 import jakarta.enterprise.inject.spi.CDI;
+
+import dev.hilla.push.PushEndpoint;
 import org.atmosphere.cpr.AtmosphereConfig;
 import org.atmosphere.inject.InjectableObjectFactory;
 

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaFormAuthenticationMechanism.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaFormAuthenticationMechanism.java
@@ -15,6 +15,9 @@
  */
 package com.github.mcollovati.quarkus.hilla;
 
+import java.util.Optional;
+import java.util.Set;
+
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.AuthenticationRequest;
@@ -24,8 +27,6 @@ import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.Cookie;
 import io.vertx.ext.web.RoutingContext;
-import java.util.Optional;
-import java.util.Set;
 
 public class HillaFormAuthenticationMechanism implements HttpAuthenticationMechanism {
     private String logoutPath;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaSecurityPolicy.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaSecurityPolicy.java
@@ -15,6 +15,13 @@
  */
 package com.github.mcollovati.quarkus.hilla;
 
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.Router;
 import com.vaadin.flow.router.internal.NavigationRouteTarget;
@@ -31,12 +38,6 @@ import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy;
 import io.quarkus.vertx.http.runtime.security.PathMatcher;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
-import jakarta.enterprise.event.Observes;
-import jakarta.inject.Inject;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.function.UnaryOperator;
 import org.eclipse.microprofile.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaSecurityRecorder.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/HillaSecurityRecorder.java
@@ -15,11 +15,12 @@
  */
 package com.github.mcollovati.quarkus.hilla;
 
+import java.util.function.Supplier;
+
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.security.FormAuthenticationMechanism;
-import java.util.function.Supplier;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusApplicationContext.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusApplicationContext.java
@@ -25,6 +25,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.vaadin.quarkus.AnyLiteral;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusApplicationContext.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusApplicationContext.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.vaadin.quarkus.AnyLiteral;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointController.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointController.java
@@ -15,12 +15,6 @@
  */
 package com.github.mcollovati.quarkus.hilla;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import dev.hilla.Endpoint;
-import dev.hilla.EndpointController;
-import dev.hilla.EndpointInvoker;
-import dev.hilla.EndpointRegistry;
-import dev.hilla.auth.CsrfChecker;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.POST;
@@ -30,6 +24,13 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.hilla.Endpoint;
+import dev.hilla.EndpointController;
+import dev.hilla.EndpointInvoker;
+import dev.hilla.EndpointRegistry;
+import dev.hilla.auth.CsrfChecker;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.ResponseEntity;
 

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointControllerConfiguration.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointControllerConfiguration.java
@@ -15,6 +15,13 @@
  */
 package com.github.mcollovati.quarkus.hilla;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import jakarta.servlet.ServletContext;
+
 import com.vaadin.flow.server.auth.AccessAnnotationChecker;
 import dev.hilla.EndpointController;
 import dev.hilla.EndpointInvoker;
@@ -28,12 +35,6 @@ import dev.hilla.parser.jackson.JacksonObjectMapperFactory;
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.runtime.Startup;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Produces;
-import jakarta.enterprise.inject.spi.BeanManager;
-import jakarta.inject.Named;
-import jakarta.inject.Singleton;
-import jakarta.servlet.ServletContext;
 import org.springframework.context.ApplicationContext;
 
 @Unremovable

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointProperties.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointProperties.java
@@ -15,9 +15,10 @@
  */
 package com.github.mcollovati.quarkus.hilla;
 
-import dev.hilla.EndpointProperties;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+
+import dev.hilla.EndpointProperties;
 
 @ApplicationScoped
 public class QuarkusEndpointProperties extends EndpointProperties {

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusHandlerHelper.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusHandlerHelper.java
@@ -15,14 +15,15 @@
  */
 package com.github.mcollovati.quarkus.hilla;
 
-import static com.vaadin.flow.server.HandlerHelper.getPathIfInsideServlet;
+import java.io.Serializable;
+import java.util.Optional;
 
 import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.communication.StreamRequestHandler;
 import com.vaadin.flow.shared.ApplicationConstants;
 import io.vertx.ext.web.RoutingContext;
-import java.io.Serializable;
-import java.util.Optional;
+
+import static com.vaadin.flow.server.HandlerHelper.getPathIfInsideServlet;
 
 public class QuarkusHandlerHelper implements Serializable {
 

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusHillaExtension.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusHillaExtension.java
@@ -15,10 +15,11 @@
  */
 package com.github.mcollovati.quarkus.hilla;
 
-import com.vaadin.flow.internal.UsageStatistics;
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.Properties;
+
+import com.vaadin.flow.internal.UsageStatistics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusViewAccessChecker.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusViewAccessChecker.java
@@ -15,16 +15,17 @@
  */
 package com.github.mcollovati.quarkus.hilla;
 
-import com.vaadin.flow.server.ServiceInitEvent;
-import com.vaadin.flow.server.VaadinRequest;
-import com.vaadin.flow.server.auth.AccessAnnotationChecker;
-import com.vaadin.flow.server.auth.ViewAccessChecker;
-import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.security.Principal;
 import java.util.function.Function;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.auth.AccessAnnotationChecker;
+import com.vaadin.flow.server.auth.ViewAccessChecker;
+import io.quarkus.security.identity.SecurityIdentity;
 
 @Singleton
 public class QuarkusViewAccessChecker extends ViewAccessChecker {

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/SpringReplacements.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/SpringReplacements.java
@@ -15,10 +15,11 @@
  */
 package com.github.mcollovati.quarkus.hilla;
 
-import io.quarkus.security.identity.CurrentIdentityAssociation;
-import io.quarkus.security.identity.SecurityIdentity;
 import java.security.Principal;
 import java.util.function.Function;
+
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
 
 public class SpringReplacements {
 

--- a/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/WebsocketHttpSessionAttachRecorder.java
+++ b/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/WebsocketHttpSessionAttachRecorder.java
@@ -15,6 +15,11 @@
  */
 package com.github.mcollovati.quarkus.hilla;
 
+import jakarta.servlet.http.HttpSession;
+import java.security.Principal;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
 import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.shared.ApplicationConstants;
 import io.quarkus.runtime.RuntimeValue;
@@ -42,10 +47,6 @@ import io.undertow.websockets.vertx.VertxWebSocketHandler;
 import io.undertow.websockets.vertx.VertxWebSocketHttpExchange;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
-import jakarta.servlet.http.HttpSession;
-import java.security.Principal;
-import java.util.Optional;
-import java.util.concurrent.Executor;
 
 /**
  * NOTE: this code has been copy/pasted from vaadin-quarkus extension, credit goes to Vaadin Ltd.


### PR DESCRIPTION
Imports will be sorted in the following order:

jakarta|java|javax

all dependency imports

com.github.mcollovati

all static imports