### PR TITLE
fix: add VaadinSpringDataHelpers to shaded deps

### DIFF
--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaNativeProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaNativeProcessor.java
@@ -50,6 +50,7 @@ import com.vaadin.hilla.EndpointExposed;
 import com.vaadin.hilla.crud.filter.Filter;
 import com.vaadin.hilla.endpointransfermapper.EndpointTransferMapper;
 import com.vaadin.hilla.push.PushEndpoint;
+import com.vaadin.hilla.signals.handler.SignalsHandler;
 import io.quarkus.arc.deployment.ExcludedTypeBuildItem;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Capabilities;
@@ -231,6 +232,7 @@ public class QuarkusHillaNativeProcessor {
         classes.addAll(getAnnotatedClasses(index, DotName.createSimple(BrowserCallable.class)));
         classes.addAll(getAnnotatedClasses(index, DotName.createSimple(Endpoint.class)));
         classes.addAll(getAnnotatedClasses(index, DotName.createSimple(EndpointExposed.class)));
+        classes.add(index.getClassByName(SignalsHandler.class));
         classes.add(index.getClassByName(PushEndpoint.class));
         classes.add(index.getClassByName(Filter.class));
         classes.add(index.getClassByName(Pageable.class));

--- a/commons/hilla-shaded-deps/pom.xml
+++ b/commons/hilla-shaded-deps/pom.xml
@@ -35,6 +35,12 @@
             <version>${vaadin.version}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-spring</artifactId>
+            <version>${vaadin.version}</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>
@@ -145,6 +151,12 @@
                                     </includes>
                                 </filter>
                                 <filter>
+                                    <artifact>com.vaadin:vaadin-spring</artifact>
+                                    <includes>
+                                        <include>com/vaadin/flow/spring/data/VaadinSpringDataHelpers.class</include>
+                                    </includes>
+                                </filter>
+                                <filter>
                                     <artifact>com.vaadin:vaadin-core-internal</artifact>
                                     <includes>
                                         <include>vaadin-core-versions.json</include>
@@ -166,6 +178,7 @@
                                     <include>org.springframework.data:spring-data-commons</include>
                                     <include>com.vaadin:vaadin-core-internal</include>
                                     <include>com.vaadin:vaadin-internal</include>
+                                    <include>com.vaadin:vaadin-spring</include>
                                 </includes>
                             </artifactSet>
                         </configuration>


### PR DESCRIPTION
Some Vaadin components like Grid and Combobox have methods that refers to the VaadinSpringDataHelpers class from vaadin-spring artifact, causing native build to fail because the class cannot be found.
This change adds the missing class to the shaded deps in order to fix native build.

Fixes #1221