### PR TITLE
chore: use hilla property for vaadin-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,14 +87,18 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-bom</artifactId>
-                <version>${vaadin.version}</version>
+                <!--
+                    For backward compatibility of GH actions workflows
+                    To be replace with vaadin.version in the future
+                -->
+                <version>${hilla.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>hilla-bom</artifactId>
-                <version>${hilla.version}</version>
+                <version>${vaadin.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
For backward compatibility with GH actions that must run on other branches. Prevents getting real Hilla version that may not always match the Vaadin platform version.