### PR TITLE
refactor: replace deprecated `QuarkusUnitTest`

### DIFF
--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/BrowserCallableControllerTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/BrowserCallableControllerTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -29,7 +29,7 @@ class BrowserCallableControllerTest extends AbstractEndpointControllerTest {
     private static final String ENDPOINT_NAME = TestBrowserCallable.class.getSimpleName();
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource(testResource("test-application.properties"))
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(TestUtils.class, Pojo.class, TestBrowserCallable.class, UploadEndpoint.class));

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/CustomPrefixEndpointControllerTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/CustomPrefixEndpointControllerTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -32,7 +32,7 @@ class CustomPrefixEndpointControllerTest extends AbstractEndpointControllerTest 
     private static final String CUSTOM_PREFIX = "/myprefix";
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource(testResource("test-application.properties"))
             .overrideConfigKey(QuarkusEndpointConfiguration.VAADIN_ENDPOINT_PREFIX, CUSTOM_PREFIX)
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointControllerTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointControllerTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -29,7 +29,7 @@ class EndpointControllerTest extends AbstractEndpointControllerTest {
     private static final String ENDPOINT_NAME = TestEndpoint.class.getSimpleName();
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource(testResource("test-application.properties"))
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(TestUtils.class, Pojo.class, TestEndpoint.class, UploadEndpoint.class));

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointSecurityTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/EndpointSecurityTest.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 
 import io.quarkus.security.test.utils.TestIdentityController;
 import io.quarkus.security.test.utils.TestIdentityProvider;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.specification.RequestSpecification;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -42,7 +42,7 @@ import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.givenEndp
 class EndpointSecurityTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource(testResource("test-application.properties"))
             .overrideRuntimeConfigKey("quarkus.http.auth.basic", "true")
             .overrideRuntimeConfigKey("quarkus.http.auth.proactive", "true")

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/MutinyReactiveEndpointTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/MutinyReactiveEndpointTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -26,7 +26,7 @@ class MutinyReactiveEndpointTest extends AbstractReactiveEndpointTest {
     private static final String ENDPOINT_NAME = MutinyReactiveEndpoint.class.getSimpleName();
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource(testResource("test-application.properties"))
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(MutinyReactiveEndpoint.class, HillaPushClient.class));

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveEndpointTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveEndpointTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -26,7 +26,7 @@ class ReactiveEndpointTest extends AbstractReactiveEndpointTest {
     private static final String ENDPOINT_NAME = ReactiveEndpoint.class.getSimpleName();
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource(testResource("test-application.properties"))
             .setArchiveProducer(() ->
                     ShrinkWrap.create(JavaArchive.class).addClasses(ReactiveEndpoint.class, HillaPushClient.class));

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveSecureEndpointTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/ReactiveSecureEndpointTest.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 
 import io.quarkus.security.test.utils.TestIdentityController;
 import io.quarkus.security.test.utils.TestIdentityProvider;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.vertx.core.http.HttpHeaders;
 import org.assertj.core.api.AbstractStringAssert;
@@ -53,7 +53,7 @@ class ReactiveSecureEndpointTest {
     private static final String ENDPOINT_NAME = ReactiveSecureEndpoint.class.getSimpleName();
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource(testResource("test-application.properties"))
             .overrideRuntimeConfigKey("quarkus.http.auth.basic", "true")
             .overrideRuntimeConfigKey("quarkus.http.auth.proactive", "true")

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SignalsSecurityTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SignalsSecurityTest.java
@@ -38,7 +38,7 @@ import com.vaadin.flow.signals.Id;
 import com.vaadin.hilla.signals.handler.SignalsHandler;
 import io.quarkus.security.test.utils.TestIdentityController;
 import io.quarkus.security.test.utils.TestIdentityProvider;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.restassured.specification.RequestSpecification;
 import io.vertx.core.http.HttpHeaders;
@@ -72,7 +72,7 @@ class SignalsSecurityTest {
     SecureNumberSignalService secureNumberSignalService;
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource(testResource("test-application.properties"))
             .overrideRuntimeConfigKey("quarkus.http.auth.basic", "true")
             .overrideRuntimeConfigKey("quarkus.http.auth.proactive", "true")

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SignalsTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SignalsTest.java
@@ -28,7 +28,7 @@ import com.vaadin.flow.signals.Id;
 import com.vaadin.flow.signals.local.ValueSignal;
 import com.vaadin.hilla.signals.handler.SignalsHandler;
 import io.quarkus.logging.Log;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import org.hamcrest.CoreMatchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -50,7 +50,7 @@ class SignalsTest {
     URI pushURI;
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource(testResource("test-application.properties"))
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .add(new StringAsset("""

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringDataExtensionsSupportTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringDataExtensionsSupportTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -33,7 +33,7 @@ class SpringDataExtensionsSupportTest extends AbstractEndpointControllerTest {
     private static final String ENDPOINT_NAME = TestBrowserCallable.class.getSimpleName();
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .overrideConfigKey("quarkus.class-loading.removed-artifacts", "com.vaadin:copilot")
             .setForcedDependencies(
                     List.of(Dependency.of("io.quarkus", "quarkus-spring-data-jpa", Version.getVersion())))

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringDiExtensionSupportReactiveEndpointTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringDiExtensionSupportReactiveEndpointTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -30,7 +30,7 @@ class SpringDiExtensionSupportReactiveEndpointTest extends AbstractReactiveEndpo
     private static final String ENDPOINT_NAME = ReactiveEndpoint.class.getSimpleName();
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource(testResource("test-spring-di-application.properties"))
             .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-spring-di", Version.getVersion())))
             .setArchiveProducer(() ->

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringDiExtensionsSupportTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringDiExtensionsSupportTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -33,7 +33,7 @@ class SpringDiExtensionsSupportTest extends AbstractEndpointControllerTest {
     private static final String ENDPOINT_NAME = TestBrowserCallable.class.getSimpleName();
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource(testResource("test-spring-di-application.properties"))
             .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-spring-di", Version.getVersion())))
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringReplacementsTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SpringReplacementsTest.java
@@ -25,7 +25,7 @@ import io.quarkus.security.test.utils.AuthData;
 import io.quarkus.security.test.utils.IdentityMock;
 import io.quarkus.security.test.utils.TestIdentityController;
 import io.quarkus.security.test.utils.TestIdentityProvider;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.BeforeAll;
@@ -42,7 +42,7 @@ import static com.github.mcollovati.quarkus.hilla.deployment.TestUtils.USER;
 class SpringReplacementsTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .withConfigurationResource(testResource("test-application.properties"))
             .overrideRuntimeConfigKey("quarkus.http.auth.basic", "true")
             .overrideRuntimeConfigKey("quarkus.http.auth.proactive", "true")

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/crud/panache/CrudRepositoryServiceTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/crud/panache/CrudRepositoryServiceTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.TestTransaction;
 import org.assertj.core.api.Assertions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class CrudRepositoryServiceTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-hibernate-orm-panache", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-jdbc-h2", Version.getVersion())))

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/crud/panache/GeneratedIsNewTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/crud/panache/GeneratedIsNewTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class GeneratedIsNewTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-hibernate-orm-panache", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-jdbc-h2", Version.getVersion())))

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/crud/panache/ListRepositoryServiceTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/crud/panache/ListRepositoryServiceTest.java
@@ -24,7 +24,7 @@ import com.vaadin.hilla.crud.filter.OrFilter;
 import com.vaadin.hilla.crud.filter.PropertyStringFilter;
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.TestTransaction;
 import org.assertj.core.api.Assertions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -41,7 +41,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 class ListRepositoryServiceTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-hibernate-orm-panache", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-jdbc-h2", Version.getVersion())))

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/crud/panache/SelfImplementedRepositoryTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/crud/panache/SelfImplementedRepositoryTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.TestTransaction;
 import org.assertj.core.api.Assertions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -35,7 +35,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 class SelfImplementedRepositoryTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-hibernate-orm-panache", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-jdbc-h2", Version.getVersion())))

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/crud/spring/CrudRepositoryServiceTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/crud/spring/CrudRepositoryServiceTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.TestTransaction;
 import org.assertj.core.api.Assertions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class CrudRepositoryServiceTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-spring-data-jpa", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-jdbc-h2", Version.getVersion())))

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/crud/spring/ListRepositoryServiceTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/crud/spring/ListRepositoryServiceTest.java
@@ -24,7 +24,7 @@ import com.vaadin.hilla.crud.filter.OrFilter;
 import com.vaadin.hilla.crud.filter.PropertyStringFilter;
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.test.TestTransaction;
 import org.assertj.core.api.Assertions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -41,7 +41,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 class ListRepositoryServiceTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest config = new QuarkusUnitTest()
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-spring-data-jpa", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-jdbc-h2", Version.getVersion())))


### PR DESCRIPTION
Quarkus 3.35.1 marked `io.quarkus.test.QuarkusUnitTest` as `@Deprecated(since = "3.35", forRemoval = true)`, with `io.quarkus.test.QuarkusExtensionTest` listed as the replacement.

Renamed the class in the 19 affected test files under `commons/deployment`. Both classes are thin subclasses of the same `AbstractQuarkusExtensionTest` and expose identical constructors and fluent methods, so the migration is a pure type-rename with no behavioral or API change.