### PR TITLE
chore(actions): refactor snapshot validation

### DIFF
--- a/.github/actions/run-validation/action.yaml
+++ b/.github/actions/run-validation/action.yaml
@@ -39,8 +39,7 @@ runs:
       run: |
         set -x -e -o pipefail
         mvn -N versions:set-property -Dproperty=hilla.version -DnewVersion=${{ inputs.hilla_version }} -DgenerateBackupPoms=false
-        vaadin_version=$(mvn -f runtime/pom.xml dependency:properties help:evaluate -Dexpression=com.vaadin:flow-server:jar -q -DforceStdout \
-          | sed -E 's/^.*flow-server-([0-9]+\.[0-9]+).*/\1/g')-SNAPSHOT
+        vaadin_version=$(mvn -ntp -N -Pdetect-vaadin-platform -q)-SNAPSHOT
         mvn versions:set-property -Dproperty=vaadin.version -DnewVersion=$vaadin_version -DgenerateBackupPoms=false -Pit-tests
         echo "Running Validation with Hilla ${{ inputs.hilla_version }} and Vaadin $vaadin_version">> "$GITHUB_STEP_SUMMARY"
         mvn -V -e -B -ntp -DskipTests -Dmaven.javadoc.skip=false install

--- a/.github/actions/run-validation/action.yaml
+++ b/.github/actions/run-validation/action.yaml
@@ -39,6 +39,10 @@ runs:
       run: |
         set -x -e -o pipefail
         mvn -N versions:set-property -Dproperty=hilla.version -DnewVersion=${{ inputs.hilla_version }} -DgenerateBackupPoms=false
+        vaadin_version=$(mvn -f runtime/pom.xml dependency:properties help:evaluate -Dexpression=com.vaadin:flow-server:jar -q -DforceStdout \
+          | sed -E 's/^.*flow-server-([0-9]+\.[0-9]+).*/\1/g')-SNAPSHOT
+        mvn versions:set-property -Dproperty=vaadin.version -DnewVersion=$vaadin_version -DgenerateBackupPoms=false -Pit-tests
+        echo "Running Validation with Hilla ${{ inputs.hilla_version }} and Vaadin $vaadin_version">> "$GITHUB_STEP_SUMMARY"
         mvn -V -e -B -ntp -DskipTests -Dmaven.javadoc.skip=false install
     - name: Test
       shell: bash
@@ -49,12 +53,12 @@ runs:
       shell: bash
       run: |
         set -x -e -o pipefail
-        mvn -V -e -B -ntp verify -Dmaven.javadoc.skip=false -DtrimStackTrace=false -Pit-tests -Dselenide.browserBinary=${{ steps.setup-chrome.outputs.chrome-path }}
+        mvn -V -e -B -ntp verify -Dmaven.javadoc.skip=false -DtrimStackTrace=false -Pit-tests,snapshot-validation -Dselenide.browserBinary=${{ steps.setup-chrome.outputs.chrome-path }}
     - name: End-to-end Tests (Production mode)
       shell: bash
       run: |
         set -x -e -o pipefail
-        mvn -V -e -B -ntp verify -Dmaven.javadoc.skip=false -DtrimStackTrace=false -Pit-tests,production -Dselenide.browserBinary=${{ steps.setup-chrome.outputs.chrome-path }}
+        mvn -V -e -B -ntp verify -Dmaven.javadoc.skip=false -DtrimStackTrace=false -Pit-tests,production,snapshot-validation -Dselenide.browserBinary=${{ steps.setup-chrome.outputs.chrome-path }}
     - name: Checkout
       uses: actions/checkout@v3
       if: ${{ always() }}

--- a/.github/actions/run-validation/action.yaml
+++ b/.github/actions/run-validation/action.yaml
@@ -16,6 +16,9 @@ inputs:
   hilla_version:
     description: 'Hilla version'
     required: true
+  skip_vaadin_version_detection:
+    description: 'Skips Vaadin platform version detection'
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -38,10 +41,12 @@ runs:
       shell: bash
       run: |
         set -x -e -o pipefail
-        mvn -N versions:set-property -Dproperty=hilla.version -DnewVersion=${{ inputs.hilla_version }} -DgenerateBackupPoms=false
-        vaadin_version=$(mvn -ntp -N -Pdetect-vaadin-platform -q)-SNAPSHOT
-        mvn versions:set-property -Dproperty=vaadin.version -DnewVersion=$vaadin_version -DgenerateBackupPoms=false -Pit-tests
-        echo "Running Validation with Hilla ${{ inputs.hilla_version }} and Vaadin $vaadin_version">> "$GITHUB_STEP_SUMMARY"
+        mvn -B -N -ntp versions:set-property -Dproperty=hilla.version -DnewVersion=${{ inputs.hilla_version }} -DgenerateBackupPoms=false
+        if [[ "${{ inputs.skip_vaadin_version_detection }}" == "false" ]]; then
+          vaadin_version=$(mvn -ntp -N -Pdetect-vaadin-platform -q)-SNAPSHOT
+          mvn -B -ntp versions:set-property -Dproperty=vaadin.version -DnewVersion=$vaadin_version -DgenerateBackupPoms=false -Pit-tests
+          echo "Running Validation with Hilla ${{ inputs.hilla_version }} and Vaadin $vaadin_version">> "$GITHUB_STEP_SUMMARY"
+        fi
         mvn -V -e -B -ntp -DskipTests -Dmaven.javadoc.skip=false install
     - name: Test
       shell: bash

--- a/.github/workflows/validation-nightly.yaml
+++ b/.github/workflows/validation-nightly.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: ./.github/actions/run-validation
         with:
-          ref: "main"
+          ref: ${{ github.event_name == 'schedule' && 'main' || github.ref }}
           java_version: ${{ matrix.java }}
           hilla_version: ${{ matrix.hilla }}
   snapshot-1_0:

--- a/.github/workflows/validation-nightly.yaml
+++ b/.github/workflows/validation-nightly.yaml
@@ -38,3 +38,4 @@ jobs:
           ref: "1.0"
           java_version: ${{ matrix.java }}
           hilla_version: ${{ matrix.hilla }}
+          skip_vaadin_version_detection: true

--- a/integration-tests/hybrid-smoke-tests/pom.xml
+++ b/integration-tests/hybrid-smoke-tests/pom.xml
@@ -196,5 +196,41 @@
                 <quarkus.package.type>native</quarkus.package.type>
             </properties>
         </profile>
+        <profile>
+            <!--
+                Profile used during snapshot validation that cleans npm stuff to prevent
+                issues with npm packages when using Hilla versions different from the one
+                used to build the lock file
+            -->
+            <id>snapshot-validation</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>clean-node-stuff</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                                <configuration>
+                                    <filesets>
+                                        <fileset>
+                                            <directory>${project.basedir}</directory>
+                                            <includes>
+                                                <include>package-lock.json</include>
+                                                <include>node_modules/**</include>
+                                            </includes>
+                                        </fileset>
+                                    </filesets>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/integration-tests/smoke-tests/pom.xml
+++ b/integration-tests/smoke-tests/pom.xml
@@ -114,7 +114,8 @@
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
-                        <selenide.reportsFolder>${project.build.directory}/selenide/selenide-reports</selenide.reportsFolder>
+                        <selenide.reportsFolder>${project.build.directory}/selenide/selenide-reports
+                        </selenide.reportsFolder>
                         <selenide.downloadsFolder>${project.build.directory}/selenide/downloads
                         </selenide.downloadsFolder>
                     </systemPropertyVariables>
@@ -196,6 +197,42 @@
                 <skipITs>false</skipITs>
                 <quarkus.package.type>native</quarkus.package.type>
             </properties>
+        </profile>
+        <profile>
+            <!--
+                Profile used during snapshot validation that cleans npm stuff to prevent
+                issues with npm packages when using Hilla versions different from the one
+                used to build the lock file
+            -->
+            <id>snapshot-validation</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>clean-node-stuff</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                                <configuration>
+                                    <filesets>
+                                        <fileset>
+                                            <directory>${project.basedir}</directory>
+                                            <includes>
+                                                <include>package-lock.json</include>
+                                                <include>node_modules/**</include>
+                                            </includes>
+                                        </fileset>
+                                    </filesets>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,7 @@
 
         <quarkus.version>3.4.1</quarkus.version>
         <vaadin.version>24.1.10</vaadin.version>
-        <vaadin-quarkus.version>2.0.1</vaadin-quarkus.version>
-        <hilla.version>2.2.0</hilla.version>
+        <hilla.version>2.3-SNAPSHOT</hilla.version>
 
         <assertj.version>3.24.2</assertj.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
         <quarkus.version>3.4.1</quarkus.version>
         <vaadin.version>24.1.10</vaadin.version>
-        <hilla.version>2.3-SNAPSHOT</hilla.version>
+        <hilla.version>2.2.0</hilla.version>
 
         <assertj.version>3.24.2</assertj.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                         <version>${build-helper-maven-plugin.version}</version>
                         <executions>
                             <execution>
-                                <id>vaaind-platform-version</id>
+                                <id>vaadin-platform-version</id>
                                 <goals>
                                     <goal>regex-property</goal>
                                 </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
         <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
         <spotless-maven-plugin.version>2.40.0</spotless-maven-plugin.version>
+        <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -435,6 +436,71 @@
                 <module>integration-tests/smoke-tests</module>
                 <module>integration-tests/hybrid-smoke-tests</module>
             </modules>
+        </profile>
+        <profile>
+            <id>detect-vaadin-platform</id>
+            <dependencies>
+                <dependency>
+                    <groupId>dev.hilla</groupId>
+                    <artifactId>hilla</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <defaultGoal>initialize</defaultGoal>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>set-version-properties</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>properties</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>${build-helper-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>vaaind-platform-version</id>
+                                <goals>
+                                    <goal>regex-property</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                                <configuration>
+                                    <name>vaadin.platform</name>
+                                    <regex>^.*flow-server-(\d+\.\d+).*</regex>
+                                    <replacement>$1</replacement>
+                                    <value>${com.vaadin:flow-server:jar}</value>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-help-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-cli</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>evaluate</goal>
+                                </goals>
+                                <configuration>
+                                    <expression>vaadin.platform</expression>
+                                    <forceStdout>true</forceStdout>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
To prevent issues with npm packages when using Hilla versions different from the one used to build the lock file the action will delete the lock file and node_modules folder for integration test modules.
It also computes the correct Vaadin platform snapshot version for the hybrid test module.