### PR TITLE
chore(actions): disable chrome install based on repository variable (#377) (CP 2.2)

### DIFF
--- a/.github/actions/run-validation/action.yaml
+++ b/.github/actions/run-validation/action.yaml
@@ -35,6 +35,7 @@ runs:
         cache: maven
     - uses: browser-actions/setup-chrome@latest
       id: setup-chrome
+      if: ${{ !vars.QH_DISABLE_CHROME_INSTALL }}
       with:
         chrome-version: stable
     - name: Build

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -59,6 +59,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@latest
         id: setup-chrome
+        if: ${{ !vars.QH_DISABLE_CHROME_INSTALL }}
         with:
           chrome-version: stable
 
@@ -104,6 +105,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@latest
         id: setup-chrome
+        if: ${{ !vars.QH_DISABLE_CHROME_INSTALL }}
         with:
           chrome-version: stable
 

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -67,6 +67,7 @@ jobs:
           cache: maven
       - uses: browser-actions/setup-chrome@latest
         id: setup-chrome
+        if: ${{ !vars.QH_DISABLE_CHROME_INSTALL }}
         with:
           chrome-version: stable
       - name: Build
@@ -104,6 +105,7 @@ jobs:
           cache: maven
       - uses: browser-actions/setup-chrome@latest
         id: setup-chrome
+        if: ${{ !vars.QH_DISABLE_CHROME_INSTALL }}
         with:
           chrome-version: stable
       - name: Build
@@ -141,6 +143,7 @@ jobs:
           cache: maven
       - uses: browser-actions/setup-chrome@latest
         id: setup-chrome
+        if: ${{ !vars.QH_DISABLE_CHROME_INSTALL }}
         with:
           chrome-version: stable
       - name: Build


### PR DESCRIPTION
Allows to disable chrome installation when there are incompatibilities with installed chromedriver. This is a temporary workaround. A proper fix would be disinstall global chromedriver or remove it from path, so that the correct driver can be installed by selenium manager

(cherry picked from commit c03fe9531faea61d333de6173c7f60610d1fdac1)