### PR TITLE
test: workaround to use correct chromedriver binary

### DIFF
--- a/integration-tests/test-commons/src/main/java/com/github/mcollovati/quarkus/testing/AbstractTest.java
+++ b/integration-tests/test-commons/src/main/java/com/github/mcollovati/quarkus/testing/AbstractTest.java
@@ -37,6 +37,13 @@ public abstract class AbstractTest {
     private static final boolean isMacOS =
             System.getProperty("os.name").toLowerCase().contains("mac");
 
+    static {
+        // Workaround for Selenide 7 issue
+        if (Configuration.browserBinary != null && System.getProperty("webdriver.chrome.driver") == null) {
+            System.setProperty("webdriver.chrome.driver", Configuration.browserBinary);
+        }
+    }
+
     @TestHTTPResource()
     private String baseURL;
 


### PR DESCRIPTION
It seems like that Selenide is not forwarding the browser binary setting to Selenium. Force the selenium system property in tests