### PR TITLE
chore: update browse callable finder note for 24.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The current Hilla support has some known limitations:
 * Vaadin Copilot is not supported
 * [Stateless Authentication](https://hilla.dev/docs/lit/guides/security/spring-stateless)
   is not supported
-* :warning: :boom: With the Vaadin 24.7, frontend **build fails** because the Hilla endpoint generation tasks relies on the execution of a Spring process. However, there is a good chance that Hilla will provide a pluggable API for endpoint discovery before 24.7 stable release. As a temporary workaround you can enable Quarkus-Hilla **Experimental embedded Vaadin plugin implementation**, or you can add the `aot-browser-finder-callable-workaround` dependency to `vaadin-maven-plugin` configuration. The dependency workaround is required only when building for production; in development mode the offending class is automatically replaced by the extension.
+* :warning: :boom: With the Vaadin 24.7, frontend **build fails** because the Hilla endpoint generation tasks relies on the execution of a Spring process. As a temporary workaround you can enable Quarkus-Hilla **Experimental embedded Vaadin plugin implementation**, or you can add the `aot-browser-finder-callable-workaround` dependency to `vaadin-maven-plugin` configuration. The dependency workaround is required only when building for production; in development mode the offending class is automatically replaced by the extension. **The workaround is not required in 24.8** because the generation has been refactored to fallback to the original lookup of endpoints based on internal class finder; in addition Hilla provided a pluggable API to configure endpoint discovery. 
   ```xml
                     <plugin>
                         <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Workaround for endpoint generation isn’t required anymore in 24.8