### PR TITLE
feat: add support for mutiny based reactive endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Hopefully, the behavior may be revisited. If you are interested you can follow t
 
 Starting with 24.7, the extension provide support for [Mutiny](https://smallrye.io/smallrye-mutiny/latest/) `Multi` in Hilla endpoints. The `Multi` instance is automatically converted into a `Flux`, that is currently the only reactive type supported by Hilla.
 `MutinyEndpointSubscription` can be used as a replacement of Hilla `EndpointSubscription` , when an unsubscribe callback is needed.
-The feature works in development mode, but for a production build it currently requires the activation of the Quarkus Hilla Embedded Vaadin plugin.
 
 ```java
 @BrowserCallable

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Hopefully, the behavior may be revisited. If you are interested you can follow t
 
 ### Support for Mutiny Multi return type in @BrowserCallable services
 
-Starting with 24.7, the extension provide support for [Mutiny](https://smallrye.io/smallrye-mutiny/latest/) `Multi` in Hilla endpoints. The `Multi` instance is automatically converted into a `Flux`, that is currently the only reactive type supported by Hilla.
-`MutinyEndpointSubscription` can be used as a replacement of Hilla `EndpointSubscription` , when an unsubscribe callback is needed.
+Starting with 24.7, the extension provides support for [Mutiny](https://smallrye.io/smallrye-mutiny/latest/) `Multi` return type in Hilla endpoints. The `Multi` instance is automatically converted into a `Flux`, that is currently the only reactive type supported by Hilla.
+`MutinyEndpointSubscription` can be used as a replacement of Hilla `EndpointSubscription`, when an unsubscribe callback is needed.
 
 ```java
 @BrowserCallable

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
@@ -69,7 +69,6 @@ import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
-import org.slf4j.LoggerFactory;
 
 import com.github.mcollovati.quarkus.hilla.BodyHandlerRecorder;
 import com.github.mcollovati.quarkus.hilla.HillaAtmosphereObjectFactory;
@@ -82,7 +81,6 @@ import com.github.mcollovati.quarkus.hilla.QuarkusEndpointProperties;
 import com.github.mcollovati.quarkus.hilla.QuarkusVaadinServiceListenerPropagator;
 import com.github.mcollovati.quarkus.hilla.crud.FilterableRepositorySupport;
 import com.github.mcollovati.quarkus.hilla.deployment.asm.OffendingMethodCallsReplacer;
-import com.github.mcollovati.quarkus.hilla.deployment.asm.TransferTypesPluginClassVisitor;
 import com.github.mcollovati.quarkus.hilla.deployment.vaadinplugin.VaadinBuildTimeConfig;
 import com.github.mcollovati.quarkus.hilla.deployment.vaadinplugin.VaadinPlugin;
 import com.github.mcollovati.quarkus.hilla.graal.DelayedInitBroadcaster;
@@ -407,13 +405,6 @@ class QuarkusHillaExtensionProcessor {
             BuildProducer<GeneratedResourceBuildItem> producer)
             throws BuildException {
         if (vaadinConfig.enabled()) {
-            try {
-                TransferTypesPluginClassVisitor.reflectionPatch(
-                        Thread.currentThread().getContextClassLoader());
-            } catch (BuildException ex) {
-                LoggerFactory.getLogger(QuarkusHillaExtensionProcessor.class.getName())
-                        .warn(ex.getMessage());
-            }
             VaadinPlugin vaadinPlugin = new VaadinPlugin(vaadinConfig, outcomeBuildItem.getApplicationModel());
             vaadinPlugin.prepareFrontend();
             vaadinPlugin.buildFrontend(indexBuildItem.getComputingIndex());

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
@@ -69,6 +69,7 @@ import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
+import org.slf4j.LoggerFactory;
 
 import com.github.mcollovati.quarkus.hilla.BodyHandlerRecorder;
 import com.github.mcollovati.quarkus.hilla.HillaAtmosphereObjectFactory;
@@ -81,7 +82,7 @@ import com.github.mcollovati.quarkus.hilla.QuarkusEndpointProperties;
 import com.github.mcollovati.quarkus.hilla.QuarkusVaadinServiceListenerPropagator;
 import com.github.mcollovati.quarkus.hilla.crud.FilterableRepositorySupport;
 import com.github.mcollovati.quarkus.hilla.deployment.asm.OffendingMethodCallsReplacer;
-import com.github.mcollovati.quarkus.hilla.deployment.vaadinplugin.QuarkusPluginAdapter;
+import com.github.mcollovati.quarkus.hilla.deployment.asm.TransferTypesPluginClassVisitor;
 import com.github.mcollovati.quarkus.hilla.deployment.vaadinplugin.VaadinBuildTimeConfig;
 import com.github.mcollovati.quarkus.hilla.deployment.vaadinplugin.VaadinPlugin;
 import com.github.mcollovati.quarkus.hilla.graal.DelayedInitBroadcaster;
@@ -406,6 +407,13 @@ class QuarkusHillaExtensionProcessor {
             BuildProducer<GeneratedResourceBuildItem> producer)
             throws BuildException {
         if (vaadinConfig.enabled()) {
+            try {
+                TransferTypesPluginClassVisitor.reflectionPatch(
+                        Thread.currentThread().getContextClassLoader());
+            } catch (BuildException ex) {
+                LoggerFactory.getLogger(QuarkusHillaExtensionProcessor.class.getName())
+                        .warn(ex.getMessage());
+            }
             VaadinPlugin vaadinPlugin = new VaadinPlugin(vaadinConfig, outcomeBuildItem.getApplicationModel());
             vaadinPlugin.prepareFrontend();
             vaadinPlugin.buildFrontend(indexBuildItem.getComputingIndex());

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
@@ -36,7 +36,6 @@ import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.builder.BuildException;
-import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.IsNormal;
@@ -408,18 +407,6 @@ class QuarkusHillaExtensionProcessor {
             VaadinPlugin vaadinPlugin = new VaadinPlugin(vaadinConfig, outcomeBuildItem.getApplicationModel());
             vaadinPlugin.prepareFrontend();
             vaadinPlugin.buildFrontend(indexBuildItem.getComputingIndex());
-        }
-    }
-
-    public static final class VaadinPluginBuildItem extends SimpleBuildItem {
-        private final QuarkusPluginAdapter plugin;
-
-        public VaadinPluginBuildItem(QuarkusPluginAdapter plugin) {
-            this.plugin = plugin;
-        }
-
-        public QuarkusPluginAdapter getPlugin() {
-            return plugin;
         }
     }
 }

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/OffendingMethodCallsReplacer.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/OffendingMethodCallsReplacer.java
@@ -110,6 +110,9 @@ public class OffendingMethodCallsReplacer {
         producer.produce(new BytecodeTransformerBuildItem(
                 "com.vaadin.hilla.parser.plugins.nonnull.NonnullPluginConfig$Processor",
                 (s, classVisitor) -> new NonnullPluginConfigProcessorClassVisitor(classVisitor)));
+        producer.produce(new BytecodeTransformerBuildItem(
+                "com.vaadin.hilla.parser.plugins.transfertypes.TransferTypesPlugin",
+                (s, classVisitor) -> new TransferTypesPluginClassVisitor(classVisitor)));
         // Remove sort method that references a type that is not in the shaded deps jar
         producer.produce(new BytecodeTransformerBuildItem(Sort.class.getName(), (className, classVisitor) -> {
             ClassTransformer transformer = new ClassTransformer(className);

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/TransferTypesPluginClassVisitor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/TransferTypesPluginClassVisitor.java
@@ -49,7 +49,11 @@ public class TransferTypesPluginClassVisitor extends ClassVisitor {
                     AbstractInsnNode returnNode = AsmUtils.findNextInsnNode(
                             iterator, node -> node instanceof InsnNode n && n.getOpcode() == Opcodes.RETURN);
                     if (returnNode == null) {
-                        return;
+                        throw new IllegalStateException(
+                                "Cannot patch com.vaadin.hilla.parser.plugins.transfertypes.TransferTypesPlugin."
+                                        + "This is most likely because the Hilla class has been changed and "
+                                        + TransferTypesPluginClassVisitor.class.getName()
+                                        + " must be updated to reflect the changes.");
                     }
                     mapToEndpointSubscription("io.smallrye.mutiny.Multi", returnNode);
                     mapToEndpointSubscription(

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/TransferTypesPluginClassVisitor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/TransferTypesPluginClassVisitor.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.asm;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.builder.BuildException;
+import io.quarkus.gizmo.Gizmo;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.LdcInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+public class TransferTypesPluginClassVisitor extends ClassVisitor {
+
+    private static final String CLASS_INITIALIZER_METHOD_NAME = "<clinit>";
+    private static final MethodSignature SET_OF_SIGNATURE = MethodSignature.of("java/util/Set", "of");
+
+    public TransferTypesPluginClassVisitor(ClassVisitor classVisitor) {
+        super(Gizmo.ASM_API_VERSION, classVisitor);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(
+            int access, String name, String descriptor, String signature, String[] exceptions) {
+        MethodVisitor superVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
+        if (CLASS_INITIALIZER_METHOD_NAME.equals(name)) {
+            return new MethodNode(Gizmo.ASM_API_VERSION, access, name, descriptor, signature, exceptions) {
+                @Override
+                public void visitEnd() {
+                    var iterator = instructions.iterator();
+                    // Find array size node, is expected to be the first IntInsnNode
+                    AbstractInsnNode returnNode = AsmUtils.findNextInsnNode(
+                            iterator, node -> node instanceof InsnNode n && n.getOpcode() == Opcodes.RETURN);
+                    if (returnNode == null) {
+                        return;
+                    }
+                    mapToEndpointSubscription("io.smallrye.mutiny.Multi", returnNode);
+                    mapToEndpointSubscription(
+                            "com.github.mcollovati.quarkus.hilla.MutinyEndpointSubscription", returnNode);
+                    accept(superVisitor);
+                }
+
+                // GETSTATIC com/vaadin/hilla/parser/plugins/transfertypes/TransferTypesPlugin.classMap :
+                // Ljava/util/Map;
+                // LDC "com.vaadin.hilla.EndpointSubscription"
+                // LDC Lcom/vaadin/hilla/runtime/transfertypes/EndpointSubscription;.class
+                // INVOKEINTERFACE java/util/Map.put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; (itf)
+                // POP
+                private void mapToEndpointSubscription(String typeName, AbstractInsnNode beforeNode) {
+                    instructions.insertBefore(
+                            beforeNode,
+                            new FieldInsnNode(
+                                    Opcodes.GETSTATIC,
+                                    "com/vaadin/hilla/parser/plugins/transfertypes/TransferTypesPlugin",
+                                    "classMap",
+                                    "Ljava/util/Map;"));
+                    instructions.insertBefore(beforeNode, new LdcInsnNode(typeName));
+                    instructions.insertBefore(
+                            beforeNode,
+                            new LdcInsnNode(
+                                    Type.getType("Lcom/vaadin/hilla/runtime/transfertypes/EndpointSubscription;")));
+                    instructions.insertBefore(
+                            beforeNode,
+                            new MethodInsnNode(
+                                    Opcodes.INVOKEINTERFACE,
+                                    "java/util/Map",
+                                    "put",
+                                    "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"));
+                    instructions.insertBefore(beforeNode, new InsnNode(Opcodes.POP));
+                }
+            };
+        }
+        return superVisitor;
+    }
+
+    /**
+     * Used at build time to update the type mapping in the {@code TransferTypesPlugin}
+     * class loaded in the Augmentation Classloader, that is not yet transformed.
+     *
+     * @param clazz the {@code TransferTypesPlugin} loaded by the Augmentation Classloader.
+     */
+    @SuppressWarnings("unchecked")
+    public static void reflectionPatch(ClassLoader classLoader) throws BuildException {
+        try {
+            Class<?> endpointSubscription =
+                    classLoader.loadClass("com.vaadin.hilla.runtime.transfertypes.EndpointSubscription");
+            Class<?> typeTransferTypesPluginClass =
+                    classLoader.loadClass("com.vaadin.hilla.parser.plugins.transfertypes.TransferTypesPlugin");
+            Field field = typeTransferTypesPluginClass.getDeclaredField("classMap");
+            field.setAccessible(true);
+            Map<String, Class<?>> classMap = (Map<String, Class<?>>) field.get(0);
+            classMap.put("io.smallrye.mutiny.Multi", endpointSubscription);
+            classMap.put("com.github.mcollovati.quarkus.hilla.MutinyEndpointSubscription", endpointSubscription);
+        } catch (Exception ex) {
+            throw new BuildException(
+                    "Cannot register additional type mapping in com.vaadin.hilla.parser.plugins.transfertypes.TransferTypesPlugin",
+                    ex,
+                    List.of());
+        }
+    }
+}

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/TransferTypesPluginClassVisitor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/TransferTypesPluginClassVisitor.java
@@ -15,11 +15,6 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.asm;
 
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.Map;
-
-import io.quarkus.builder.BuildException;
 import io.quarkus.gizmo.Gizmo;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
@@ -93,31 +88,5 @@ public class TransferTypesPluginClassVisitor extends ClassVisitor {
             };
         }
         return superVisitor;
-    }
-
-    /**
-     * Used at build time to update the type mapping in the {@code TransferTypesPlugin}
-     * class loaded in the Augmentation Classloader, that is not yet transformed.
-     *
-     * @param clazz the {@code TransferTypesPlugin} loaded by the Augmentation Classloader.
-     */
-    @SuppressWarnings("unchecked")
-    public static void reflectionPatch(ClassLoader classLoader) throws BuildException {
-        try {
-            Class<?> endpointSubscription =
-                    classLoader.loadClass("com.vaadin.hilla.runtime.transfertypes.EndpointSubscription");
-            Class<?> typeTransferTypesPluginClass =
-                    classLoader.loadClass("com.vaadin.hilla.parser.plugins.transfertypes.TransferTypesPlugin");
-            Field field = typeTransferTypesPluginClass.getDeclaredField("classMap");
-            field.setAccessible(true);
-            Map<String, Class<?>> classMap = (Map<String, Class<?>>) field.get(0);
-            classMap.put("io.smallrye.mutiny.Multi", endpointSubscription);
-            classMap.put("com.github.mcollovati.quarkus.hilla.MutinyEndpointSubscription", endpointSubscription);
-        } catch (Exception ex) {
-            throw new BuildException(
-                    "Cannot register additional type mapping in com.vaadin.hilla.parser.plugins.transfertypes.TransferTypesPlugin",
-                    ex,
-                    List.of());
-        }
     }
 }

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/vaadinplugin/VaadinPlugin.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/vaadinplugin/VaadinPlugin.java
@@ -41,6 +41,8 @@ import io.quarkus.bootstrap.workspace.WorkspaceModule;
 import io.quarkus.builder.BuildException;
 import org.jboss.jandex.IndexView;
 
+import com.github.mcollovati.quarkus.hilla.build.TransferTypesPluginPatch;
+
 /**
  * Implementation of the Vaadin plugin.
  * <p></p>
@@ -59,6 +61,7 @@ public final class VaadinPlugin {
      */
     public VaadinPlugin(VaadinBuildTimeConfig vaadinConfig, ApplicationModel applicationModel) {
         this.pluginAdapter = new QuarkusPluginAdapter(vaadinConfig, applicationModel);
+        TransferTypesPluginPatch.addMutinySupport(this.pluginAdapter.getClassFinder());
     }
 
     /**

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/MutinyReactiveEndpointTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/MutinyReactiveEndpointTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.mcollovati.quarkus.hilla.deployment.endpoints.MutinyReactiveEndpoint;
+
+class MutinyReactiveEndpointTest extends AbstractReactiveEndpointTest {
+    private static final String ENDPOINT_NAME = MutinyReactiveEndpoint.class.getSimpleName();
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource(testResource("test-application.properties"))
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MutinyReactiveEndpoint.class, HillaPushClient.class));
+
+    @Override
+    public String getEndpointName() {
+        return ENDPOINT_NAME;
+    }
+
+    private static String testResource(String name) {
+        return MutinyReactiveEndpointTest.class.getPackageName().replace('.', '/') + '/' + name;
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/MutinyReactiveEndpoint.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/endpoints/MutinyReactiveEndpoint.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.endpoints;
+
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+import com.vaadin.hilla.BrowserCallable;
+import io.smallrye.mutiny.Multi;
+
+import com.github.mcollovati.quarkus.hilla.MutinyEndpointSubscription;
+
+@BrowserCallable
+@AnonymousAllowed
+public class MutinyReactiveEndpoint {
+
+    private final ConcurrentHashMap<String, AtomicInteger> counters = new ConcurrentHashMap<>();
+
+    public Multi<Integer> count(String counterName) {
+        Duration interval = Duration.ofMillis(200);
+        return Multi.createFrom()
+                .ticks()
+                .startingAfter(interval)
+                .every(interval)
+                .map(_interval -> counters.computeIfAbsent(counterName, unused -> new AtomicInteger())
+                        .incrementAndGet());
+    }
+
+    public MutinyEndpointSubscription<Integer> cancelableCount(String counterName) {
+        return MutinyEndpointSubscription.of(count(counterName), () -> {
+            counters.get(counterName).set(-1);
+        });
+    }
+
+    public Integer counterValue(String counterName) {
+        if (counters.containsKey(counterName)) {
+            return counters.get(counterName).get();
+        }
+        return null;
+    }
+}

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/MutinyEndpointSubscription.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/MutinyEndpointSubscription.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla;
+
+import io.smallrye.mutiny.Multi;
+
+/**
+ * A subscription that wraps a Multi and allows to listen for unsubscribe events
+ * from the browser.
+ * <p>
+ * An unsubscribe event is sent when "cancel" is called in the browser but also
+ * if the browser has disconnected from the server either explicitly or been
+ * disconnected from the server for a long enough time.
+ * <p>
+ * Attribution:
+ * This file is based on work from Vaadin Ltd.
+ * Copyright 2000-2024 Vaadin Ltd. https://vaadin.com
+ * Original source: https://github.com/vaadin/hilla/blob/main/packages/java/endpoint/src/main/java/com/vaadin/hilla/EndpointSubscription.java
+ * Changes made:
+ * - Replaced reactor Flux type with Mutiny Multi.
+ */
+public class MutinyEndpointSubscription<TT> {
+
+    private Multi<TT> multi;
+    private Runnable onUnsubscribe;
+
+    private MutinyEndpointSubscription(Multi<TT> multi, Runnable onUnsubscribe) {
+        this.multi = multi;
+        this.onUnsubscribe = onUnsubscribe;
+    }
+
+    /**
+     * Returns the multi value provide for this subscription.
+     */
+    public Multi<TT> getMulti() {
+        return multi;
+    }
+
+    /**
+     * Returns the callback that is invoked when the browser unsubscribes from
+     * the subscription.
+     */
+    public Runnable getOnUnsubscribe() {
+        return onUnsubscribe;
+    }
+
+    /**
+     * Creates a new endpoint subscription.
+     *
+     * A subscription wraps a multi that provides the values for the subscriber
+     * (browser) and a callback that is invoked when the browser unsubscribes
+     * from the subscription.
+     *
+     * @param <T>
+     *            the type of data in the subscription
+     * @param flux
+     *            the multi that produces the data
+     * @param onDisconnect
+     *            a callback that is invoked when the browser unsubscribes
+     * @return a subscription
+     */
+    public static <T> MutinyEndpointSubscription<T> of(Multi<T> flux, Runnable onDisconnect) {
+        return new MutinyEndpointSubscription<>(flux, onDisconnect);
+    }
+}

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/MutinyEndpointSubscription.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/MutinyEndpointSubscription.java
@@ -66,13 +66,13 @@ public class MutinyEndpointSubscription<TT> {
      *
      * @param <T>
      *            the type of data in the subscription
-     * @param flux
+     * @param multi
      *            the multi that produces the data
      * @param onDisconnect
      *            a callback that is invoked when the browser unsubscribes
      * @return a subscription
      */
-    public static <T> MutinyEndpointSubscription<T> of(Multi<T> flux, Runnable onDisconnect) {
-        return new MutinyEndpointSubscription<>(flux, onDisconnect);
+    public static <T> MutinyEndpointSubscription<T> of(Multi<T> multi, Runnable onDisconnect) {
+        return new MutinyEndpointSubscription<>(multi, onDisconnect);
     }
 }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointControllerConfiguration.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointControllerConfiguration.java
@@ -54,6 +54,7 @@ import io.quarkus.arc.DefaultBean;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.runtime.StartupEvent;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.context.ManagedExecutor;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
@@ -149,9 +150,15 @@ class QuarkusEndpointControllerConfiguration {
             @Named("endpointObjectMapper") ObjectMapper objectMapper,
             ExplicitNullableTypeChecker explicitNullableTypeChecker,
             ServletContext servletContext,
-            EndpointRegistry endpointRegistry) {
-        return new EndpointInvoker(
-                applicationContext, objectMapper, explicitNullableTypeChecker, servletContext, endpointRegistry);
+            EndpointRegistry endpointRegistry,
+            ManagedExecutor executor) {
+        return new QuarkusEndpointInvoker(
+                applicationContext,
+                objectMapper,
+                explicitNullableTypeChecker,
+                servletContext,
+                endpointRegistry,
+                executor);
     }
 
     @Produces

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointInvoker.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/QuarkusEndpointInvoker.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2024 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla;
+
+import jakarta.servlet.ServletContext;
+import java.security.Principal;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.vaadin.hilla.EndpointInvocationException;
+import com.vaadin.hilla.EndpointInvoker;
+import com.vaadin.hilla.EndpointRegistry;
+import com.vaadin.hilla.EndpointSubscription;
+import com.vaadin.hilla.ExplicitNullableTypeChecker;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.subscription.Cancellable;
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.springframework.context.ApplicationContext;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Extension of EndpointInvoker that handles transformations for Quarkus types.
+ * <p></p>
+ * Implemented transformations:
+ * - Multi -> Flux
+ */
+public class QuarkusEndpointInvoker extends EndpointInvoker {
+
+    private final Scheduler scheduler;
+
+    /**
+     * Creates an instance of this bean.
+     *
+     * @param applicationContext          The Spring application context
+     * @param endpointObjectMapper        mapper used for serializing and deserializing request and response bodies.
+     * @param explicitNullableTypeChecker the method parameter and return value type checker to verify
+     *                                    that null values are explicit
+     * @param servletContext              the servlet context
+     * @param endpointRegistry            the registry used to store endpoint information
+     */
+    public QuarkusEndpointInvoker(
+            ApplicationContext applicationContext,
+            ObjectMapper endpointObjectMapper,
+            ExplicitNullableTypeChecker explicitNullableTypeChecker,
+            ServletContext servletContext,
+            EndpointRegistry endpointRegistry,
+            ManagedExecutor executor) {
+        super(applicationContext, endpointObjectMapper, explicitNullableTypeChecker, servletContext, endpointRegistry);
+        scheduler = Schedulers.fromExecutor(executor);
+    }
+
+    @Override
+    public Class<?> getReturnType(String endpointName, String methodName) {
+        Class<?> returnType = super.getReturnType(endpointName, methodName);
+
+        if (returnType != null
+                && (Multi.class.isAssignableFrom(returnType)
+                        || MutinyEndpointSubscription.class.isAssignableFrom(returnType))) {
+            return EndpointSubscription.class;
+        }
+        return returnType;
+    }
+
+    @Override
+    public Object invoke(
+            String endpointName,
+            String methodName,
+            ObjectNode body,
+            Principal principal,
+            Function<String, Boolean> rolesChecker)
+            throws EndpointInvocationException.EndpointNotFoundException,
+                    EndpointInvocationException.EndpointAccessDeniedException,
+                    EndpointInvocationException.EndpointBadRequestException,
+                    EndpointInvocationException.EndpointInternalException {
+        Object object = super.invoke(endpointName, methodName, body, principal, rolesChecker);
+        if (object instanceof Multi<?> multi) {
+            object = multiToEndpointSubscription(multi, null);
+        } else if (object instanceof MutinyEndpointSubscription<?> endpointSubscription) {
+            object = multiToEndpointSubscription(
+                    endpointSubscription.getMulti(), endpointSubscription.getOnUnsubscribe());
+        }
+        return object;
+    }
+
+    @SuppressWarnings({"MutinyCallingSubscribeInNonBlockingScope", "ReactiveStreamsPublisherImplementation"})
+    private EndpointSubscription<?> multiToEndpointSubscription(Multi<?> multi, Runnable onUnsubscribe) {
+        OnDisconnect onDisconnect = new OnDisconnect(onUnsubscribe);
+        Flux<?> flux = Flux.from(subscribe -> {
+                    Cancellable cancelable =
+                            multi.subscribe().with(subscribe::onNext, subscribe::onError, subscribe::onComplete);
+                    onDisconnect.setCancellable(cancelable);
+                })
+                .cancelOn(scheduler)
+                .subscribeOn(scheduler)
+                .publishOn(scheduler);
+        return EndpointSubscription.of(flux, onDisconnect);
+    }
+
+    private static class OnDisconnect implements Runnable {
+        private final Runnable onUnsubscribe;
+        private Cancellable cancellable;
+
+        OnDisconnect(Runnable onUnsubscribe) {
+            this.onUnsubscribe = onUnsubscribe;
+        }
+
+        void setCancellable(Cancellable cancellable) {
+            this.cancellable = cancellable;
+        }
+
+        @Override
+        public void run() {
+            if (cancellable != null) {
+                cancellable.cancel();
+            }
+            if (onUnsubscribe != null) {
+                onUnsubscribe.run();
+            }
+        }
+    }
+}

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/build/TransferTypesPluginPatch.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/build/TransferTypesPluginPatch.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.build;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+import com.vaadin.flow.server.frontend.Options;
+import com.vaadin.flow.server.frontend.TypeScriptBootstrapModifier;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+
+/**
+ * Workaround to path TransferTypesPlugin to add Mutiny support.
+ */
+public class TransferTypesPluginPatch implements TypeScriptBootstrapModifier {
+    @Override
+    public void modify(
+            List<String> bootstrapTypeScript,
+            Options options,
+            FrontendDependenciesScanner frontendDependenciesScanner) {
+        addMutinySupport(options.getClassFinder());
+    }
+
+    /**
+     * Used at build time (quarkus or maven) to add type mappings to the {@code TransferTypesPlugin}
+     */
+    @SuppressWarnings("unchecked")
+    public static void addMutinySupport(ClassFinder classFinder) {
+        try {
+            Class<?> endpointSubscription =
+                    classFinder.loadClass("com.vaadin.hilla.runtime.transfertypes.EndpointSubscription");
+            Class<?> typeTransferTypesPluginClass =
+                    classFinder.loadClass("com.vaadin.hilla.parser.plugins.transfertypes.TransferTypesPlugin");
+            Field field = typeTransferTypesPluginClass.getDeclaredField("classMap");
+            field.setAccessible(true);
+            Map<String, Class<?>> classMap = (Map<String, Class<?>>) field.get(0);
+            if (!classMap.containsKey("io.smallrye.mutiny.Multi")) {
+                classMap.put("io.smallrye.mutiny.Multi", endpointSubscription);
+                classMap.put("com.github.mcollovati.quarkus.hilla.MutinyEndpointSubscription", endpointSubscription);
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException(
+                    "Cannot register additional type mapping in com.vaadin.hilla.parser.plugins.transfertypes.TransferTypesPlugin",
+                    ex);
+        }
+    }
+}

--- a/integration-tests/react-smoke-tests/src/main/frontend/views/MutinyPushView.tsx
+++ b/integration-tests/react-smoke-tests/src/main/frontend/views/MutinyPushView.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {ViewConfig} from "@vaadin/hilla-file-router/types.js";
+import {Subscription} from "@vaadin/hilla-frontend";
+import {useSignal} from "@vaadin/hilla-react-signals";
+import {Button} from "@vaadin/react-components/Button.js";
+import {ClockService, MutinyClockService} from "Frontend/generated/endpoints";
+
+export const config: ViewConfig = {
+    title: "Push View (Mutiny)",
+    route: "push-mutiny"
+}
+
+export default function MutinyPushView() {
+
+    const subscription = useSignal<Subscription<string> | undefined>(undefined);
+    const currentTime = useSignal<string>("");
+
+    const cancelClock = async () => {
+        if (subscription.value) {
+            subscription.value.cancel();
+        }
+        subscription.value = undefined;
+    }
+    const toggleClock = async (factory: () => Subscription<string>) => {
+        await cancelClock();
+        currentTime.value = "Loading...";
+        subscription.value = factory()
+            .onNext((msg) => currentTime.value = msg)
+            .onError(() => {
+                currentTime.value = "Something failed. Maybe you are not authorized?";
+                cancelClock();
+            })
+            .onComplete(() => {
+                currentTime.value = "Bye. Thanks.";
+                cancelClock()
+            });
+    }
+
+    return <>
+        <div id="push-view" className="flex flex-col p-m gap-m items-center">
+            <Button id="public"
+                    onClick={(e) =>
+                        toggleClock(() => MutinyClockService.getPublicClock(undefined))
+                    }
+                    disabled={!!subscription.value}>Public</Button>
+            <Button id="public-limit"
+                    onClick={(e) =>
+                        toggleClock(() => ClockService.getPublicClock(10))
+                    }
+                    disabled={!!subscription.value}>Public (Limit 10)</Button>
+            <Button id="protected"
+                    onClick={(e) =>
+                        toggleClock(ClockService.getClock)
+                    }
+                    disabled={!!subscription.value}>Protected</Button>
+            <Button id="subscription"
+                    onClick={(e) =>
+                        toggleClock(ClockService.getClockCancellable)
+                    }
+                    disabled={!!subscription.value}>EndpointSubscription</Button>
+            <Button id="stop" onClick={(e) => {
+                cancelClock().then(() => currentTime.value = "");
+            }} disabled={!subscription.value}>Stop</Button>
+        </div>
+        {currentTime.value ?
+            <div id="push-contents">{currentTime.value}</div>
+            : ''
+        }
+    </>
+}

--- a/integration-tests/react-smoke-tests/src/main/frontend/views/PushView.tsx
+++ b/integration-tests/react-smoke-tests/src/main/frontend/views/PushView.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {ViewConfig} from "@vaadin/hilla-file-router/types.js";
+import {Subscription} from "@vaadin/hilla-frontend";
+import {useSignal} from "@vaadin/hilla-react-signals";
+import {Button} from "@vaadin/react-components/Button.js";
+import {ClockService} from "Frontend/generated/endpoints";
+
+export const config: ViewConfig = {
+    title: "Push View",
+    route: "push"
+}
+
+export default function PushView() {
+
+    const subscription = useSignal<Subscription<string> | undefined>(undefined);
+    const currentTime = useSignal<string>("");
+
+    const cancelClock = async () => {
+        if (subscription.value) {
+            subscription.value.cancel();
+        }
+        subscription.value = undefined;
+    }
+    const toggleClock = async (factory: () => Subscription<string>) => {
+        await cancelClock();
+        currentTime.value = "Loading...";
+        subscription.value = factory()
+            .onNext((msg) => currentTime.value = msg)
+            .onError(() => {
+                currentTime.value = "Something failed. Maybe you are not authorized?";
+                cancelClock();
+            })
+            .onComplete(() => {
+                currentTime.value = "Bye. Thanks.";
+                cancelClock()
+            });
+    }
+
+    return <>
+        <div id="push-view" className="flex flex-col p-m gap-m items-center">
+            <Button id="public"
+                    onClick={(e) =>
+                        toggleClock(() => ClockService.getPublicClock(undefined))
+                    }
+                    disabled={!!subscription.value}>Public</Button>
+            <Button id="public-limit"
+                    onClick={(e) =>
+                        toggleClock(() => ClockService.getPublicClock(10))
+                    }
+                    disabled={!!subscription.value}>Public (Limit 10)</Button>
+            <Button id="protected"
+                    onClick={(e) =>
+                        toggleClock(ClockService.getClock)
+                    }
+                    disabled={!!subscription.value}>Protected</Button>
+            <Button id="subscription"
+                    onClick={(e) =>
+                        toggleClock(ClockService.getClockCancellable)
+                    }
+                    disabled={!!subscription.value}>EndpointSubscription</Button>
+            <Button id="stop" onClick={(e) => {
+                cancelClock().then(() => currentTime.value = "");
+            }} disabled={!subscription.value}>Stop</Button>
+        </div>
+        {currentTime.value ?
+            <div id="push-contents">{currentTime.value}</div>
+            : ''
+        }
+    </>
+}

--- a/integration-tests/react-smoke-tests/src/main/java/com/example/application/ClockService.java
+++ b/integration-tests/react-smoke-tests/src/main/java/com/example/application/ClockService.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.time.Duration;
+import java.util.Date;
+import java.util.UUID;
+
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+import com.vaadin.hilla.BrowserCallable;
+import com.vaadin.hilla.EndpointSubscription;
+import com.vaadin.hilla.Nonnull;
+import com.vaadin.hilla.Nullable;
+import io.quarkus.security.identity.SecurityIdentity;
+import org.eclipse.microprofile.context.ThreadContext;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+@ApplicationScoped
+@BrowserCallable
+@AnonymousAllowed
+public class ClockService {
+
+    private final SecurityIdentity securityIdentity;
+
+    public ClockService(SecurityIdentity securityIdentity, ThreadContext threadContext) {
+        this.securityIdentity = securityIdentity;
+        Schedulers.onScheduleHook("managed-thread", threadContext::contextualRunnable);
+    }
+
+    private final String id = UUID.randomUUID().toString();
+
+    public String getId() {
+        return id;
+    }
+
+    private String getUsername() {
+        if (securityIdentity.isAnonymous()) {
+            return "Anonymous";
+        } else {
+            return securityIdentity.getPrincipal().getName();
+        }
+    }
+
+    @PermitAll
+    public Flux<@Nonnull String> getClock() {
+        String userName = getUsername();
+        return Flux.interval(Duration.ofSeconds(1))
+                .onBackpressureDrop()
+                .map(unused -> userName + " " + new Date() + " " + id)
+                .doOnError(Throwable::printStackTrace)
+                .onErrorReturn("Sorry, something failed...");
+    }
+
+    @RolesAllowed("ADMIN")
+    public EndpointSubscription<@Nonnull String> getClockCancellable() {
+        return EndpointSubscription.of(getClock(), () -> System.getLogger("TESTME")
+                .log(System.Logger.Level.INFO, "Subscription has been cancelled"));
+    }
+
+    @AnonymousAllowed
+    public Flux<@Nonnull String> getPublicClock(@Nullable Integer limit) {
+        Flux<String> flux = getClock();
+        if (limit != null) {
+            flux = flux.take(limit, true);
+        }
+        return flux.map(msg -> "PUBLIC: " + msg);
+    }
+}

--- a/integration-tests/react-smoke-tests/src/main/java/com/example/application/MutinyClockService.java
+++ b/integration-tests/react-smoke-tests/src/main/java/com/example/application/MutinyClockService.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.time.Duration;
+import java.util.Date;
+import java.util.UUID;
+
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+import com.vaadin.hilla.BrowserCallable;
+import com.vaadin.hilla.Nonnull;
+import com.vaadin.hilla.Nullable;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Multi;
+import org.eclipse.microprofile.context.ThreadContext;
+import reactor.core.scheduler.Schedulers;
+
+import com.github.mcollovati.quarkus.hilla.MutinyEndpointSubscription;
+
+@ApplicationScoped
+@BrowserCallable
+@AnonymousAllowed
+public class MutinyClockService {
+
+    private final SecurityIdentity securityIdentity;
+
+    public MutinyClockService(SecurityIdentity securityIdentity, ThreadContext threadContext) {
+        this.securityIdentity = securityIdentity;
+        Schedulers.onScheduleHook("managed-thread", threadContext::contextualRunnable);
+    }
+
+    private final String id = UUID.randomUUID().toString();
+
+    public String getId() {
+        return id;
+    }
+
+    private String getUsername() {
+        if (securityIdentity.isAnonymous()) {
+            return "Anonymous";
+        } else {
+            return securityIdentity.getPrincipal().getName();
+        }
+    }
+
+    @PermitAll
+    public Multi<@Nonnull String> getClock() {
+        String userName = getUsername();
+        return Multi.createFrom()
+                .ticks()
+                .startingAfter(Duration.ofSeconds(1))
+                .every(Duration.ofSeconds(1))
+                .onOverflow()
+                .drop()
+                .map(unused -> userName + " " + new Date() + " " + id)
+                .onFailure()
+                .recoverWithItem(err -> {
+                    err.printStackTrace();
+                    return "Sorry, something failed...";
+                });
+    }
+
+    @RolesAllowed("ADMIN")
+    public MutinyEndpointSubscription<@Nonnull String> getClockCancellable() {
+        return MutinyEndpointSubscription.of(getClock(), () -> System.getLogger("TESTME")
+                .log(System.Logger.Level.INFO, "Subscription has been cancelled"));
+    }
+
+    @AnonymousAllowed
+    public Multi<@Nonnull String> getPublicClock(@Nullable Integer limit) {
+        Multi<String> flux = getClock();
+        if (limit != null) {
+            flux = flux.capDemandsTo(limit);
+        }
+        return flux.map(msg -> "PUBLIC: " + msg);
+    }
+}

--- a/integration-tests/react-smoke-tests/src/test/java/com/example/application/MutinyPushNativeIT.java
+++ b/integration-tests/react-smoke-tests/src/test/java/com/example/application/MutinyPushNativeIT.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class MutinyPushNativeIT extends MutinyPushTest {}

--- a/integration-tests/react-smoke-tests/src/test/java/com/example/application/MutinyPushTest.java
+++ b/integration-tests/react-smoke-tests/src/test/java/com/example/application/MutinyPushTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.codeborne.selenide.Condition;
+import io.quarkus.test.junit.QuarkusTest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.testing.AbstractTest;
+
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+import static org.awaitility.Awaitility.await;
+
+@QuarkusTest
+class MutinyPushTest extends AbstractTest {
+
+    public static final String COMPLETE_MESSAGE = "Bye. Thanks.";
+
+    @Override
+    protected String getTestUrl() {
+        return getBaseURL() + "push-mutiny";
+    }
+
+    @Test
+    void publicEndpoint_anonymousUser_changesPushed() {
+        openAndWait(() -> $("div#push-view"));
+
+        $("vaadin-button#public").click();
+
+        AtomicReference<String> previousContents = new AtomicReference<>();
+        await().pollInSameThread().during(5, TimeUnit.SECONDS).untilAsserted(() -> changesPushed(previousContents));
+
+        $("vaadin-button#stop").click();
+
+        $("div#push-contents").shouldNot(visible);
+    }
+
+    @Test
+    void publicEndpoint_anonymousUser_subscriptionAutoClose() {
+        openAndWait(() -> $("div#push-view"));
+
+        $("vaadin-button#public-limit").click();
+
+        AtomicReference<String> previousContents = new AtomicReference<>();
+        await().pollInSameThread().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> changesPushed(previousContents));
+
+        await().pollInSameThread()
+                .until(() -> COMPLETE_MESSAGE.equals(
+                        $("div#push-contents").shouldBe(visible).getText()));
+    }
+
+    @Test
+    void protectedEndpoint_anonymousUser_subscriptionFails() {
+        openAndWait(() -> $("div#push-view"));
+
+        $("vaadin-button#protected").click();
+
+        $("div#push-contents")
+                .shouldBe(visible)
+                .shouldHave(Condition.text("Something failed. Maybe you are not authorized?"));
+    }
+
+    // Checks that the current shown message is different from the previous one
+    // to ensures new content is pushed from the server
+    private static void changesPushed(AtomicReference<String> previousContents) {
+        String contents = $("div#push-contents").shouldBe(visible).getText();
+        if (!COMPLETE_MESSAGE.equals(contents)) {
+            Assertions.assertThat(contents)
+                    .startsWith("PUBLIC:")
+                    .contains("Anonymous")
+                    .isNotEqualTo(previousContents);
+        }
+        previousContents.set(contents);
+    }
+}

--- a/integration-tests/react-smoke-tests/src/test/java/com/example/application/PushNativeIT.java
+++ b/integration-tests/react-smoke-tests/src/test/java/com/example/application/PushNativeIT.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class PushNativeIT extends PushTest {}

--- a/integration-tests/react-smoke-tests/src/test/java/com/example/application/PushTest.java
+++ b/integration-tests/react-smoke-tests/src/test/java/com/example/application/PushTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.codeborne.selenide.Condition;
+import io.quarkus.test.junit.QuarkusTest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.testing.AbstractTest;
+
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+import static org.awaitility.Awaitility.await;
+
+@QuarkusTest
+class PushTest extends AbstractTest {
+
+    public static final String COMPLETE_MESSAGE = "Bye. Thanks.";
+
+    @Override
+    protected String getTestUrl() {
+        return getBaseURL() + "push";
+    }
+
+    @Test
+    void publicEndpoint_anonymousUser_changesPushed() {
+        openAndWait(() -> $("div#push-view"));
+
+        $("vaadin-button#public").click();
+
+        AtomicReference<String> previousContents = new AtomicReference<>();
+        await().pollInSameThread().during(5, TimeUnit.SECONDS).untilAsserted(() -> changesPushed(previousContents));
+
+        $("vaadin-button#stop").click();
+
+        $("div#push-contents").shouldNot(visible);
+    }
+
+    @Test
+    void publicEndpoint_anonymousUser_subscriptionAutoClose() {
+        openAndWait(() -> $("div#push-view"));
+
+        $("vaadin-button#public-limit").click();
+
+        AtomicReference<String> previousContents = new AtomicReference<>();
+        await().pollInSameThread().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> changesPushed(previousContents));
+
+        await().pollInSameThread()
+                .until(() -> COMPLETE_MESSAGE.equals(
+                        $("div#push-contents").shouldBe(visible).getText()));
+    }
+
+    @Test
+    void protectedEndpoint_anonymousUser_subscriptionFails() {
+        openAndWait(() -> $("div#push-view"));
+
+        $("vaadin-button#protected").click();
+
+        $("div#push-contents")
+                .shouldBe(visible)
+                .shouldHave(Condition.text("Something failed. Maybe you are not authorized?"));
+    }
+
+    // Checks that the current shown message is different from the previous one
+    // to ensures new content is pushed from the server
+    private static void changesPushed(AtomicReference<String> previousContents) {
+        String contents = $("div#push-contents").shouldBe(visible).getText();
+        if (!COMPLETE_MESSAGE.equals(contents)) {
+            Assertions.assertThat(contents)
+                    .startsWith("PUBLIC:")
+                    .contains("Anonymous")
+                    .isNotEqualTo(previousContents);
+        }
+        previousContents.set(contents);
+    }
+}


### PR DESCRIPTION
Allows Hilla endpoints to specify Mutiny Multi as return type for reactive endpoints. Also introduces MutinyEndpointSubscription as a Mutiny alternative to Hilla EndpointSubscription to provide unsubscribe callback.

Fixes #1028