### PR TITLE
chore: add hibernate-validator dependency

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -26,6 +26,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow-deployment</artifactId>
         </dependency>
         <dependency>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -28,6 +28,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
It's likely that a Hilla application will use jakarta validation annotations, so it makes sense adding the hibernate-validator as extension dependency.