### PR TITLE
test: wait for sidenav item to be visible

### DIFF
--- a/integration-tests/test-commons/src/main/java/com/github/mcollovati/quarkus/testing/VaadinConditions.java
+++ b/integration-tests/test-commons/src/main/java/com/github/mcollovati/quarkus/testing/VaadinConditions.java
@@ -31,6 +31,9 @@ public final class VaadinConditions {
                 "SideNavItem[" + href + "]",
                 element -> "vaadin-side-nav-item".equals(element.getTagName())
                         && $(element.getShadowRoot().findElement(By.cssSelector("a")))
-                                .has(Condition.domAttribute("href", href)));
+                                .has(Condition.and(
+                                        "Visible SideNavItem[" + href + "]",
+                                        Condition.domAttribute("href", href),
+                                        Condition.visible)));
     }
 }


### PR DESCRIPTION
With login overlay, the sidenav item is still on the dom when submitting form. Waiting for visibility ensure the page has been reloaded