### PR TITLE
chore(actions): add rules for hilla version upgrade detection

### DIFF
--- a/etc/release-version-rules.xml
+++ b/etc/release-version-rules.xml
@@ -1,0 +1,7 @@
+<ruleset comparisonMethod="maven"
+         xmlns="https://www.mojohaus.org/VERSIONS/RULE/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://www.mojohaus.org/VERSIONS/RULE/2.1.0 https://www.mojohaus.org/versions/versions-model/xsd/rule-2.1.0.xsd">
+  <rules>
+    <rule groupId="dev.hilla" comparisonMethod="numeric"/>
+  </rules>
+</ruleset>


### PR DESCRIPTION
Used by release process to pin Hilla version, when POM defines a SNAPSHOT