### PR TITLE
test: prevent reusing dev-server

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -110,6 +110,7 @@
                         </selenide.reportsFolder>
                         <selenide.downloadsFolder>${project.build.directory}/selenide/downloads
                         </selenide.downloadsFolder>
+                        <vaadin.reuseDevServer>false</vaadin.reuseDevServer>
                     </systemPropertyVariables>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                 </configuration>


### PR DESCRIPTION
Quarkus tests reuse the same application instance, unless tests define different profiles or test resources. However, the JVM is always the same and Flow reuses the existing dev server instance.
This can cause errors when the application is restarted if frontend files are forcibly deleted.
This change make sure that the dev server is always stopped and restarted.