### PR TITLE
chore: downgrade selenide for JDK 11

### DIFF
--- a/integration-tests/smoke-tests/pom.xml
+++ b/integration-tests/smoke-tests/pom.xml
@@ -196,5 +196,14 @@
                 <quarkus.package.type>native</quarkus.package.type>
             </properties>
         </profile>
+        <profile>
+            <id>java11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <properties>
+                <selenide.version>6.19.1</selenide.version>
+            </properties>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Selenide 7 required at least Java 17