### PR TITLE
fix: check for Vaadin native process

### DIFF
--- a/.github/workflows/validation-native.yaml
+++ b/.github/workflows/validation-native.yaml
@@ -61,7 +61,7 @@ jobs:
         id: set-matrix
         run: |
           test_modules=$(find integration-tests -maxdepth 1 -mindepth 1 -type d -name "*-tests")
-          test_modules=$(while IFS= read -r mod; do grep -q "%test-security." $mod/src/main/resources/application.properties; echo "{\"name\": \"${mod/integration-tests\//}\", \"path\": \"$mod\", \"security\": $? }"; done <<< "${test_modules}" | jq -s -c '.')
+          test_modules=$(while IFS= read -r mod; do test -f $mod/src/main/resources/application.properties && grep -q "%test-security." $mod/src/main/resources/application.properties; echo "{\"name\": \"${mod/integration-tests\//}\", \"path\": \"$mod\", \"security\": $? }"; done <<< "${test_modules}" | jq -s -c '.')
           echo "modules=${test_modules}" >> "$GITHUB_OUTPUT"
   build-and-test-native:
     name: Native tests
@@ -98,7 +98,7 @@ jobs:
           set -x -e -o pipefail
           mvn -V -e -B -ntp verify -am -DtrimStackTrace=false -Dselenide.browserBinary=${{ steps.setup-chrome.outputs.chrome-path }} -Pit-tests,production -Dnative -pl ${{ matrix.module.path }}
       - name: Native Security Test
-        if: ${{ matrix.module.security == 1 }}
+        if: ${{ matrix.module.security == 0 }}
         run: |
           set -x -e -o pipefail
           mvn -V -e -B -ntp verify -am -DtrimStackTrace=false -Dselenide.browserBinary=${{ steps.setup-chrome.outputs.chrome-path }} -Pit-tests,production -Dnative -Dquarkus.profile=test-security -pl ${{ matrix.module.path }}

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaNativeProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaNativeProcessor.java
@@ -111,13 +111,13 @@ import com.github.mcollovati.quarkus.hilla.graal.DelayedSchedulerExecutorsFactor
 
 public class QuarkusHillaNativeProcessor {
 
-    @BuildStep(onlyIf = IsNativeBuild.class)
+    @BuildStep(onlyIf = IsNativeBuild.class, onlyIfNot = IsVaadinNativeProcessorAvailable.class)
     void patchAtmosphere(CombinedIndexBuildItem index, BuildProducer<BytecodeTransformerBuildItem> producer) {
         AtmospherePatches patcher = new AtmospherePatches(index.getComputingIndex());
         patcher.apply(producer);
     }
 
-    @BuildStep(onlyIf = IsNativeBuild.class)
+    @BuildStep(onlyIf = IsNativeBuild.class, onlyIfNot = IsVaadinNativeProcessorAvailable.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     @Produce(DefaultRouteBuildItem.class)
     void deferAtmosphereInit(
@@ -157,7 +157,7 @@ public class QuarkusHillaNativeProcessor {
      * application is build with subscription key and the license-checker is not
      * configured as explicit project dependency.
      */
-    @BuildStep(onlyIf = IsNativeBuild.class)
+    @BuildStep(onlyIf = IsNativeBuild.class, onlyIfNot = IsVaadinNativeProcessorAvailable.class)
     void generateDummyDauClassesIfLicenseCheckerIsNotPresent(
             BuildProducer<GeneratedNativeImageClassBuildItem> producer) {
         String dauIntegration = "com.vaadin.pro.licensechecker.dau.DauIntegration";
@@ -224,6 +224,7 @@ public class QuarkusHillaNativeProcessor {
         nativeImageResource.produce(NativeImageResourcePatternsBuildItem.builder()
                 .includePatterns("hilla-openapi\\.json", "hilla-engine-configuration\\.json", "file-routes\\.json")
                 .includePatterns("META-INF/microprofile-config\\.properties")
+                .includePatterns("META-INF/maven/com.github.mcollovati/quarkus-hilla-commons/pom\\.properties")
                 .build());
 
         IndexView index = combinedIndex.getComputingIndex();
@@ -288,7 +289,7 @@ public class QuarkusHillaNativeProcessor {
         return classes;
     }
 
-    @BuildStep
+    @BuildStep(onlyIfNot = IsVaadinNativeProcessorAvailable.class)
     void vaadinNativeSupport(
             CombinedIndexBuildItem combinedIndex,
             BuildProducer<RuntimeInitializedPackageBuildItem> runtimeInitializedPackage,
@@ -300,7 +301,7 @@ public class QuarkusHillaNativeProcessor {
         nativeImageResource.produce(NativeImageResourcePatternsBuildItem.builder()
                 .includeGlobs("META-INF/VAADIN/**", "com/vaadin/**", "vaadin-i18n/**")
                 .includePatterns("org/atmosphere/util/version\\.properties")
-                .includePatterns("META-INF/maven/com.github.mcollovati/quarkus-hilla-commons/pom\\.properties")
+                .includePatterns("META-INF/maven/com.vaadin/vaadin-core/pom\\.properties")
                 .build());
 
         runtimeInitializedPackage.produce(new RuntimeInitializedPackageBuildItem("org.atmosphere.util.analytics"));
@@ -440,6 +441,22 @@ public class QuarkusHillaNativeProcessor {
         @Override
         public boolean getAsBoolean() {
             return nativeConfig.enabled();
+        }
+    }
+
+    public static class IsVaadinNativeProcessorAvailable implements BooleanSupplier {
+
+        @Override
+        public boolean getAsBoolean() {
+            try {
+                Class.forName(
+                        "com.vaadin.quarkus.deployment.VaadinQuarkusNativeProcessor",
+                        false,
+                        Thread.currentThread().getContextClassLoader());
+                return true;
+            } catch (ClassNotFoundException e) {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Vaadin Quarkus extension introduced build steps for native image. This change prevents the execution of the same steps from Quarkus Hilla extension, if the Vaadin native processor is available.