### PR TITLE
fix: ignore spring related classes in native build

### DIFF
--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaNativeProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaNativeProcessor.java
@@ -126,18 +126,22 @@ public class QuarkusHillaNativeProcessor {
         producer.produce(new ExcludedTypeBuildItem(ServletDeployer.class.getName()));
     }
 
+    /*
+     * Quarkus Spring-Data extension does not currently support JpaSpecificationExecutor.
+     * Hilla classes based on that API must be removed from the native build
+     * to prevent NoClassDefFound errors
+     * https://quarkus.io/guides/spring-data-jpa#what-is-currently-unsupported
+     */
     @BuildStep(onlyIf = IsNativeBuild.class)
-    void removeUnusedSpringRelatedClasses(Capabilities capabilities, BuildProducer<RemovedResourceBuildItem> producer) {
-        if (!capabilities.isPresent(QuarkusHillaExtensionProcessor.SPRING_DATA_SUPPORT)) {
-            producer.produce(new RemovedResourceBuildItem(
-                    ArtifactKey.of("com.vaadin", "hilla-endpoint", null, "jar"),
-                    Set.of(
-                            "com/vaadin/hilla/crud/CrudConfiguration.class",
-                            "com/vaadin/hilla/crud/CrudRepositoryService.class",
-                            "com/vaadin/hilla/crud/JpaFilterConverter.class",
-                            "com/vaadin/hilla/crud/ListRepositoryService.class",
-                            "com/vaadin/hilla/crud/PropertyStringFilterSpecification.class")));
-        }
+    void removeHillaSpringBasedClasses(Capabilities capabilities, BuildProducer<RemovedResourceBuildItem> producer) {
+        producer.produce(new RemovedResourceBuildItem(
+                ArtifactKey.of("com.vaadin", "hilla-endpoint", null, "jar"),
+                Set.of(
+                        "com/vaadin/hilla/crud/CrudConfiguration.class",
+                        "com/vaadin/hilla/crud/CrudRepositoryService.class",
+                        "com/vaadin/hilla/crud/JpaFilterConverter.class",
+                        "com/vaadin/hilla/crud/ListRepositoryService.class",
+                        "com/vaadin/hilla/crud/PropertyStringFilterSpecification.class")));
     }
 
     /*

--- a/commons/hilla-shaded-deps/pom.xml
+++ b/commons/hilla-shaded-deps/pom.xml
@@ -135,6 +135,8 @@
                                         <include>org/springframework/data/domain/Sort$Order.class</include>
                                         <include>org/springframework/data/domain/Sort$NullHandling.class</include>
                                         <include>org/springframework/data/domain/Unpaged.class</include>
+                                        <include>org/springframework/data/repository/CrudRepository.class</include>
+                                        <include>org/springframework/data/repository/Repository.class</include>
                                         <include>org/springframework/data/util/Streamable.class</include>
                                         <include>org/springframework/data/util/StreamUtils.class</include>
                                         <include>org/springframework/data/util/LazyStreamable.class</include>

--- a/commons/runtime/pom.xml
+++ b/commons/runtime/pom.xml
@@ -71,6 +71,20 @@
             <groupId>com.github.mcollovati</groupId>
             <artifactId>hilla-shaded-deps</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.security</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.data</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.graalvm.sdk</groupId>


### PR DESCRIPTION
Removes from the native build Hilla classes referencing Spring Data classes to preven failures during native image creation.