### PR TITLE
chore(actions): improve release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,7 @@ jobs:
             if [[ "${{ inputs.hilla-version }}" = "${{ inputs.target-branch }}."* ]]; then            
               mvn -N -ntp versions:set-property -Dproperty=hilla.version -DnewVersion="${{ inputs.hilla-version }}"
               echo "⚠️ Hilla version set to ${{ inputs.hilla-version }}." | tee -a  $GITHUB_STEP_SUMMARY
-            elif
+            else
               echo "🚫 Hilla version '${{ inputs.hilla-version }}' does not match release branch ${{ inputs.target-branch }}." \
                 | tee -a  $GITHUB_STEP_SUMMARY
               exit 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,9 +79,9 @@ jobs:
              | tee -a  $GITHUB_STEP_SUMMARY
             exit 1
           fi
-          echo "Releasing version '${{ inputs.version }}' from branch '${{ inputs.target-branch }}'." >> $GITHUB_STEP_SUMMARY
+          echo "Releasing version '${{ inputs.version }}' from branch '${{ inputs.target-branch }}'." | tee -a $GITHUB_STEP_SUMMARY
           if [[ "${{ github.event.inputs.dry-run }}" == "true" ]]; then
-            echo "⚠️ dry-run execution, artifacts will not be published on Maven Central." >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ dry-run execution, artifacts will not be published on Maven Central." | tee -a $GITHUB_STEP_SUMMARY
           fi
       - name: Pin Hilla version
         run: |
@@ -95,18 +95,18 @@ jobs:
               hilla_version="${{ inputs.hilla-version }}"
             else
               echo "🚫 Forced Hilla version '${{ inputs.hilla-version }}' does not match Hilla version on release branch '$hilla_version_major_minor'." \
-                | tee -a  $GITHUB_STEP_SUMMARY
+                | tee -a $GITHUB_STEP_SUMMARY
               exit 1
             fi
           fi
           if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
             mvn -N -ntp -Dproperty=hilla.version -DallowMinorUpdates=false -DgenerateBackupPoms=false -Dmaven.version.rules=file://$(pwd)/etc/release-version-rules.xml versions:update-property
             hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
-            echo "⚠️ SNAPSHOT detected for Hilla version. Forced version to $hilla_version." | tee -a  $GITHUB_STEP_SUMMARY
+            echo "⚠️ SNAPSHOT detected for Hilla version. Forced version to $hilla_version." | tee -a $GITHUB_STEP_SUMMARY
           fi
           if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
             echo "🚫 Hilla version '${{ inputs.hilla-version }}' is a SNAPSHOT. Please provide a proper release version." \
-             | tee -a  $GITHUB_STEP_SUMMARY
+             | tee -a $GITHUB_STEP_SUMMARY
             exit 1
           fi
       - name: Setup Java

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,6 @@ jobs:
           if [[ "main" != "${BRANCH_NAME}" ]]; then
             echo "🚫 Release Workflow must be dispatched on 'main' branch." \
              | tee -a  $GITHUB_STEP_SUMMARY
-            exit 1
           fi
 
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -117,7 +117,7 @@ jobs:
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
         run: |
-          mvn -N -V -ntp -Pdistribution -Drevision=${{ inputs.version }} -Djreleaser.dry.run="${{ github.event.inputs.dry-run }}" jreleaser:full-release
+          mvn -N -V -ntp -Pdistribution -Drevision=${{ inputs.version }} -Djreleaser.dry.run="${{ github.event.inputs.dry-run }}" ${{ github.event.inputs.dry-run && '-DskipTests' || '' }} jreleaser:full-release
 
       - name: JReleaser release output
         if: always()

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,12 @@ on:
         description: "Version to release (e.g. 1.1.0 or 1.2.0-alpha1)"
         required: true
         type: string
+      hilla-version:
+        description: |
+          Version of Hilla to pin for this release. If not provided, the value of the hilla.version property in will be used.
+          If the Hilla version is a SNAPSHOT, the latest available release compatible with quarkus-hilla major.minor will be used.
+        required: false
+        type: string
       dry-run:
         description: "Dry run (skips remote operations)"
         required: true
@@ -75,6 +81,22 @@ jobs:
           echo "Releasing version '${{ inputs.version }}' from branch '${{ inputs.target-branch }}'." >> $GITHUB_STEP_SUMMARY
           if [[ "${{ github.event.inputs.dry-run }}" == "true" ]]; then
             echo "⚠️ dry-run execution, artifacts will not be published on Maven Central." >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [[ -n "${{ input.hilla-version }}" ]]; then
+            mvn -N versions:set-property -Dproperty=hilla.version -DnewVersion="${{ input.hilla-version }}"
+            echo "Hilla version set to ${{ input.hilla-version }}." >> $GITHUB_STEP_SUMMARY
+          fi
+          hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
+          if [[ "$hilla_version" =~ '.*-SNAPSHOT' ]]; then
+            mvn -N -Ppin-hilla-version
+            hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
+            echo "Autodetected Hilla version $hilla_version." >> $GITHUB_STEP_SUMMARY
+          fi
+          if [[ "$hilla_version" =~ '.*-SNAPSHOT' ]]; then
+            echo "🚫 Hilla version '${{ inputs.hilla-version }}' is a SNAPSHOT. Please provide a proper release version." \
+             | tee -a  $GITHUB_STEP_SUMMARY
+            exit 1
           fi
       - name: Setup Java
         uses: actions/setup-java@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,9 +83,9 @@ jobs:
             echo "⚠️ dry-run execution, artifacts will not be published on Maven Central." >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [[ -n "${{ input.hilla-version }}" ]]; then
-            mvn -N versions:set-property -Dproperty=hilla.version -DnewVersion="${{ input.hilla-version }}"
-            echo "Hilla version set to ${{ input.hilla-version }}." >> $GITHUB_STEP_SUMMARY
+          if [[ -n "${{ inputs.hilla-version }}" ]]; then
+            mvn -N versions:set-property -Dproperty=hilla.version -DnewVersion="${{ inputs.hilla-version }}"
+            echo "Hilla version set to ${{ inputs.hilla-version }}." >> $GITHUB_STEP_SUMMARY
           fi
           hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
           if [[ "$hilla_version" =~ '.*-SNAPSHOT' ]]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,7 +88,7 @@ jobs:
           fi
           hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
           if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
-            mvn -N -Ppin-hilla-version
+            mvn -N -Dproperty=hilla.version -DallowMinorUpdates=false -DgenerateBackupPoms=false -Dmaven.version.rules=file://$(pwd)/etc/release-version-rules.xml versions:update-property
             hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
             echo "Autodetected Hilla version $hilla_version." >> $GITHUB_STEP_SUMMARY
           fi
@@ -105,7 +105,7 @@ jobs:
 
       - name: Staging artifacts
         run: |
-          mvn -V -ntp -Pdistribution,default-modules -Drevision=${{ inputs.version }} -DaltDeploymentRepository=local::file:./target/staging-deploy -DskipTests deploy
+          mvn -V -ntp -Pdistribution,default-modules -Drevision=${{ inputs.version }} -DaltDeploymentRepository=local::file:./target/staging-deploy ${{ github.event.inputs.dry-run && '-DskipTests' || '' }} deploy
 
       - name: Run JReleaser
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,12 +87,13 @@ jobs:
         run: |
           hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
           hilla_version_major_minor=$(echo "${hilla_version/-*/}" | cut -d. -f1,2)
+          echo "POM file Hilla version: $hilla_version." | tee -a  $GITHUB_STEP_SUMMARY
           if [[ -n "${{ inputs.hilla-version }}" ]]; then
             if [[ "${{ inputs.hilla-version }}" = "${hilla_version_major_minor}."* ]]; then
               mvn -N -ntp versions:set-property -Dproperty=hilla.version -DnewVersion="${{ inputs.hilla-version }}"
-              echo "⚠️ Hilla version set to ${{ inputs.hilla-version }}." | tee -a  $GITHUB_STEP_SUMMARY
+              echo "⚠️ Hilla version forced to ${{ inputs.hilla-version }}." | tee -a  $GITHUB_STEP_SUMMARY
             else
-              echo "🚫 Hilla version '${{ inputs.hilla-version }}' does not match Hilla version on release branch '${{ inputs.target-branch }}'." \
+              echo "🚫 Forced Hilla version '${{ inputs.hilla-version }}' does not match Hilla version on release branch '$hilla_version_major_minor'." \
                 | tee -a  $GITHUB_STEP_SUMMARY
               exit 1
             fi
@@ -100,9 +101,7 @@ jobs:
           if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
             mvn -N -ntp -Dproperty=hilla.version -DallowMinorUpdates=false -DgenerateBackupPoms=false -Dmaven.version.rules=file://$(pwd)/etc/release-version-rules.xml versions:update-property
             hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
-            echo "⚠️ Autodetected Hilla version $hilla_version." | tee -a  $GITHUB_STEP_SUMMARY
-          elif
-            echo "Hilla version $hilla_version." | tee -a  $GITHUB_STEP_SUMMARY
+            echo "⚠️ SNAPSHOT detected for Hilla version. Forced version to $hilla_version." | tee -a  $GITHUB_STEP_SUMMARY
           fi
           if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
             echo "🚫 Hilla version '${{ inputs.hilla-version }}' is a SNAPSHOT. Please provide a proper release version." \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
             exit 1
           fi
           if [[ "${{ inputs.target-branch }}" != "main" && ! "${{ inputs.version }}" = "${{ inputs.target-branch }}."* ]]; then
-            echo "ERROR: Invalid version specified: '${{ inputs.version }}' does not match the release branch '${{ inputs.target-branch }}'." \
+            echo "🚫 Invalid version specified: '${{ inputs.version }}' does not match the release branch '${{ inputs.target-branch }}'." \
              | tee -a  $GITHUB_STEP_SUMMARY
             exit 1
           fi
@@ -86,14 +86,20 @@ jobs:
       - name: Pin Hilla version
         run: |
           if [[ -n "${{ inputs.hilla-version }}" ]]; then
-            mvn -N -ntp versions:set-property -Dproperty=hilla.version -DnewVersion="${{ inputs.hilla-version }}"
-            echo "Hilla version set to ${{ inputs.hilla-version }}." | tee -a  $GITHUB_STEP_SUMMARY
+            if [[ "${{ inputs.hilla-version }}" = "${{ inputs.target-branch }}."* ]]; then            
+              mvn -N -ntp versions:set-property -Dproperty=hilla.version -DnewVersion="${{ inputs.hilla-version }}"
+              echo "⚠️ Hilla version set to ${{ inputs.hilla-version }}." | tee -a  $GITHUB_STEP_SUMMARY
+            elif
+              echo "🚫 Hilla version '${{ inputs.hilla-version }}' does not match release branch ${{ inputs.target-branch }}." \
+                | tee -a  $GITHUB_STEP_SUMMARY
+              exit 1
+            fi
           fi
           hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
           if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
             mvn -N -ntp -Dproperty=hilla.version -DallowMinorUpdates=false -DgenerateBackupPoms=false -Dmaven.version.rules=file://$(pwd)/etc/release-version-rules.xml versions:update-property
             hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
-            echo "Autodetected Hilla version $hilla_version." | tee -a  $GITHUB_STEP_SUMMARY
+            echo "⚠️ Autodetected Hilla version $hilla_version." | tee -a  $GITHUB_STEP_SUMMARY
           elif
             echo "Hilla version $hilla_version." | tee -a  $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,6 +94,8 @@ jobs:
             mvn -N -ntp -Dproperty=hilla.version -DallowMinorUpdates=false -DgenerateBackupPoms=false -Dmaven.version.rules=file://$(pwd)/etc/release-version-rules.xml versions:update-property
             hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
             echo "Autodetected Hilla version $hilla_version." | tee -a  $GITHUB_STEP_SUMMARY
+          elif
+            echo "Hilla version $hilla_version." | tee -a  $GITHUB_STEP_SUMMARY
           fi
           if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
             echo "🚫 Hilla version '${{ inputs.hilla-version }}' is a SNAPSHOT. Please provide a proper release version." \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Pin Hilla version
         run: |
           if [[ -n "${{ inputs.hilla-version }}" ]]; then
-            mvn -N versions:set-property -Dproperty=hilla.version -DnewVersion="${{ inputs.hilla-version }}"
+            mvn -N -ntp versions:set-property -Dproperty=hilla.version -DnewVersion="${{ inputs.hilla-version }}"
             echo "Hilla version set to ${{ inputs.hilla-version }}." | tee -a  $GITHUB_STEP_SUMMARY
           fi
           hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,7 @@ jobs:
           fi
           hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
           if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
-            mvn -N -Dproperty=hilla.version -DallowMinorUpdates=false -DgenerateBackupPoms=false -Dmaven.version.rules=file://$(pwd)/etc/release-version-rules.xml versions:update-property
+            mvn -N -ntp -Dproperty=hilla.version -DallowMinorUpdates=false -DgenerateBackupPoms=false -Dmaven.version.rules=file://$(pwd)/etc/release-version-rules.xml versions:update-property
             hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
             echo "Autodetected Hilla version $hilla_version." | tee -a  $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,12 +87,12 @@ jobs:
             echo "Hilla version set to ${{ inputs.hilla-version }}." >> $GITHUB_STEP_SUMMARY
           fi
           hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
-          if [[ "$hilla_version" =~ '.*-SNAPSHOT' ]]; then
+          if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
             mvn -N -Ppin-hilla-version
             hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
             echo "Autodetected Hilla version $hilla_version." >> $GITHUB_STEP_SUMMARY
           fi
-          if [[ "$hilla_version" =~ '.*-SNAPSHOT' ]]; then
+          if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
             echo "🚫 Hilla version '${{ inputs.hilla-version }}' is a SNAPSHOT. Please provide a proper release version." \
              | tee -a  $GITHUB_STEP_SUMMARY
             exit 1
@@ -105,7 +105,7 @@ jobs:
 
       - name: Staging artifacts
         run: |
-          mvn -V -ntp -Pdistribution,default-modules -Drevision=${{ inputs.version }} -DaltDeploymentRepository=local::file:./target/staging-deploy deploy
+          mvn -V -ntp -Pdistribution,default-modules -Drevision=${{ inputs.version }} -DaltDeploymentRepository=local::file:./target/staging-deploy -DskipTests deploy
 
       - name: Run JReleaser
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,8 +85,10 @@ jobs:
           fi
       - name: Pin Hilla version
         run: |
+          hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
+          hilla_version_major_minor=$(echo "${hilla_version/-*/}" | cut -d. -f1,2)
           if [[ -n "${{ inputs.hilla-version }}" ]]; then
-            if [[ "${{ inputs.hilla-version }}" = "${{ inputs.target-branch }}."* ]]; then            
+            if [[ "${{ inputs.hilla-version }}" = "${hilla_version_major_minor}."* ]]; then
               mvn -N -ntp versions:set-property -Dproperty=hilla.version -DnewVersion="${{ inputs.hilla-version }}"
               echo "⚠️ Hilla version set to ${{ inputs.hilla-version }}." | tee -a  $GITHUB_STEP_SUMMARY
             else
@@ -95,7 +97,6 @@ jobs:
               exit 1
             fi
           fi
-          hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
           if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
             mvn -N -ntp -Dproperty=hilla.version -DallowMinorUpdates=false -DgenerateBackupPoms=false -Dmaven.version.rules=file://$(pwd)/etc/release-version-rules.xml versions:update-property
             hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,6 +92,7 @@ jobs:
             if [[ "${{ inputs.hilla-version }}" = "${hilla_version_major_minor}."* ]]; then
               mvn -N -ntp versions:set-property -Dproperty=hilla.version -DnewVersion="${{ inputs.hilla-version }}"
               echo "⚠️ Hilla version forced to ${{ inputs.hilla-version }}." | tee -a  $GITHUB_STEP_SUMMARY
+              hilla_version="${{ inputs.hilla-version }}"
             else
               echo "🚫 Forced Hilla version '${{ inputs.hilla-version }}' does not match Hilla version on release branch '$hilla_version_major_minor'." \
                 | tee -a  $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,11 +46,13 @@ jobs:
           echo "🚫 **${{ github.actor }}** is an external contributor, only **${{ github.repository }}** team members can perform a release" \
             | tee -a $GITHUB_STEP_SUMMARY && exit 1
       - name: Validate Workflow branch
+        if: ${{ !github.event.inputs.dry-run }}
         run: |
           BRANCH_NAME=${GITHUB_REF##*/}
           if [[ "main" != "${BRANCH_NAME}" ]]; then
             echo "🚫 Release Workflow must be dispatched on 'main' branch." \
              | tee -a  $GITHUB_STEP_SUMMARY
+            exit 1
           fi
 
       - name: Checkout
@@ -81,16 +83,17 @@ jobs:
           if [[ "${{ github.event.inputs.dry-run }}" == "true" ]]; then
             echo "⚠️ dry-run execution, artifacts will not be published on Maven Central." >> $GITHUB_STEP_SUMMARY
           fi
-
+      - name: Pin Hilla version
+        run: |
           if [[ -n "${{ inputs.hilla-version }}" ]]; then
             mvn -N versions:set-property -Dproperty=hilla.version -DnewVersion="${{ inputs.hilla-version }}"
-            echo "Hilla version set to ${{ inputs.hilla-version }}." >> $GITHUB_STEP_SUMMARY
+            echo "Hilla version set to ${{ inputs.hilla-version }}." | tee -a  $GITHUB_STEP_SUMMARY
           fi
           hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
           if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
             mvn -N -Dproperty=hilla.version -DallowMinorUpdates=false -DgenerateBackupPoms=false -Dmaven.version.rules=file://$(pwd)/etc/release-version-rules.xml versions:update-property
             hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
-            echo "Autodetected Hilla version $hilla_version." >> $GITHUB_STEP_SUMMARY
+            echo "Autodetected Hilla version $hilla_version." | tee -a  $GITHUB_STEP_SUMMARY
           fi
           if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
             echo "🚫 Hilla version '${{ inputs.hilla-version }}' is a SNAPSHOT. Please provide a proper release version." \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,7 +90,7 @@ jobs:
               mvn -N -ntp versions:set-property -Dproperty=hilla.version -DnewVersion="${{ inputs.hilla-version }}"
               echo "⚠️ Hilla version set to ${{ inputs.hilla-version }}." | tee -a  $GITHUB_STEP_SUMMARY
             else
-              echo "🚫 Hilla version '${{ inputs.hilla-version }}' does not match release branch ${{ inputs.target-branch }}." \
+              echo "🚫 Hilla version '${{ inputs.hilla-version }}' does not match Hilla version on release branch '${{ inputs.target-branch }}'." \
                 | tee -a  $GITHUB_STEP_SUMMARY
               exit 1
             fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,7 @@ jobs:
           if [[ -n "${{ inputs.hilla-version }}" ]]; then
             if [[ "${{ inputs.hilla-version }}" = "${hilla_version_major_minor}."* ]]; then
               mvn -N -ntp versions:set-property -Dproperty=hilla.version -DnewVersion="${{ inputs.hilla-version }}"
-              echo "⚠️ Hilla version forced to ${{ inputs.hilla-version }}." | tee -a  $GITHUB_STEP_SUMMARY
+              echo "⚠️ Hilla version manually forced to ${{ inputs.hilla-version }}." | tee -a  $GITHUB_STEP_SUMMARY
               hilla_version="${{ inputs.hilla-version }}"
             else
               echo "🚫 Forced Hilla version '${{ inputs.hilla-version }}' does not match Hilla version on release branch '$hilla_version_major_minor'." \
@@ -102,7 +102,7 @@ jobs:
           if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
             mvn -N -ntp -Dproperty=hilla.version -DallowMinorUpdates=false -DgenerateBackupPoms=false -Dmaven.version.rules=file://$(pwd)/etc/release-version-rules.xml versions:update-property
             hilla_version=$(mvn -ntp -N -q help:evaluate -Dexpression=hilla.version -DforceStdout)
-            echo "⚠️ SNAPSHOT detected for Hilla version. Forced version to $hilla_version." | tee -a $GITHUB_STEP_SUMMARY
+            echo "⚠️ SNAPSHOT detected for Hilla version. Automatically forcing version to $hilla_version." | tee -a $GITHUB_STEP_SUMMARY
           fi
           if [[ "$hilla_version" =~ .*-SNAPSHOT ]]; then
             echo "🚫 Hilla version '${{ inputs.hilla-version }}' is a SNAPSHOT. Please provide a proper release version." \

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target/
 .settings
 .project
 .classpath
+pom.xml.versionsBackup
 
 *.iml
 .DS_Store

--- a/etc/release-version-rules.xml
+++ b/etc/release-version-rules.xml
@@ -1,0 +1,7 @@
+<ruleset comparisonMethod="maven"
+         xmlns="https://www.mojohaus.org/VERSIONS/RULE/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://www.mojohaus.org/VERSIONS/RULE/2.1.0 https://www.mojohaus.org/versions/versions-model/xsd/rule-2.1.0.xsd">
+  <rules>
+    <rule groupId="dev.hilla" comparisonMethod="numeric"/>
+  </rules>
+</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
         <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
+        <versions-maven-plugin.version>2.16.1</versions-maven-plugin.version>
         <jandex-maven-plugin.version>3.1.5</jandex-maven-plugin.version>
         <jreleaser-maven-plugin.version>1.9.0</jreleaser-maven-plugin.version>
         <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
@@ -507,6 +508,25 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>pin-hilla-version</id>
+            <build>
+                <defaultGoal>versions:update-property</defaultGoal>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>versions-maven-plugin</artifactId>
+                        <version>${versions-maven-plugin.version}</version>
+                        <configuration>
+                            <rulesUri>file://${project.basedir}/etc/release-version-rules.xml</rulesUri>
+                            <property>hilla.version</property>
+                            <allowMinorUpdates>false</allowMinorUpdates>
+                            <generateBackupPoms>false</generateBackupPoms>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -513,25 +513,6 @@
             </build>
         </profile>
         <profile>
-            <id>pin-hilla-version</id>
-            <build>
-                <defaultGoal>versions:update-property</defaultGoal>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>versions-maven-plugin</artifactId>
-                        <version>${versions-maven-plugin.version}</version>
-                        <configuration>
-                            <rulesUri>file://${project.basedir}/etc/release-version-rules.xml</rulesUri>
-                            <property>hilla.version</property>
-                            <allowMinorUpdates>false</allowMinorUpdates>
-                            <generateBackupPoms>false</generateBackupPoms>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>all-modules</id>
             <modules>
                 <module>deployment</module>


### PR DESCRIPTION
Improvements to the release process:
- allow specifying the pinned Hilla version manually
- autodetect latest Hilla release or pre-release if version in POM is a SNAPSHOT
- Skip tests in dry-run execution to get faster feedback