### PR TITLE
fix(copilot): keep dev tools message handler registered (#2122) (CP: 25.1)

### DIFF
--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/CopilotDevToolsMessageHandlerTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/CopilotDevToolsMessageHandlerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class CopilotDevToolsMessageHandlerTest {
+
+    private static final String COPILOT_COORDINATES = "com.vaadin:copilot";
+    private static final String DEV_TOOLS_MESSAGE_HANDLER_SERVICE =
+            "META-INF/services/com.vaadin.base.devserver.DevToolsMessageHandler";
+
+    @Test
+    void runtimeExtensionsDoNotRemoveCopilotDevToolsMessageHandler() throws Exception {
+        Path root = projectRoot();
+
+        assertNoCopilotDevToolsMessageHandlerRemoval(root.resolve("lit/runtime/pom.xml"));
+        assertNoCopilotDevToolsMessageHandlerRemoval(root.resolve("react/runtime/pom.xml"));
+    }
+
+    private static void assertNoCopilotDevToolsMessageHandlerRemoval(Path pom) throws Exception {
+        List<String> removedResources = copilotRemovedResources(pom);
+
+        assertFalse(
+                removedResources.contains(DEV_TOOLS_MESSAGE_HANDLER_SERVICE),
+                () -> String.format("Copilot DevToolsMessageHandler must stay registered in %s", pom));
+    }
+
+    private static List<String> copilotRemovedResources(Path pom) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setExpandEntityReferences(false);
+
+        Document document = factory.newDocumentBuilder().parse(pom.toFile());
+        NodeList artifacts = document.getElementsByTagName("artifact");
+        List<String> removedResources = new ArrayList<>();
+
+        for (int i = 0; i < artifacts.getLength(); i++) {
+            Node node = artifacts.item(i);
+            if (node instanceof Element artifact && COPILOT_COORDINATES.equals(childText(artifact, "key"))) {
+                Arrays.stream(childText(artifact, "resources").split(","))
+                        .map(String::trim)
+                        .filter(resource -> !resource.isEmpty())
+                        .forEach(removedResources::add);
+            }
+        }
+        return removedResources;
+    }
+
+    private static String childText(Element element, String name) {
+        Node child = element.getElementsByTagName(name).item(0);
+        return child == null ? "" : child.getTextContent().trim();
+    }
+
+    private static Path projectRoot() {
+        String multiModuleProjectDirectory = System.getProperty("maven.multiModuleProjectDirectory");
+        if (multiModuleProjectDirectory != null) {
+            Path root = Path.of(multiModuleProjectDirectory);
+            if (Files.exists(root.resolve("react/runtime/pom.xml"))) {
+                return root;
+            }
+        }
+
+        Path current = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+        while (current != null) {
+            if (Files.exists(current.resolve("react/runtime/pom.xml"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Cannot locate quarkus-hilla project root");
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -19,6 +19,7 @@
 
         <awaitility.version>4.3.0</awaitility.version>
         <selenide.version>7.16.0</selenide.version>
+        <selenide.browser>chrome</selenide.browser>
 
         <!--
             By default, skips Hilla plugin execution to prevent build errors for modules
@@ -116,6 +117,7 @@
                         </selenide.reportsFolder>
                         <selenide.downloadsFolder>${project.build.directory}/selenide/downloads
                         </selenide.downloadsFolder>
+                        <selenide.browser>${selenide.browser}</selenide.browser>
                         <vaadin.reuseDevServer>false</vaadin.reuseDevServer>
                     </systemPropertyVariables>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
@@ -140,6 +142,7 @@
                                 </selenide.reportsFolder>
                                 <selenide.downloadsFolder>${project.build.directory}/selenide/downloads
                                 </selenide.downloadsFolder>
+                                <selenide.browser>${selenide.browser}</selenide.browser>
                             </systemPropertyVariables>
                             <forkNode
                                     implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
@@ -150,6 +153,17 @@
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>macos-tests</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                </os>
+            </activation>
+            <properties>
+                <selenide.browser>safari</selenide.browser>
+            </properties>
+        </profile>
         <profile>
             <id>development</id>
             <activation>

--- a/integration-tests/react-smoke-tests/pom.xml
+++ b/integration-tests/react-smoke-tests/pom.xml
@@ -43,4 +43,24 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>copilot-clickability-test</id>
+            <activation>
+                <property>
+                    <name>quarkus-hilla.test-mode</name>
+                    <value>development</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>copilot</artifactId>
+                    <version>${vaadin.version}</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/integration-tests/react-smoke-tests/src/test/java/com/example/application/CopilotClickabilityTest.java
+++ b/integration-tests/react-smoke-tests/src/test/java/com/example/application/CopilotClickabilityTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application;
+
+import java.time.Duration;
+
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.SelenideElement;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.testing.AbstractTest;
+
+import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$$;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@QuarkusTest
+@Tag("development-only")
+class CopilotClickabilityTest extends AbstractTest {
+
+    @Override
+    protected boolean copilotEnabled() {
+        return true;
+    }
+
+    @Test
+    void copilotEnabled_rootViewControlsStayClickable() {
+        assumeTrue("development".equals(System.getProperty("quarkus-hilla.test-mode")));
+
+        openAndWait(() -> $("vaadin-app-layout"));
+        $("copilot-main").shouldBe(exist, Duration.ofSeconds(30));
+
+        SelenideElement textField = $("vaadin-text-field").shouldBe(visible);
+        SelenideElement input = textField.$("input").shouldBe(visible);
+        SelenideElement button =
+                $$("vaadin-button").filter(Condition.text("Say hello")).first().shouldBe(visible);
+
+        String name = "Copilot";
+        input.click();
+        input.sendKeys(name);
+        button.click();
+
+        $("vaadin-notification-card").shouldHave(text("Hello " + name));
+    }
+}

--- a/integration-tests/test-commons/src/main/java/com/github/mcollovati/quarkus/testing/AbstractTest.java
+++ b/integration-tests/test-commons/src/main/java/com/github/mcollovati/quarkus/testing/AbstractTest.java
@@ -38,26 +38,29 @@ import static com.codeborne.selenide.Selenide.Wait;
 @ExtendWith({BrowserPerTestStrategyExtension.class})
 public abstract class AbstractTest {
 
-    private static final boolean isMacOS =
-            System.getProperty("os.name").toLowerCase().contains("mac");
-
     @TestHTTPResource()
     private String baseURL;
 
     @BeforeEach
     void setup() {
-        if (isMacOS) {
+        String configuredBrowser = System.getProperty("selenide.browser", "chrome");
+        if (configuredBrowser.isBlank()) {
+            configuredBrowser = "chrome";
+            System.setProperty("selenide.browser", configuredBrowser);
+        }
+        Configuration.browser = configuredBrowser;
+        if ("safari".equalsIgnoreCase(configuredBrowser)) {
             Configuration.headless = false;
-            Configuration.browser = "safari";
         } else {
             Configuration.headless = runHeadless();
+        }
+        if ("chrome".equalsIgnoreCase(configuredBrowser)) {
             System.setProperty("chromeoptions.args", "--remote-allow-origins=*");
         }
         Configuration.fastSetValue = true;
 
-        // Disable Copilot because currently it slows down the page load
-        // because of license checking
-        System.setProperty("vaadin.copilot.enable", "false");
+        // Disable Copilot by default because it slows down page load because of license checking.
+        System.setProperty("vaadin.copilot.enable", Boolean.toString(copilotEnabled()));
     }
 
     protected final String getBaseURL() {
@@ -118,6 +121,10 @@ public abstract class AbstractTest {
 
     protected boolean runHeadless() {
         return !isJavaInDebugMode();
+    }
+
+    protected boolean copilotEnabled() {
+        return false;
     }
 
     static boolean isJavaInDebugMode() {

--- a/lit/runtime/pom.xml
+++ b/lit/runtime/pom.xml
@@ -54,16 +54,6 @@
                             <resources>com/vaadin/hilla/ConditionalOnFeatureFlag.class,com/vaadin/hilla/EndpointControllerConfiguration.class,com/vaadin/hilla/FeatureFlagCondition.class,com/vaadin/hilla/startup/EndpointsValidator.class,com/vaadin/hilla/push/PushConfigurer.class</resources>
                             <!-- @formatter:on -->
                         </artifact>
-                        <artifact>
-                            <key>com.vaadin:copilot</key>
-                            <!--
-                            There should be no newlines in the classes list, otherwise the filter silently
-                            fails at runtime
-                            @formatter:off
-                            -->
-                            <resources>META-INF/services/com.vaadin.base.devserver.DevToolsMessageHandler</resources>
-                            <!-- @formatter:on -->
-                        </artifact>
                     </removedResources>
                 </configuration>
                 <executions>

--- a/react/runtime/pom.xml
+++ b/react/runtime/pom.xml
@@ -55,16 +55,6 @@
                             <resources>com/vaadin/hilla/ConditionalOnFeatureFlag.class,com/vaadin/hilla/EndpointControllerConfiguration.class,com/vaadin/hilla/FeatureFlagCondition.class,com/vaadin/hilla/startup/EndpointsValidator.class,com/vaadin/hilla/push/PushConfigurer.class</resources>
                             <!-- @formatter:on -->
                         </artifact>
-                        <artifact>
-                            <key>com.vaadin:copilot</key>
-                            <!--
-                            There should be no newlines in the classes list, otherwise the filter silently
-                            fails at runtime
-                            @formatter:off
-                            -->
-                            <resources>META-INF/services/com.vaadin.base.devserver.DevToolsMessageHandler</resources>
-                            <!-- @formatter:on -->
-                        </artifact>
                     </removedResources>
                 </configuration>
                 <executions>


### PR DESCRIPTION
## Summary

Re-enables Copilot's dev-tools message handling for Quarkus-Hilla by keeping `META-INF/services/com.vaadin.base.devserver.DevToolsMessageHandler` in the packaged runtime artifacts. Without that service registration, Copilot still injects `copilot-main` into the DOM in dev mode, but its backend message handler is missing; the overlay can then receive pointer events and block normal UI interaction.

This also adds targeted regression coverage so the issue is caught both at build configuration level and through a real browser click path with Copilot enabled.

## Changes

- **Runtime packaging**: stop removing Copilot's `DevToolsMessageHandler` service resource from `lit/runtime/pom.xml` and `react/runtime/pom.xml`.
- **Static regression guard**: add `CopilotDevToolsMessageHandlerTest` to fail if the Copilot service resource is stripped again.
- **UI regression coverage**: add `CopilotClickabilityTest`, a development-mode browser test that enables Copilot, asserts `copilot-main` is present, and verifies the root view still accepts real clicks.
- **Test support**: keep Copilot disabled by default in `AbstractTest`, but allow focused tests to opt in via `copilotEnabled()`.
- **Browser selection**: set `selenide.browser` to `chrome` by default, override it to `safari` through a macOS profile, and keep explicit local `-Dselenide.browser=...` overrides working.
- **Test dependency override**: add a development-mode profile in the React smoke tests so this one regression test gets `com.vaadin:copilot` despite the integration-test parent excluding it by default.

## Implementation notes

Existing tests did not catch this because Copilot was intentionally kept out of normal test runs: the integration-test parent excludes `com.vaadin:copilot` from `vaadin-dev`, and `AbstractTest` unconditionally set `vaadin.copilot.enable=false`. That made the normal dev-mode and production-mode suites good for app behavior, but blind to Copilot overlay regressions.

The new UI test uses real WebDriver clicks instead of DOM hit-testing. `copilot-main` can legitimately remain present in the DOM after Copilot initializes, so the relevant regression signal is whether app controls can still be clicked and used.

Browser selection now uses Selenide's standard `selenide.browser` property with non-empty defaults. GitHub Actions and other non-macOS environments use Chrome by default; macOS uses Safari through the `macos-tests` Maven profile. `AbstractTest` still applies browser-specific runtime settings: Safari runs headful, Chrome gets `--remote-allow-origins=*` and follows the normal headless/debug-mode handling.

The CI failure seen during review was caused by passing an empty `selenide.browser` system property to Selenide. Selenide interpreted the empty value as a custom driver class name and failed with `Class not found:` before any UI assertion ran. The POM now always provides a non-empty default, and `AbstractTest` guards accidental blank values by falling back to Chrome.

This was validated against the old behavior before the fix: with the removed service resource restored, the static guard fails and the browser test fails with `ElementClickInterceptedException` because `copilot-main` receives the click. With this change, the browser test clicks the text field and button successfully and reaches `HelloWorldService.sayHello`.

This does not address Copilot's separate SpringBridge/classloader compatibility; that remains out of scope for this PR.

## Test plan

- [x] `mvn -q help:evaluate -Dexpression=selenide.browser -DforceStdout` from `integration-tests` returns `safari` on macOS.
- [x] `mvn -q help:evaluate -Dexpression=selenide.browser -DforceStdout -Dselenide.browser=chrome` from `integration-tests` returns `chrome`.
- [x] `mvn -pl commons/runtime -am -Dtest=CopilotDevToolsMessageHandlerTest -Dsurefire.failIfNoSpecifiedTests=false -DskipExtensionValidation=true test`
- [x] `mvn -Pit-tests -pl integration-tests/react-smoke-tests -am -Dtest=SmokeTest#rootPath_viewDisplayed -Dsurefire.failIfNoSpecifiedTests=false -Dquarkus-hilla.test-mode=development -DskipExtensionValidation=true test`
- [x] `mvn -Pit-tests -pl integration-tests/react-smoke-tests -am -Dtest=CopilotClickabilityTest -Dsurefire.failIfNoSpecifiedTests=false -Dquarkus-hilla.test-mode=development -Dselenide.browser=chrome -DskipExtensionValidation=true test`
- [x] `mvn -Pit-tests -pl integration-tests/test-commons,integration-tests/react-smoke-tests spotless:check`
- [x] `git diff --check`

## Related

- Partially addresses mcollovati/quarkus-hilla#1913: message-handler resource removal and regression coverage only.
- Context: vaadin/quarkus#286.