### PR TITLE
feat(copilot): add Quarkus integration bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Hilla is an open source framework, provided by [Vaadin Ltd.](https://vaadin.com)
 - ⚡ **Reactive Streaming** - Support for Mutiny `Multi` and reactive endpoints
 - 🔒 **Security Integration** - Built-in support for authentication and authorization
 - 🔄 **Hot Reload** - Endpoints live reload in development mode
+- 🧭 **Vaadin Copilot Integration** - Development-time support for Copilot endpoint and Flow service discovery
 - 🖥️ **Dev UI Integration** - Visualize endpoint security constraints and null-safety in Quarkus Dev UI (since 24.7)
 - 🏗️ **Auto CRUD** - Automatic CRUD operations with Auto Grid and Auto Form (React)
 - 🚀 **Native Image** - Full GraalVM native image support (since 24.5)
@@ -111,6 +112,7 @@ That's it! The TypeScript client is automatically generated and type-safe.
 - 📖 [Wiki Documentation](../../wiki)
 - 🔧 [CRUD & Repository Services](../../wiki/Crud-List-repository-service)
 - 🛠️ [Build and Test](docs/build-and-test.md)
+- 🧭 [Vaadin Copilot Integration](docs/copilot-integration.md)
 - 🚢 [Release Process](docs/release-process.md)
 - 🧬 [Update Codestarts](docs/update-codestarts.md)
 - 🔢 [Bump Project Version](docs/bump-project-version.md)
@@ -120,6 +122,25 @@ That's it! The TypeScript client is automatically generated and type-safe.
 ---
 
 ## 🎯 Features & Highlights
+
+### Vaadin Copilot Integration ![Since 25.1.2](https://flat.badgen.net/static/Since/25.1.2/007bff?scale=0.9)
+
+Vaadin Copilot can inspect and edit Quarkus-Hilla applications in development mode. The integration maps Copilot's Spring-oriented backend hooks to Quarkus CDI and Vaadin Quarkus runtime APIs.
+
+Supported Copilot data sources:
+- Hilla `@BrowserCallable` and `@Endpoint` services from the Hilla `EndpointRegistry`
+- Flow UI services from Quarkus Arc bean discovery
+- Quarkus configuration properties
+- Vaadin route security status
+- Quarkus-Hilla version information
+
+Flow UI service discovery is intentionally conservative by default. It starts from application beans with service-like scopes and can be widened or narrowed with `vaadin.copilot.flow-services.*` configuration.
+
+> [!NOTE]
+> Copilot Java edits in Flow views currently use Quarkus Live Reload when no JVM hotswap agent is available. Changes are applied, but Copilot may show a warning that the operation is slower.
+
+> [!TIP]
+> See [Vaadin Copilot Integration](docs/copilot-integration.md) for service discovery modes, filtering options, and implementation details.
 
 ### Quarkus Dev UI Integration ![Since 24.7](https://flat.badgen.net/static/Since/24.7/007bff?scale=0.9)
 
@@ -329,7 +350,7 @@ Starting with 2.4.1, the extension is subdivided into two artifacts based on the
 
 The current Hilla support has some known limitations that we aim to address in future releases.
 
-- ❌ Vaadin Copilot is not supported
+- ⚠️ Vaadin Copilot support does not include JPA/Data helpers, Spring Security user switching, or full JVM hotswap integration
 - ❌ [Stateless Authentication](https://vaadin.com/docs/latest/hilla/guides/security/spring-stateless) is not supported
 
 <details>
@@ -410,6 +431,33 @@ Quarkus-Hilla provides various configuration parameters to customize the behavio
 | `vaadin.security.logout-path`               | String  | `/logout` | 24.7  | Path of the logout HTTP POST endpoint handling logout requests. |
 | `vaadin.security.post-logout-redirect-uri`  | String  | -         | 24.7  | URI to redirect to after successful logout.                     |
 | `vaadin.security.logout-invalidate-session` | Boolean | `true`    | 24.7  | Whether HTTP session should be invalidated on logout.           |
+
+### Copilot Configuration
+
+> [!NOTE]
+> Quarkus-Hilla supports Vaadin Copilot in development mode since 25.1.2. See [Vaadin Copilot Integration](docs/copilot-integration.md) for behavior details and limitations.
+
+| Property                                         | Type       | Default                                                                 | Since | Description                                                                                                                    |
+|--------------------------------------------------|------------|-------------------------------------------------------------------------|-------|--------------------------------------------------------------------------------------------------------------------------------|
+| `vaadin.copilot.flow-services.discovery`         | Enum       | `SERVICES`                                                              | 25.1.2 | Flow UI service discovery mode: `NONE`, `SERVICES`, or `ALL`. Explicit includes still work when discovery is `NONE`.           |
+| `vaadin.copilot.flow-services.packages`          | Enum       | `APPLICATION`                                                           | 25.1.2 | Package discovery mode: `APPLICATION` for root application archive classes, or `ALL` for all discovered bean packages.          |
+| `vaadin.copilot.flow-services.include-scopes`    | Set<String> | `application,singleton,dependent,vaadin-service,vaadin-session,vaadin-ui,vaadin-route` | 25.1.2 | Scope keys included when discovery is `SERVICES`.                                                                              |
+| `vaadin.copilot.flow-services.include-packages`  | Set<String> | -                                                                       | 25.1.2 | Package prefixes that are always added to Flow UI service discovery.                                                           |
+| `vaadin.copilot.flow-services.exclude-packages`  | Set<String> | -                                                                       | 25.1.2 | Package prefixes that are always removed from Flow UI service discovery.                                                       |
+| `vaadin.copilot.flow-services.include-classes`   | Set<String> | -                                                                       | 25.1.2 | Fully qualified class names that are always added to Flow UI service discovery.                                                |
+| `vaadin.copilot.flow-services.exclude-classes`   | Set<String> | -                                                                       | 25.1.2 | Fully qualified class names that are always removed from Flow UI service discovery. Excludes win over includes.                 |
+
+Example:
+
+```properties
+vaadin.copilot.flow-services.discovery=services
+vaadin.copilot.flow-services.packages=application
+vaadin.copilot.flow-services.include-packages=com.example.shared
+vaadin.copilot.flow-services.exclude-packages=com.example.internal
+vaadin.copilot.flow-services.include-classes=com.example.admin.AdminFacade
+```
+
+See [Vaadin Copilot Integration](docs/copilot-integration.md) for details.
 
 ### Build Configuration (Experimental)
 

--- a/commons/deployment/pom.xml
+++ b/commons/deployment/pom.xml
@@ -153,6 +153,7 @@
                         </vaadin.frontend.frontend.folder>
                         <vaadin.project.frontend.generated>${project.build.directory}/frontend/generated
                         </vaadin.project.frontend.generated>
+                        <vaadin.version>${vaadin.version}</vaadin.version>
                     </systemPropertyVariables>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                 </configuration>

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
@@ -15,12 +15,19 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment;
 
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.startup.ServletDeployer;
 import com.vaadin.hilla.BrowserCallable;
 import com.vaadin.hilla.Endpoint;
@@ -31,8 +38,10 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
 import io.quarkus.arc.deployment.ExcludedTypeBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.arc.processor.DotNames;
+import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -40,10 +49,12 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ExcludeDependencyBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
@@ -56,12 +67,15 @@ import org.atmosphere.cpr.ApplicationConfig;
 import org.atmosphere.interceptor.AtmosphereResourceLifecycleInterceptor;
 import org.atmosphere.interceptor.SuspendTrackerInterceptor;
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationTransformation;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 
 import com.github.mcollovati.quarkus.hilla.BodyHandlerRecorder;
+import com.github.mcollovati.quarkus.hilla.CopilotApplicationMetadata;
+import com.github.mcollovati.quarkus.hilla.CopilotConfiguration;
 import com.github.mcollovati.quarkus.hilla.HillaAtmosphereObjectFactory;
 import com.github.mcollovati.quarkus.hilla.HillaConfiguration;
 import com.github.mcollovati.quarkus.hilla.NonNullApi;
@@ -84,6 +98,32 @@ class QuarkusHillaExtensionProcessor {
             DotName.createSimple("com.github.mcollovati.quarkus.hilla.crud.spring.FilterableRepository");
     public static final DotName PANACHE_FILTERABLE_REPOSITORY =
             DotName.createSimple("com.github.mcollovati.quarkus.hilla.crud.panache.FilterableRepository");
+    private static final List<String> COPILOT_HARD_EXCLUDED_PACKAGES = List.of(
+            "com.vaadin.",
+            "com.github.mcollovati.quarkus.hilla.",
+            "io.quarkus.",
+            "io.smallrye.",
+            "io.vertx.",
+            "jakarta.",
+            "javax.",
+            "org.jboss.",
+            "org.eclipse.microprofile.",
+            "org.springframework.");
+    private static final DotName COPILOT_SPRING_SERVICE_ANNOTATION =
+            DotName.createSimple("org.springframework.stereotype.Service");
+    private static final Map<DotName, String> COPILOT_SCOPE_KEYS = Map.ofEntries(
+            Map.entry(DotName.createSimple("jakarta.enterprise.context.ApplicationScoped"), "application"),
+            Map.entry(DotName.createSimple("jakarta.inject.Singleton"), "singleton"),
+            Map.entry(DotName.createSimple("jakarta.enterprise.context.Dependent"), "dependent"),
+            Map.entry(DotName.createSimple("jakarta.enterprise.context.RequestScoped"), "request"),
+            Map.entry(DotName.createSimple("jakarta.enterprise.context.SessionScoped"), "session"),
+            Map.entry(DotName.createSimple("jakarta.enterprise.context.ConversationScoped"), "conversation"),
+            Map.entry(DotName.createSimple("com.vaadin.quarkus.annotation.VaadinServiceScoped"), "vaadin-service"),
+            Map.entry(DotName.createSimple("com.vaadin.quarkus.annotation.VaadinSessionScoped"), "vaadin-session"),
+            Map.entry(DotName.createSimple("com.vaadin.quarkus.annotation.UIScoped"), "vaadin-ui"),
+            Map.entry(DotName.createSimple("com.vaadin.quarkus.annotation.NormalUIScoped"), "vaadin-ui"),
+            Map.entry(DotName.createSimple("com.vaadin.quarkus.annotation.RouteScoped"), "vaadin-route"),
+            Map.entry(DotName.createSimple("com.vaadin.quarkus.annotation.NormalRouteScoped"), "vaadin-route"));
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -214,6 +254,8 @@ class QuarkusHillaExtensionProcessor {
     @BuildStep
     void addMarkersForHillaJars(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> producer) {
         producer.produce(new AdditionalApplicationArchiveMarkerBuildItem("com/vaadin/hilla"));
+        producer.produce(new AdditionalApplicationArchiveMarkerBuildItem("com/vaadin/copilot"));
+        producer.produce(new AdditionalApplicationArchiveMarkerBuildItem("com/vaadin/copilot/SpringBridge.class"));
     }
 
     @BuildStep
@@ -291,6 +333,71 @@ class QuarkusHillaExtensionProcessor {
     }
 
     @BuildStep
+    void generateCopilotApplicationMetadata(
+            ApplicationArchivesBuildItem applicationArchives,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources) {
+        ApplicationArchive rootArchive = applicationArchives.getRootArchive();
+        if (rootArchive == null || rootArchive.getIndex() == null) {
+            generatedResources.produce(new GeneratedResourceBuildItem(
+                    CopilotApplicationMetadata.RESOURCE,
+                    CopilotApplicationMetadata.empty().toResourceBytes()));
+            return;
+        }
+
+        IndexView rootIndex = rootArchive.getIndex();
+        Set<String> applicationClasses = rootIndex.getKnownClasses().stream()
+                .filter(classInfo -> !classInfo.isSynthetic())
+                .filter(classInfo -> !classInfo.isAnnotation())
+                .map(classInfo -> classInfo.name().toString())
+                .filter(name -> !"module-info".equals(name))
+                .sorted()
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        String applicationClass =
+                selectCopilotApplicationClass(rootIndex, applicationClasses).orElse("");
+
+        generatedResources.produce(new GeneratedResourceBuildItem(
+                CopilotApplicationMetadata.RESOURCE,
+                CopilotApplicationMetadata.of(applicationClass, applicationClasses)
+                        .toResourceBytes()));
+    }
+
+    @BuildStep
+    void preserveCopilotFlowServiceBeans(
+            ApplicationArchivesBuildItem applicationArchives,
+            CopilotConfiguration copilotConfiguration,
+            BuildProducer<UnremovableBeanBuildItem> unremovableBeans) {
+        Set<String> includePackages = copy(copilotConfiguration.includePackages());
+        Set<String> excludePackages = copy(copilotConfiguration.excludePackages());
+        Set<String> includeClasses = copy(copilotConfiguration.includeClasses());
+        Set<String> excludeClasses = copy(copilotConfiguration.excludeClasses());
+        Set<String> includeScopeKeys = normalizeScopeKeys(copilotConfiguration.includeScopes());
+
+        ApplicationArchive rootArchive = applicationArchives.getRootArchive();
+        Set<String> rootArchiveClasses = rootArchive == null
+                ? Set.of()
+                : knownClasses(rootArchive)
+                        .map(classInfo -> classInfo.name().toString())
+                        .collect(Collectors.toSet());
+
+        Set<String> unremovableClassNames = applicationArchives.getAllApplicationArchives().stream()
+                .flatMap(archive -> knownClasses(archive)
+                        .filter(classInfo -> isCopilotUnremovableCandidate(
+                                classInfo,
+                                rootArchiveClasses,
+                                copilotConfiguration,
+                                includeScopeKeys,
+                                includePackages,
+                                excludePackages,
+                                includeClasses,
+                                excludeClasses))
+                        .map(classInfo -> classInfo.name().toString()))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        if (!unremovableClassNames.isEmpty()) {
+            unremovableBeans.produce(UnremovableBeanBuildItem.beanClassNames(unremovableClassNames));
+        }
+    }
+
+    @BuildStep
     void replaceOffendingMethodCalls(BuildProducer<BytecodeTransformerBuildItem> producer) {
         OffendingMethodCallsReplacer.addClassVisitors(producer);
     }
@@ -347,5 +454,107 @@ class QuarkusHillaExtensionProcessor {
         producer.produce(new ExcludedTypeBuildItem("org.atmosphere.cpr.ContainerInitializer"));
         producer.produce(new ExcludedTypeBuildItem("org.atmosphere.cpr.AnnotationScanningServletContainerInitializer"));
         producer.produce(new ExcludedTypeBuildItem(ServletDeployer.class.getName()));
+    }
+
+    private static Optional<String> selectCopilotApplicationClass(IndexView rootIndex, Set<String> applicationClasses) {
+        DotName appShellConfigurator = DotName.createSimple(AppShellConfigurator.class.getName());
+        return Stream.of(
+                        rootIndex.getKnownDirectImplementations(appShellConfigurator).stream()
+                                .map(ClassInfo::name)
+                                .map(DotName::toString),
+                        annotatedClasses(rootIndex, DotName.createSimple(Route.class.getName())),
+                        annotatedClasses(rootIndex, DotName.createSimple(BrowserCallable.class.getName())),
+                        annotatedClasses(rootIndex, DotName.createSimple(Endpoint.class.getName())),
+                        applicationClasses.stream())
+                .map(stream ->
+                        stream.filter(applicationClasses::contains).sorted().findFirst())
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
+    }
+
+    private static Stream<String> annotatedClasses(IndexView rootIndex, DotName annotation) {
+        return rootIndex.getAnnotations(annotation).stream()
+                .filter(instance -> instance.target().kind() == AnnotationTarget.Kind.CLASS)
+                .map(AnnotationInstance::target)
+                .map(AnnotationTarget::asClass)
+                .map(ClassInfo::name)
+                .map(DotName::toString);
+    }
+
+    private static boolean isCopilotUnremovableCandidate(
+            ClassInfo classInfo,
+            Set<String> rootArchiveClasses,
+            CopilotConfiguration config,
+            Set<String> includeScopeKeys,
+            Set<String> includePackages,
+            Set<String> excludePackages,
+            Set<String> includeClasses,
+            Set<String> excludeClasses) {
+        String className = classInfo.name().toString();
+        if (classInfo.isSynthetic()
+                || classInfo.isAnnotation()
+                || isCopilotHardExcluded(className)
+                || excludeClasses.contains(className)
+                || matchesPackage(className, excludePackages)) {
+            return false;
+        }
+        if (includeClasses.contains(className) || matchesPackage(className, includePackages)) {
+            return true;
+        }
+        if (config.discovery() == CopilotConfiguration.Discovery.NONE) {
+            return false;
+        }
+        if (config.packageMode() == CopilotConfiguration.PackageMode.APPLICATION
+                && !rootArchiveClasses.contains(className)) {
+            return false;
+        }
+        return config.discovery() == CopilotConfiguration.Discovery.ALL
+                || isCopilotServiceLike(classInfo, includeScopeKeys);
+    }
+
+    private static boolean isCopilotServiceLike(ClassInfo classInfo, Set<String> includeScopeKeys) {
+        return classInfo.classAnnotation(COPILOT_SPRING_SERVICE_ANNOTATION) != null
+                || COPILOT_SCOPE_KEYS.entrySet().stream()
+                        .filter(entry -> includeScopeKeys.contains(entry.getValue()))
+                        .map(Map.Entry::getKey)
+                        .anyMatch(annotation -> classInfo.classAnnotation(annotation) != null);
+    }
+
+    private static boolean isCopilotHardExcluded(String className) {
+        return COPILOT_HARD_EXCLUDED_PACKAGES.stream().anyMatch(className::startsWith);
+    }
+
+    private static boolean matchesPackage(String className, Set<String> packagePrefixes) {
+        int separator = className.lastIndexOf('.');
+        String packageName = separator > 0 ? className.substring(0, separator) : "";
+        return packagePrefixes.stream()
+                .anyMatch(prefix -> packageName.equals(prefix)
+                        || packageName.startsWith(prefix + ".")
+                        || className.startsWith(prefix + "."));
+    }
+
+    private static Stream<ClassInfo> knownClasses(ApplicationArchive archive) {
+        if (archive == null || archive.getIndex() == null) {
+            return Stream.empty();
+        }
+        return archive.getIndex().getKnownClasses().stream();
+    }
+
+    private static Set<String> normalizeScopeKeys(Set<String> scopeKeys) {
+        if (scopeKeys == null || scopeKeys.isEmpty()) {
+            return Set.of();
+        }
+        return scopeKeys.stream()
+                .map(scopeKey -> scopeKey.trim().toLowerCase(Locale.ROOT).replace('_', '-'))
+                .filter(scopeKey -> !scopeKey.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private static Set<String> copy(Optional<Set<String>> values) {
+        return values.orElseGet(Set::of).stream()
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
     }
 }

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/OffendingMethodCallsReplacer.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/OffendingMethodCallsReplacer.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.hilla.ApplicationContextProvider;
 import com.vaadin.hilla.AuthenticationUtil;
 import com.vaadin.hilla.EndpointCodeGenerator;
@@ -43,6 +44,7 @@ import org.objectweb.asm.Opcodes;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.domain.Sort;
 
+import com.github.mcollovati.quarkus.hilla.CopilotQuarkusIntegration;
 import com.github.mcollovati.quarkus.hilla.HillaReplacements;
 import com.github.mcollovati.quarkus.hilla.SpringReplacements;
 
@@ -127,6 +129,9 @@ public class OffendingMethodCallsReplacer {
         }));
         producer.produce(applicationContextProvider_runOnContext_patch());
         producer.produce(endpointCodeGenerator_findBrowserCallables_replacement());
+        producer.produce(copilotSpringBridge_patch());
+        producer.produce(
+                transform("com.vaadin.copilot.customcomponent.CustomComponents", "isCustomComponent", Class_forName));
         producer.produce(new BytecodeTransformerBuildItem(
                 "com.vaadin.hilla.EndpointController",
                 (className, classVisitor) -> new EndpointControllerVisitor(classVisitor)));
@@ -135,8 +140,14 @@ public class OffendingMethodCallsReplacer {
     @SafeVarargs
     private static BytecodeTransformerBuildItem transform(
             Class<?> clazz, String method, Map.Entry<MethodSignature, MethodSignature>... replacements) {
+        return transform(clazz.getName(), method, replacements);
+    }
+
+    @SafeVarargs
+    private static BytecodeTransformerBuildItem transform(
+            String className, String method, Map.Entry<MethodSignature, MethodSignature>... replacements) {
         return new BytecodeTransformerBuildItem(
-                clazz.getName(),
+                className,
                 (s, classVisitor) ->
                         new MethodReplacementClassVisitor(classVisitor, method, Map.ofEntries(replacements)));
     }
@@ -197,5 +208,48 @@ public class OffendingMethodCallsReplacer {
             }
             return transformer.applyTo(classVisitor);
         });
+    }
+
+    private static BytecodeTransformerBuildItem copilotSpringBridge_patch() {
+        return new BytecodeTransformerBuildItem("com.vaadin.copilot.SpringBridge", (className, classVisitor) -> {
+            ClassTransformer transformer = new ClassTransformer(className);
+            replaceCopilotBridgeMethod(transformer, className, "callSpring", "callSpring");
+            replaceCopilotBridgeMethod(transformer, className, "callSpringSecurity", "callSpringSecurity");
+            replaceCopilotBridgeMethod(transformer, className, "callSpringData", "callSpringData");
+            replaceCopilotIsSpringAvailable(transformer, className);
+            return transformer.applyTo(classVisitor);
+        });
+    }
+
+    private static void replaceCopilotBridgeMethod(
+            ClassTransformer transformer, String className, String methodName, String replacementMethodName) {
+        MethodDescriptor bridgeMethod =
+                MethodDescriptor.ofMethod(className, methodName, Object.class, String.class, Object[].class);
+        transformer.removeMethod(bridgeMethod);
+        try (MethodCreator creator = transformer.addMethod(bridgeMethod)) {
+            creator.setModifiers(Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_VARARGS);
+            creator.returnValue(creator.invokeStaticMethod(
+                    MethodDescriptor.ofMethod(
+                            CopilotQuarkusIntegration.class,
+                            replacementMethodName,
+                            Object.class,
+                            String.class,
+                            Object[].class),
+                    creator.getMethodParam(0),
+                    creator.getMethodParam(1)));
+        }
+    }
+
+    private static void replaceCopilotIsSpringAvailable(ClassTransformer transformer, String className) {
+        MethodDescriptor isSpringAvailable =
+                MethodDescriptor.ofMethod(className, "isSpringAvailable", boolean.class, VaadinContext.class);
+        transformer.removeMethod(isSpringAvailable);
+        try (MethodCreator creator = transformer.addMethod(isSpringAvailable)) {
+            creator.setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+            creator.returnValue(creator.invokeStaticMethod(
+                    MethodDescriptor.ofMethod(
+                            CopilotQuarkusIntegration.class, "isAvailable", boolean.class, VaadinContext.class),
+                    creator.getMethodParam(0)));
+        }
     }
 }

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotCustomComponentsPatchTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotCustomComponentsPatchTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.copilot;
+
+import java.lang.reflect.Proxy;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Supplier;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CopilotCustomComponentsPatchTest {
+
+    private static final String HIDDEN_COMPONENT = "dev.codex.quarkushilla.hidden.HiddenComponent";
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.extensionTest()
+            .setArchiveProducer(CopilotQuarkusIntegrationTestSupport::rootArchive);
+
+    @Test
+    void customComponentsIsCustomComponent_loadsClassesFromThreadContextClassLoader() throws Exception {
+        Path outputDirectory = compileHiddenComponent();
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try (URLClassLoader hiddenClassLoader =
+                new URLClassLoader(new java.net.URL[] {outputDirectory.toUri().toURL()}, null)) {
+            Class<?> hiddenComponent = hiddenClassLoader.loadClass(HIDDEN_COMPONENT);
+            registerCustomComponent(hiddenComponent);
+
+            Thread.currentThread().setContextClassLoader(hiddenClassLoader);
+
+            Class<?> customComponents = Class.forName("com.vaadin.copilot.customcomponent.CustomComponents");
+            boolean customComponent = (boolean) customComponents
+                    .getMethod("isCustomComponent", String.class)
+                    .invoke(null, HIDDEN_COMPONENT);
+
+            assertThat(customComponent).isTrue();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        }
+    }
+
+    private static Path compileHiddenComponent() throws Exception {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertThat(compiler).isNotNull();
+
+        Path sourceDirectory = Files.createTempDirectory("copilot-hidden-component-src");
+        Path outputDirectory = Files.createTempDirectory("copilot-hidden-component-classes");
+        Path sourceFile = sourceDirectory.resolve("dev/codex/quarkushilla/hidden/HiddenComponent.java");
+        Files.createDirectories(sourceFile.getParent());
+        Files.writeString(sourceFile, """
+                package dev.codex.quarkushilla.hidden;
+
+                public class HiddenComponent {
+                }
+                """);
+
+        int result = compiler.run(null, null, null, "-d", outputDirectory.toString(), sourceFile.toString());
+        assertThat(result).isZero();
+        return outputDirectory;
+    }
+
+    private static void registerCustomComponent(Class<?> componentClass) throws Exception {
+        Class<?> customComponentType = Class.forName("com.vaadin.copilot.customcomponent.CustomComponent");
+        Object customComponent = Proxy.newProxyInstance(
+                customComponentType.getClassLoader(),
+                new Class<?>[] {customComponentType},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "componentClass" -> componentClass;
+                    case "getType" -> null;
+                    case "litTemplate" -> false;
+                    case "getChildAddableMethods" -> List.of();
+                    case "toString" -> "HiddenComponentCustomComponent";
+                    default -> null;
+                });
+
+        Class<?> customComponents = Class.forName("com.vaadin.copilot.customcomponent.CustomComponents");
+        java.lang.reflect.Method put = customComponents.getDeclaredMethod("put", Class.class, Supplier.class);
+        put.setAccessible(true);
+        put.invoke(null, componentClass, (Supplier<?>) () -> customComponent);
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationDefaultTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationDefaultTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.copilot;
+
+import java.util.Set;
+
+import dev.codex.quarkushilla.copilot.app.CopilotTestBeans;
+import dev.codex.quarkushilla.copilot.dependency.DependencyTestBeans;
+import io.quarkus.test.QuarkusExtensionTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.mcollovati.quarkus.hilla.CopilotQuarkusIntegration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CopilotQuarkusIntegrationDefaultTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.extensionTest()
+            .setArchiveProducer(CopilotQuarkusIntegrationTestSupport::rootArchive)
+            .addAdditionalDependency(CopilotQuarkusIntegrationTestSupport.dependencyArchive());
+
+    @Test
+    void flowServices_defaultServicesMode_findsScopedApplicationBeansOnly() {
+        Set<String> methods = CopilotQuarkusIntegrationTestSupport.flowServiceMethods();
+
+        assertThat(methods)
+                .contains(
+                        method(CopilotTestBeans.ApplicationScopedFlowService.class, "applicationMethod"),
+                        method(CopilotTestBeans.SingletonFlowService.class, "singletonMethod"),
+                        method(CopilotTestBeans.DependentFlowService.class, "dependentMethod"),
+                        method(CopilotTestBeans.VaadinServiceScopedFlowService.class, "vaadinServiceMethod"),
+                        method(CopilotTestBeans.VaadinSessionScopedFlowService.class, "vaadinSessionMethod"),
+                        method(CopilotTestBeans.VaadinUiScopedFlowService.class, "vaadinUiMethod"),
+                        method(CopilotTestBeans.VaadinRouteScopedFlowService.class, "vaadinRouteMethod"))
+                .doesNotContain(
+                        method(CopilotTestBeans.RequestScopedFlowService.class, "requestMethod"),
+                        method(CopilotTestBeans.BrowserCallableEndpoint.class, "browserCallableMethod"),
+                        method(CopilotTestBeans.LegacyEndpoint.class, "endpointMethod"),
+                        method(DependencyTestBeans.DependencyApplicationScopedService.class, "dependencyMethod"));
+    }
+
+    @Test
+    void endpoints_returnsHillaEndpointsAndFlowServicesDoNotDuplicateThem() {
+        Set<String> endpoints = CopilotQuarkusIntegrationTestSupport.endpointMethods();
+        Set<String> flowServices = CopilotQuarkusIntegrationTestSupport.flowServiceMethods();
+
+        assertThat(endpoints)
+                .contains(
+                        method(CopilotTestBeans.BrowserCallableEndpoint.class, "browserCallableMethod"),
+                        method(CopilotTestBeans.LegacyEndpoint.class, "endpointMethod"));
+        assertThat(flowServices)
+                .doesNotContain(
+                        method(CopilotTestBeans.BrowserCallableEndpoint.class, "browserCallableMethod"),
+                        method(CopilotTestBeans.LegacyEndpoint.class, "endpointMethod"));
+    }
+
+    @Test
+    void springBridgePatch_routesCopilotCallsToQuarkusIntegration() {
+        assertThat(CopilotQuarkusIntegrationTestSupport.springBridgeAvailable()).isTrue();
+        assertThat(CopilotQuarkusIntegrationTestSupport.springBridgeFlowServiceMethods())
+                .contains(method(CopilotTestBeans.ApplicationScopedFlowService.class, "applicationMethod"));
+    }
+
+    @Test
+    void applicationClass_prefersAppShellConfiguratorOverAlphabeticallyEarlierClasses() {
+        assertThat(CopilotQuarkusIntegration.getApplicationClass(null)).isEqualTo(CopilotTestBeans.ZzzAppShell.class);
+    }
+
+    private static String method(Class<?> serviceClass, String methodName) {
+        return CopilotQuarkusIntegrationTestSupport.methodId(serviceClass, methodName);
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationDiscoveryAllTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationDiscoveryAllTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.copilot;
+
+import dev.codex.quarkushilla.copilot.app.CopilotTestBeans;
+import io.quarkus.test.QuarkusExtensionTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CopilotQuarkusIntegrationDiscoveryAllTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.extensionTest()
+            .overrideConfigKey("vaadin.copilot.flow-services.discovery", "all")
+            .setArchiveProducer(CopilotQuarkusIntegrationTestSupport::rootArchive);
+
+    @Test
+    void flowServices_allDiscovery_includesNonDefaultScopedApplicationBeans() {
+        assertThat(CopilotQuarkusIntegrationTestSupport.flowServiceMethods())
+                .contains(method(CopilotTestBeans.RequestScopedFlowService.class, "requestMethod"));
+    }
+
+    private static String method(Class<?> serviceClass, String methodName) {
+        return CopilotQuarkusIntegrationTestSupport.methodId(serviceClass, methodName);
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationExcludePackagesTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationExcludePackagesTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.copilot;
+
+import dev.codex.quarkushilla.copilot.app.CopilotTestBeans;
+import dev.codex.quarkushilla.copilot.included.IncludedTestBeans;
+import io.quarkus.test.QuarkusExtensionTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CopilotQuarkusIntegrationExcludePackagesTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.extensionTest()
+            .overrideConfigKey("vaadin.copilot.flow-services.discovery", "none")
+            .overrideConfigKey(
+                    "vaadin.copilot.flow-services.include-packages", "dev.codex.quarkushilla.copilot.included")
+            .overrideConfigKey(
+                    "vaadin.copilot.flow-services.exclude-packages", "dev.codex.quarkushilla.copilot.included")
+            .overrideConfigKey(
+                    "vaadin.copilot.flow-services.include-classes",
+                    "dev.codex.quarkushilla.copilot.app.CopilotTestBeans$ApplicationScopedFlowService")
+            .setArchiveProducer(CopilotQuarkusIntegrationTestSupport::rootArchive);
+
+    @Test
+    void flowServices_excludePackageWinsOverIncludedPackage() {
+        assertThat(CopilotQuarkusIntegrationTestSupport.flowServiceMethods())
+                .contains(method(CopilotTestBeans.ApplicationScopedFlowService.class, "applicationMethod"))
+                .doesNotContain(
+                        method(IncludedTestBeans.IncludedPackageService.class, "includedPackageMethod"),
+                        method(IncludedTestBeans.ExcludedIncludedService.class, "excludedIncludedMethod"));
+    }
+
+    private static String method(Class<?> serviceClass, String methodName) {
+        return CopilotQuarkusIntegrationTestSupport.methodId(serviceClass, methodName);
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationIncludeScopesTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationIncludeScopesTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.copilot;
+
+import dev.codex.quarkushilla.copilot.app.CopilotTestBeans;
+import io.quarkus.test.QuarkusExtensionTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CopilotQuarkusIntegrationIncludeScopesTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.extensionTest()
+            .overrideConfigKey("vaadin.copilot.flow-services.include-scopes", "request")
+            .setArchiveProducer(CopilotQuarkusIntegrationTestSupport::rootArchive);
+
+    @Test
+    void flowServices_servicesMode_respectsConfiguredScopeKeys() {
+        assertThat(CopilotQuarkusIntegrationTestSupport.flowServiceMethods())
+                .contains(method(CopilotTestBeans.RequestScopedFlowService.class, "requestMethod"))
+                .doesNotContain(method(CopilotTestBeans.DependentFlowService.class, "dependentMethod"));
+    }
+
+    private static String method(Class<?> serviceClass, String methodName) {
+        return CopilotQuarkusIntegrationTestSupport.methodId(serviceClass, methodName);
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationIncludesExcludesTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationIncludesExcludesTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.copilot;
+
+import dev.codex.quarkushilla.copilot.app.CopilotTestBeans;
+import dev.codex.quarkushilla.copilot.included.IncludedTestBeans;
+import io.quarkus.test.QuarkusExtensionTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CopilotQuarkusIntegrationIncludesExcludesTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.extensionTest()
+            .overrideConfigKey("vaadin.copilot.flow-services.discovery", "none")
+            .overrideConfigKey(
+                    "vaadin.copilot.flow-services.include-packages", "dev.codex.quarkushilla.copilot.included")
+            .overrideConfigKey(
+                    "vaadin.copilot.flow-services.include-classes",
+                    "dev.codex.quarkushilla.copilot.app.CopilotTestBeans$ApplicationScopedFlowService")
+            .overrideConfigKey(
+                    "vaadin.copilot.flow-services.exclude-classes",
+                    "dev.codex.quarkushilla.copilot.included.IncludedTestBeans$ExcludedIncludedService")
+            .setArchiveProducer(CopilotQuarkusIntegrationTestSupport::rootArchive);
+
+    @Test
+    void flowServices_noneDiscovery_appliesIncludesAndExcludes() {
+        assertThat(CopilotQuarkusIntegrationTestSupport.flowServiceMethods())
+                .contains(
+                        method(CopilotTestBeans.ApplicationScopedFlowService.class, "applicationMethod"),
+                        method(IncludedTestBeans.IncludedPackageService.class, "includedPackageMethod"))
+                .doesNotContain(
+                        method(CopilotTestBeans.DependentFlowService.class, "dependentMethod"),
+                        method(IncludedTestBeans.ExcludedIncludedService.class, "excludedIncludedMethod"));
+    }
+
+    private static String method(Class<?> serviceClass, String methodName) {
+        return CopilotQuarkusIntegrationTestSupport.methodId(serviceClass, methodName);
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationPackagesAllTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationPackagesAllTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.copilot;
+
+import dev.codex.quarkushilla.copilot.dependency.DependencyTestBeans;
+import io.quarkus.test.QuarkusExtensionTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CopilotQuarkusIntegrationPackagesAllTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.extensionTest()
+            .overrideConfigKey("vaadin.copilot.flow-services.packages", "all")
+            .setArchiveProducer(CopilotQuarkusIntegrationTestSupport::rootArchive)
+            .addAdditionalDependency(CopilotQuarkusIntegrationTestSupport.dependencyArchive());
+
+    @Test
+    void flowServices_allPackages_includesBeansFromAdditionalApplicationArchives() {
+        assertThat(CopilotQuarkusIntegrationTestSupport.flowServiceMethods())
+                .contains(method(DependencyTestBeans.DependencyApplicationScopedService.class, "dependencyMethod"));
+    }
+
+    private static String method(Class<?> serviceClass, String methodName) {
+        return CopilotQuarkusIntegrationTestSupport.methodId(serviceClass, methodName);
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationTestSupport.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationTestSupport.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.copilot;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.vaadin.flow.server.VaadinContext;
+import dev.codex.quarkushilla.copilot.app.CopilotTestBeans;
+import dev.codex.quarkushilla.copilot.dependency.DependencyTestBeans;
+import dev.codex.quarkushilla.copilot.included.IncludedTestBeans;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusExtensionTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+import com.github.mcollovati.quarkus.hilla.CopilotQuarkusIntegration;
+
+public final class CopilotQuarkusIntegrationTestSupport {
+
+    private static final String REMOVED_OPTIONAL_ARTIFACTS = String.join(
+            ",",
+            "io.quarkus:quarkus-hibernate-orm",
+            "io.quarkus:quarkus-hibernate-orm-deployment",
+            "io.quarkus:quarkus-hibernate-orm-panache-common",
+            "io.quarkus:quarkus-hibernate-orm-panache-common-deployment",
+            "io.quarkus:quarkus-hibernate-orm-panache",
+            "io.quarkus:quarkus-hibernate-orm-panache-deployment",
+            "io.quarkus:quarkus-spring-di",
+            "io.quarkus:quarkus-spring-di-deployment",
+            "io.quarkus:quarkus-spring-data-jpa",
+            "io.quarkus:quarkus-spring-data-jpa-deployment");
+
+    private CopilotQuarkusIntegrationTestSupport() {}
+
+    public static QuarkusExtensionTest extensionTest() {
+        return new QuarkusExtensionTest()
+                .setForcedDependencies(
+                        List.of(Dependency.of("com.vaadin", "copilot", System.getProperty("vaadin.version"))))
+                .overrideConfigKey("quarkus.class-loading.removed-artifacts", REMOVED_OPTIONAL_ARTIFACTS);
+    }
+
+    public static JavaArchive rootArchive() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addClasses(
+                        CopilotQuarkusIntegrationTestSupport.class,
+                        CopilotTestBeans.class,
+                        CopilotTestBeans.AAlphabeticallyFirstHelper.class,
+                        CopilotTestBeans.ZzzAppShell.class,
+                        CopilotTestBeans.ApplicationScopedFlowService.class,
+                        CopilotTestBeans.SingletonFlowService.class,
+                        CopilotTestBeans.DependentFlowService.class,
+                        CopilotTestBeans.RequestScopedFlowService.class,
+                        CopilotTestBeans.VaadinServiceScopedFlowService.class,
+                        CopilotTestBeans.VaadinSessionScopedFlowService.class,
+                        CopilotTestBeans.VaadinUiScopedFlowService.class,
+                        CopilotTestBeans.VaadinRouteScopedFlowService.class,
+                        CopilotTestBeans.BrowserCallableEndpoint.class,
+                        CopilotTestBeans.LegacyEndpoint.class,
+                        IncludedTestBeans.class,
+                        IncludedTestBeans.IncludedPackageService.class,
+                        IncludedTestBeans.ExcludedIncludedService.class);
+    }
+
+    public static JavaArchive dependencyArchive() {
+        return ShrinkWrap.create(JavaArchive.class, "copilot-flow-services-dependency.jar")
+                .addClasses(DependencyTestBeans.class, DependencyTestBeans.DependencyApplicationScopedService.class);
+    }
+
+    public static Set<String> flowServiceMethods() {
+        return methodIds(CopilotQuarkusIntegration.getFlowUIServices(null));
+    }
+
+    public static Set<String> endpointMethods() {
+        return methodIds(CopilotQuarkusIntegration.getEndpoints(null));
+    }
+
+    public static boolean springBridgeAvailable() {
+        try {
+            Class<?> springBridge = Class.forName("com.vaadin.copilot.SpringBridge");
+            return (boolean) springBridge
+                    .getMethod("isSpringAvailable", VaadinContext.class)
+                    .invoke(null, new Object[] {null});
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Invalid SpringBridge integration", e);
+        }
+    }
+
+    public static Set<String> springBridgeFlowServiceMethods() {
+        try {
+            Class<?> springBridge = Class.forName("com.vaadin.copilot.SpringBridge");
+            List<?> services = (List<?>) springBridge
+                    .getMethod("getFlowUIServices", VaadinContext.class)
+                    .invoke(null, new Object[] {null});
+            return methodIds(services);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Invalid SpringBridge integration", e);
+        }
+    }
+
+    public static String methodId(Class<?> serviceClass, String methodName) {
+        return serviceClass.getName() + "#" + methodName;
+    }
+
+    private static Set<String> methodIds(Iterable<?> serviceMethodInfos) {
+        return java.util.stream.StreamSupport.stream(serviceMethodInfos.spliterator(), false)
+                .map(CopilotQuarkusIntegrationTestSupport::methodId)
+                .collect(Collectors.toSet());
+    }
+
+    private static String methodId(Object serviceMethodInfo) {
+        try {
+            Class<?> serviceClass = (Class<?>)
+                    serviceMethodInfo.getClass().getMethod("serviceClass").invoke(serviceMethodInfo);
+            Method serviceMethod = (Method)
+                    serviceMethodInfo.getClass().getMethod("serviceMethod").invoke(serviceMethodInfo);
+            return methodId(serviceClass, serviceMethod.getName());
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Invalid ServiceMethodInfo", e);
+        }
+    }
+}

--- a/commons/deployment/src/test/java/dev/codex/quarkushilla/copilot/app/CopilotTestBeans.java
+++ b/commons/deployment/src/test/java/dev/codex/quarkushilla/copilot/app/CopilotTestBeans.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.codex.quarkushilla.copilot.app;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Singleton;
+
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.hilla.BrowserCallable;
+import com.vaadin.hilla.Endpoint;
+import com.vaadin.quarkus.annotation.NormalRouteScoped;
+import com.vaadin.quarkus.annotation.NormalUIScoped;
+import com.vaadin.quarkus.annotation.VaadinServiceScoped;
+import com.vaadin.quarkus.annotation.VaadinSessionScoped;
+
+public final class CopilotTestBeans {
+
+    private CopilotTestBeans() {}
+
+    public static class AAlphabeticallyFirstHelper {}
+
+    public static class ZzzAppShell implements AppShellConfigurator {}
+
+    @ApplicationScoped
+    public static class ApplicationScopedFlowService {
+
+        public String applicationMethod() {
+            return "application";
+        }
+    }
+
+    @Singleton
+    public static class SingletonFlowService {
+
+        public String singletonMethod() {
+            return "singleton";
+        }
+    }
+
+    @Dependent
+    public static class DependentFlowService {
+
+        public String dependentMethod() {
+            return "dependent";
+        }
+    }
+
+    @RequestScoped
+    public static class RequestScopedFlowService {
+
+        public String requestMethod() {
+            return "request";
+        }
+    }
+
+    @VaadinServiceScoped
+    public static class VaadinServiceScopedFlowService {
+
+        public String vaadinServiceMethod() {
+            return "vaadin-service";
+        }
+    }
+
+    @VaadinSessionScoped
+    public static class VaadinSessionScopedFlowService {
+
+        public String vaadinSessionMethod() {
+            return "vaadin-session";
+        }
+    }
+
+    @NormalUIScoped
+    public static class VaadinUiScopedFlowService {
+
+        public String vaadinUiMethod() {
+            return "vaadin-ui";
+        }
+    }
+
+    @NormalRouteScoped
+    public static class VaadinRouteScopedFlowService {
+
+        public String vaadinRouteMethod() {
+            return "vaadin-route";
+        }
+    }
+
+    @BrowserCallable
+    public static class BrowserCallableEndpoint {
+
+        public String browserCallableMethod() {
+            return "browser-callable";
+        }
+    }
+
+    @Endpoint
+    public static class LegacyEndpoint {
+
+        public String endpointMethod() {
+            return "endpoint";
+        }
+    }
+}

--- a/commons/deployment/src/test/java/dev/codex/quarkushilla/copilot/dependency/DependencyTestBeans.java
+++ b/commons/deployment/src/test/java/dev/codex/quarkushilla/copilot/dependency/DependencyTestBeans.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.codex.quarkushilla.copilot.dependency;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+public final class DependencyTestBeans {
+
+    private DependencyTestBeans() {}
+
+    @ApplicationScoped
+    public static class DependencyApplicationScopedService {
+
+        public String dependencyMethod() {
+            return "dependency";
+        }
+    }
+}

--- a/commons/deployment/src/test/java/dev/codex/quarkushilla/copilot/included/IncludedTestBeans.java
+++ b/commons/deployment/src/test/java/dev/codex/quarkushilla/copilot/included/IncludedTestBeans.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.codex.quarkushilla.copilot.included;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.RequestScoped;
+
+public final class IncludedTestBeans {
+
+    private IncludedTestBeans() {}
+
+    @RequestScoped
+    public static class IncludedPackageService {
+
+        public String includedPackageMethod() {
+            return "included";
+        }
+    }
+
+    @ApplicationScoped
+    public static class ExcludedIncludedService {
+
+        public String excludedIncludedMethod() {
+            return "excluded";
+        }
+    }
+}

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/CopilotApplicationMetadata.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/CopilotApplicationMetadata.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Build-time application metadata used by the Copilot runtime bridge.
+ */
+public final class CopilotApplicationMetadata {
+
+    public static final String RESOURCE = "META-INF/quarkus-hilla/copilot-application-metadata.properties";
+
+    private static final String APPLICATION_CLASS = "applicationClass";
+    private static final String APPLICATION_CLASSES = "applicationClasses";
+
+    private final String applicationClassName;
+    private final Set<String> applicationClassNames;
+
+    private CopilotApplicationMetadata(String applicationClassName, Set<String> applicationClassNames) {
+        this.applicationClassName = applicationClassName;
+        this.applicationClassNames = Set.copyOf(applicationClassNames);
+    }
+
+    public static CopilotApplicationMetadata empty() {
+        return new CopilotApplicationMetadata("", Set.of());
+    }
+
+    public static CopilotApplicationMetadata of(String applicationClassName, Set<String> applicationClassNames) {
+        return new CopilotApplicationMetadata(
+                Objects.requireNonNullElse(applicationClassName, ""), new LinkedHashSet<>(applicationClassNames));
+    }
+
+    public static CopilotApplicationMetadata load() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = CopilotApplicationMetadata.class.getClassLoader();
+        }
+        try (InputStream input = classLoader.getResourceAsStream(RESOURCE)) {
+            if (input == null) {
+                return empty();
+            }
+            Properties properties = new Properties();
+            properties.load(input);
+            Set<String> classes = split(properties.getProperty(APPLICATION_CLASSES));
+            return of(properties.getProperty(APPLICATION_CLASS, ""), classes);
+        } catch (IOException e) {
+            return empty();
+        }
+    }
+
+    public byte[] toResourceBytes() {
+        String content = APPLICATION_CLASS + "=" + applicationClassName + "\n" + APPLICATION_CLASSES + "="
+                + applicationClassNames.stream().sorted().collect(Collectors.joining(",")) + "\n";
+        return content.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public Optional<String> applicationClassName() {
+        return Optional.ofNullable(applicationClassName).filter(value -> !value.isBlank());
+    }
+
+    public Set<String> applicationClassNames() {
+        return applicationClassNames;
+    }
+
+    public boolean isApplicationClass(Class<?> type) {
+        return type != null && applicationClassNames.contains(type.getName());
+    }
+
+    private static Set<String> split(String value) {
+        if (value == null || value.isBlank()) {
+            return Set.of();
+        }
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(token -> !token.isEmpty())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+}

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/CopilotConfiguration.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/CopilotConfiguration.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla;
+
+import java.util.Optional;
+import java.util.Set;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
+
+/**
+ * Copilot Flow service discovery configuration.
+ */
+@ConfigMapping(prefix = "vaadin.copilot.flow-services")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface CopilotConfiguration {
+
+    /**
+     * Automatic discovery mode.
+     *
+     * @return discovery mode.
+     */
+    @WithDefault("services")
+    Discovery discovery();
+
+    /**
+     * Package discovery mode.
+     *
+     * @return package mode.
+     */
+    @WithName("packages")
+    @WithDefault("application")
+    PackageMode packageMode();
+
+    /**
+     * Bean scope keys included in service discovery mode.
+     *
+     * @return included scope keys.
+     */
+    @WithName("include-scopes")
+    @WithDefault("application,singleton,dependent,vaadin-service,vaadin-session,vaadin-ui,vaadin-route")
+    Set<String> includeScopes();
+
+    /**
+     * Package prefixes that are always added to discovery.
+     *
+     * @return included package prefixes.
+     */
+    @WithName("include-packages")
+    Optional<Set<String>> includePackages();
+
+    /**
+     * Package prefixes that are always removed from discovery.
+     *
+     * @return excluded package prefixes.
+     */
+    @WithName("exclude-packages")
+    Optional<Set<String>> excludePackages();
+
+    /**
+     * Classes that are always added to discovery.
+     *
+     * @return included classes.
+     */
+    @WithName("include-classes")
+    Optional<Set<String>> includeClasses();
+
+    /**
+     * Classes that are always removed from discovery.
+     *
+     * @return excluded classes.
+     */
+    @WithName("exclude-classes")
+    Optional<Set<String>> excludeClasses();
+
+    enum Discovery {
+        NONE,
+        SERVICES,
+        ALL
+    }
+
+    enum PackageMode {
+        APPLICATION,
+        ALL
+    }
+}

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/CopilotQuarkusIntegration.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/CopilotQuarkusIntegration.java
@@ -1,0 +1,499 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ConversationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Singleton;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
+import com.vaadin.flow.server.auth.NavigationAccessControl;
+import com.vaadin.hilla.BrowserCallable;
+import com.vaadin.hilla.Endpoint;
+import com.vaadin.hilla.EndpointRegistry;
+import io.smallrye.config.SmallRyeConfig;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+/**
+ * Reflection target for Vaadin Copilot's Spring bridge in Quarkus applications.
+ */
+public final class CopilotQuarkusIntegration {
+
+    private static final String SPRING_BRIDGE = "com.vaadin.copilot.SpringBridge";
+    private static final String SERVICE_METHOD_INFO = SPRING_BRIDGE + "$ServiceMethodInfo";
+    private static final String VERSION_INFO = SPRING_BRIDGE + "$VersionInfo";
+
+    private static final List<String> HARD_EXCLUDED_PACKAGES = List.of(
+            "com.vaadin.",
+            "com.github.mcollovati.quarkus.hilla.",
+            "io.quarkus.",
+            "io.smallrye.",
+            "io.vertx.",
+            "jakarta.",
+            "javax.",
+            "org.jboss.",
+            "org.eclipse.microprofile.",
+            "org.springframework.");
+
+    private static final Set<String> DEFAULT_SCOPE_KEYS = Set.of(
+            "application", "singleton", "dependent", "vaadin-service", "vaadin-session", "vaadin-ui", "vaadin-route");
+
+    private CopilotQuarkusIntegration() {}
+
+    public static Object callSpring(String methodName, Object... args) {
+        return call(methodName, args);
+    }
+
+    public static Object callSpringSecurity(String methodName, Object... args) {
+        return call(methodName, args);
+    }
+
+    public static Object callSpringData(String methodName, Object... args) {
+        return call(methodName, args);
+    }
+
+    public static boolean isAvailable(VaadinContext context) {
+        return beanManager().isPresent();
+    }
+
+    public static Object getWebApplicationContext(VaadinContext context) {
+        return beanManager().map(QuarkusApplicationContext::new).orElse(null);
+    }
+
+    public static String getPropertyValue(VaadinContext context, String propertyName) {
+        try {
+            return ConfigProvider.getConfig()
+                    .getOptionalValue(propertyName, String.class)
+                    .orElse(null);
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    public static Class<?> getApplicationClass(VaadinContext context) {
+        CopilotApplicationMetadata metadata = CopilotApplicationMetadata.load();
+        Optional<Class<?>> configuredApplicationClass =
+                metadata.applicationClassName().flatMap(CopilotQuarkusIntegration::loadClass);
+        if (configuredApplicationClass.isPresent()) {
+            return configuredApplicationClass.get();
+        }
+        return getEndpointClasses().stream()
+                .findFirst()
+                .or(() -> discoveredBeanClasses().stream()
+                        .filter(metadata::isApplicationClass)
+                        .findFirst())
+                .orElse(CopilotQuarkusIntegration.class);
+    }
+
+    public static boolean isViewSecurityEnabled(VaadinContext context) {
+        return bean(NavigationAccessControl.class)
+                .filter(NavigationAccessControl::isEnabled)
+                .filter(accessControl -> accessControl.hasAccessChecker(AnnotatedViewAccessChecker.class))
+                .isPresent();
+    }
+
+    public static boolean isSpringSecurityEnabled(VaadinContext context) {
+        return false;
+    }
+
+    public static void setActiveSpringSecurityUser(String username, VaadinSession session) {
+        // Spring Security user switching has no Quarkus equivalent in this integration.
+    }
+
+    public static List<?> getEndpoints(VaadinContext context) {
+        return endpointRegistry()
+                .map(registry -> registry.getEndpoints().values().stream()
+                        .flatMap(endpointData -> {
+                            Object endpointObject = endpointData.getEndpointObject();
+                            Class<?> endpointClass = userClass(endpointObject);
+                            if (endpointClass == null || isVaadinInternal(endpointClass)) {
+                                return List.of().stream();
+                            }
+                            return endpointData.getMethods().values().stream()
+                                    .sorted(methodComparator())
+                                    .map(method -> serviceMethodInfo(endpointClass, method));
+                        })
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList()))
+                .orElseGet(List::of);
+    }
+
+    public static List<?> getFlowUIServices(VaadinContext context) {
+        Optional<BeanManager> beanManager = beanManager();
+        if (beanManager.isEmpty()) {
+            return List.of();
+        }
+
+        FlowServicesSettings settings = flowServicesSettings();
+        CopilotApplicationMetadata metadata = CopilotApplicationMetadata.load();
+        Set<String> endpointClassNames =
+                getEndpointClasses().stream().map(Class::getName).collect(Collectors.toSet());
+
+        Set<Class<?>> beanClasses = discoveredBeanClasses();
+        Set<Class<?>> selectedClasses = new LinkedHashSet<>();
+        for (Class<?> beanClass : beanClasses) {
+            if (isExplicitlyIncluded(beanClass, settings)) {
+                selectedClasses.add(beanClass);
+            }
+            if (settings.discovery() != CopilotConfiguration.Discovery.NONE
+                    && isAutomaticCandidate(beanManager.get(), beanClass, metadata, settings)) {
+                selectedClasses.add(beanClass);
+            }
+        }
+
+        return selectedClasses.stream()
+                .filter(beanClass -> !isHardExcluded(beanClass))
+                .filter(beanClass -> !isExplicitlyExcluded(beanClass, settings))
+                .filter(beanClass -> !endpointClassNames.contains(beanClass.getName()))
+                .filter(beanClass -> !isHillaEndpoint(beanClass))
+                .flatMap(beanClass ->
+                        publicServiceMethods(beanClass).map(method -> serviceMethodInfo(beanClass, method)))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    public static Object getVersionInfo() {
+        return springBridgeRecord(
+                VERSION_INFO,
+                new Class<?>[] {String.class, String.class},
+                "Quarkus Hilla",
+                QuarkusHillaExtension.getVersion().orElse(""));
+    }
+
+    public static boolean getJpaDatasourceInitialization(VaadinContext context) {
+        return false;
+    }
+
+    public static List<Class<?>> getJpaEntityClasses(VaadinContext context) {
+        return List.of();
+    }
+
+    public static Optional<?> getH2Info(VaadinContext context) {
+        return Optional.empty();
+    }
+
+    private static Object call(String methodName, Object... args) {
+        return switch (methodName) {
+            case "getWebApplicationContext" -> getWebApplicationContext((VaadinContext) args[0]);
+            case "getPropertyValue" -> getPropertyValue((VaadinContext) args[0], (String) args[1]);
+            case "getApplicationClass" -> getApplicationClass((VaadinContext) args[0]);
+            case "isViewSecurityEnabled" -> isViewSecurityEnabled((VaadinContext) args[0]);
+            case "getJpaDatasourceInitialization" -> getJpaDatasourceInitialization((VaadinContext) args[0]);
+            case "getEndpoints" -> getEndpoints((VaadinContext) args[0]);
+            case "getFlowUIServices" -> getFlowUIServices((VaadinContext) args[0]);
+            case "getVersionInfo" -> getVersionInfo();
+            case "isSpringSecurityEnabled" -> isSpringSecurityEnabled((VaadinContext) args[0]);
+            case "setActiveSpringSecurityUser" -> {
+                setActiveSpringSecurityUser((String) args[0], (VaadinSession) args[1]);
+                yield null;
+            }
+            case "getJpaEntityClasses" -> getJpaEntityClasses((VaadinContext) args[0]);
+            case "getH2Info" -> getH2Info((VaadinContext) args[0]);
+            default -> throw new IllegalArgumentException("Unsupported Copilot bridge method " + methodName);
+        };
+    }
+
+    private static boolean isAutomaticCandidate(
+            BeanManager beanManager,
+            Class<?> beanClass,
+            CopilotApplicationMetadata metadata,
+            FlowServicesSettings settings) {
+        if (isHardExcluded(beanClass) || isExplicitlyExcluded(beanClass, settings)) {
+            return false;
+        }
+        if (settings.packageMode() == CopilotConfiguration.PackageMode.APPLICATION
+                && !metadata.isApplicationClass(beanClass)) {
+            return false;
+        }
+        return switch (settings.discovery()) {
+            case NONE -> false;
+            case ALL -> true;
+            case SERVICES -> isServiceLikeBean(beanManager, beanClass, settings);
+        };
+    }
+
+    private static boolean isServiceLikeBean(
+            BeanManager beanManager, Class<?> beanClass, FlowServicesSettings settings) {
+        if (hasAnnotationNamed(beanClass, "org.springframework.stereotype.Service")) {
+            return true;
+        }
+        return beansForClass(beanManager, beanClass).stream()
+                .map(Bean::getScope)
+                .map(CopilotQuarkusIntegration::scopeKey)
+                .anyMatch(settings.includeScopeKeys()::contains);
+    }
+
+    private static Set<Class<?>> discoveredBeanClasses() {
+        return beanManager()
+                .map(beanManager -> beanManager.getBeans(Object.class, new AnyLiteral()).stream()
+                        .map(Bean::getBeanClass)
+                        .filter(Objects::nonNull)
+                        .map(SpringReplacements::classUtils_getUserClass)
+                        .filter(CopilotQuarkusIntegration::isDiscoverableClass)
+                        .sorted(Comparator.comparing(Class::getName))
+                        .collect(Collectors.toCollection(LinkedHashSet::new)))
+                .orElseGet(LinkedHashSet::new);
+    }
+
+    private static Set<Bean<?>> beansForClass(BeanManager beanManager, Class<?> beanClass) {
+        return beanManager.getBeans(Object.class, new AnyLiteral()).stream()
+                .filter(bean -> SpringReplacements.classUtils_getUserClass(bean.getBeanClass())
+                        .equals(beanClass))
+                .collect(Collectors.toSet());
+    }
+
+    private static Optional<EndpointRegistry> endpointRegistry() {
+        return bean(EndpointRegistry.class);
+    }
+
+    private static Set<Class<?>> getEndpointClasses() {
+        return endpointRegistry()
+                .map(registry -> registry.getEndpoints().values().stream()
+                        .map(EndpointRegistry.VaadinEndpointData::getEndpointObject)
+                        .map(CopilotQuarkusIntegration::userClass)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toCollection(LinkedHashSet::new)))
+                .orElseGet(LinkedHashSet::new);
+    }
+
+    private static <T> Optional<T> bean(Class<T> beanType) {
+        return beanManager().flatMap(beanManager -> {
+            Set<Bean<?>> beans = beanManager.getBeans(beanType, new AnyLiteral());
+            if (beans.isEmpty()) {
+                return Optional.empty();
+            }
+            Bean<?> bean = beanManager.resolve(beans);
+            CreationalContext<?> context = beanManager.createCreationalContext(bean);
+            return Optional.of(beanType.cast(beanManager.getReference(bean, beanType, context)));
+        });
+    }
+
+    private static Optional<BeanManager> beanManager() {
+        try {
+            return Optional.of(CDI.current().getBeanManager());
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static Class<?> userClass(Object object) {
+        if (object == null) {
+            return null;
+        }
+        return SpringReplacements.classUtils_getUserClass(object);
+    }
+
+    private static boolean isDiscoverableClass(Class<?> type) {
+        return type != null
+                && type != Object.class
+                && !type.isPrimitive()
+                && !type.isArray()
+                && !type.isAnnotation()
+                && !type.isEnum()
+                && !type.isAnonymousClass()
+                && !type.isLocalClass();
+    }
+
+    private static boolean isHillaEndpoint(Class<?> type) {
+        return type.isAnnotationPresent(BrowserCallable.class) || type.isAnnotationPresent(Endpoint.class);
+    }
+
+    private static boolean isVaadinInternal(Class<?> type) {
+        return type.getName().startsWith("com.vaadin.");
+    }
+
+    private static boolean isHardExcluded(Class<?> type) {
+        String className = type.getName();
+        return HARD_EXCLUDED_PACKAGES.stream().anyMatch(className::startsWith);
+    }
+
+    private static boolean isExplicitlyIncluded(Class<?> type, FlowServicesSettings settings) {
+        return settings.includeClasses().contains(type.getName()) || matchesPackage(type, settings.includePackages());
+    }
+
+    private static boolean isExplicitlyExcluded(Class<?> type, FlowServicesSettings settings) {
+        return settings.excludeClasses().contains(type.getName()) || matchesPackage(type, settings.excludePackages());
+    }
+
+    private static boolean matchesPackage(Class<?> type, Set<String> packagePrefixes) {
+        String className = type.getName();
+        String packageName = packageName(type);
+        return packagePrefixes.stream()
+                .map(String::trim)
+                .filter(prefix -> !prefix.isEmpty())
+                .anyMatch(prefix -> packageName.equals(prefix)
+                        || packageName.startsWith(prefix + ".")
+                        || className.startsWith(prefix + "."));
+    }
+
+    private static String packageName(Class<?> type) {
+        Package typePackage = type.getPackage();
+        if (typePackage != null) {
+            return typePackage.getName();
+        }
+        String className = type.getName();
+        int separator = className.lastIndexOf('.');
+        return separator > 0 ? className.substring(0, separator) : "";
+    }
+
+    private static java.util.stream.Stream<Method> publicServiceMethods(Class<?> beanClass) {
+        return Arrays.stream(beanClass.getMethods())
+                .filter(method -> Modifier.isPublic(method.getModifiers()))
+                .filter(method -> !Modifier.isStatic(method.getModifiers()))
+                .filter(method -> !method.isBridge())
+                .filter(method -> !method.isSynthetic())
+                .filter(method -> method.getDeclaringClass() != Object.class)
+                .sorted(methodComparator());
+    }
+
+    private static Comparator<Method> methodComparator() {
+        return Comparator.comparing(Method::getName)
+                .thenComparing(method -> Arrays.toString(method.getParameterTypes()));
+    }
+
+    private static Object serviceMethodInfo(Class<?> serviceClass, Method serviceMethod) {
+        return springBridgeRecord(
+                SERVICE_METHOD_INFO, new Class<?>[] {Class.class, Method.class}, serviceClass, serviceMethod);
+    }
+
+    private static Object springBridgeRecord(String className, Class<?>[] parameterTypes, Object... args) {
+        try {
+            Class<?> recordClass = SpringReplacements.class_forName(className);
+            Constructor<?> constructor = recordClass.getConstructor(parameterTypes);
+            return constructor.newInstance(args);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to create Copilot bridge record " + className, e);
+        }
+    }
+
+    private static Optional<Class<?>> loadClass(String className) {
+        try {
+            return Optional.of(SpringReplacements.class_forName(className));
+        } catch (ClassNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static boolean hasAnnotationNamed(Class<?> type, String annotationName) {
+        return Arrays.stream(type.getAnnotations())
+                .map(Annotation::annotationType)
+                .anyMatch(annotationType -> annotationType.getName().equals(annotationName));
+    }
+
+    private static String scopeKey(Class<? extends Annotation> scope) {
+        String scopeName = scope.getName();
+        if (scope == ApplicationScoped.class) {
+            return "application";
+        }
+        if (scope == Singleton.class) {
+            return "singleton";
+        }
+        if (scope == Dependent.class) {
+            return "dependent";
+        }
+        if (scope == RequestScoped.class) {
+            return "request";
+        }
+        if (scope == SessionScoped.class) {
+            return "session";
+        }
+        if (scope == ConversationScoped.class) {
+            return "conversation";
+        }
+        return switch (scopeName) {
+            case "com.vaadin.quarkus.annotation.VaadinServiceScoped" -> "vaadin-service";
+            case "com.vaadin.quarkus.annotation.VaadinSessionScoped" -> "vaadin-session";
+            case "com.vaadin.quarkus.annotation.UIScoped", "com.vaadin.quarkus.annotation.NormalUIScoped" ->
+                "vaadin-ui";
+            case "com.vaadin.quarkus.annotation.RouteScoped", "com.vaadin.quarkus.annotation.NormalRouteScoped" ->
+                "vaadin-route";
+            default -> scopeName;
+        };
+    }
+
+    private static FlowServicesSettings flowServicesSettings() {
+        try {
+            CopilotConfiguration config = ConfigProvider.getConfig()
+                    .unwrap(SmallRyeConfig.class)
+                    .getConfigMapping(CopilotConfiguration.class);
+            return new FlowServicesSettings(
+                    config.discovery(),
+                    config.packageMode(),
+                    normalizeScopeKeys(config.includeScopes()),
+                    copy(config.includePackages()),
+                    copy(config.excludePackages()),
+                    copy(config.includeClasses()),
+                    copy(config.excludeClasses()));
+        } catch (RuntimeException e) {
+            return new FlowServicesSettings(
+                    CopilotConfiguration.Discovery.SERVICES,
+                    CopilotConfiguration.PackageMode.APPLICATION,
+                    DEFAULT_SCOPE_KEYS,
+                    Set.of(),
+                    Set.of(),
+                    Set.of(),
+                    Set.of());
+        }
+    }
+
+    private static Set<String> normalizeScopeKeys(Set<String> scopeKeys) {
+        if (scopeKeys == null || scopeKeys.isEmpty()) {
+            return Set.of();
+        }
+        return scopeKeys.stream()
+                .map(scopeKey -> scopeKey.trim().toLowerCase(Locale.ROOT).replace('_', '-'))
+                .filter(scopeKey -> !scopeKey.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private static Set<String> copy(Optional<Set<String>> values) {
+        return values.orElseGet(Set::of).stream()
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private record FlowServicesSettings(
+            CopilotConfiguration.Discovery discovery,
+            CopilotConfiguration.PackageMode packageMode,
+            Set<String> includeScopeKeys,
+            Set<String> includePackages,
+            Set<String> excludePackages,
+            Set<String> includeClasses,
+            Set<String> excludeClasses) {}
+}

--- a/docs/copilot-integration.md
+++ b/docs/copilot-integration.md
@@ -1,0 +1,150 @@
+# Vaadin Copilot Integration
+
+Quarkus-Hilla supports Vaadin Copilot in development mode by adapting Copilot's Spring-oriented backend bridge to Quarkus CDI, Hilla, and Vaadin Quarkus runtime APIs.
+
+The integration is intended for application inspection, Flow view editing, Hilla endpoint discovery, and Flow UI service discovery. It does not add Spring runtime dependencies.
+
+> [!NOTE]
+> Quarkus-Hilla adapts Vaadin Copilot in development mode only. Production builds do not need Copilot-specific runtime behavior.
+
+## Supported Features
+
+- Hilla `@BrowserCallable` and `@Endpoint` discovery through the Hilla `EndpointRegistry`
+- Flow UI service discovery through Quarkus Arc bean discovery
+- Quarkus configuration property lookup
+- Vaadin route security status lookup
+- Quarkus-Hilla version reporting
+- Context-classloader-aware custom component class loading
+
+## Known Limitations
+
+> [!NOTE]
+> Java edits use Quarkus Live Reload when no JVM hotswap agent is available. The edit is applied, but Copilot may show a warning and the browser reload can take longer.
+
+- Spring Security user switching has no Quarkus equivalent in this integration.
+- Spring Data/JPA helper panels are not implemented.
+- H2 datasource helper information is not implemented.
+
+## Browser Callables
+
+Copilot browser-callable metadata is read from the Hilla `EndpointRegistry`.
+
+The integration exposes public endpoint methods from application endpoints and skips Vaadin internal endpoints under `com.vaadin.*`.
+
+Hilla endpoints are also removed from Flow UI service discovery, so Copilot does not show them twice.
+
+## Flow UI Services
+
+Flow UI services are discovered from Quarkus Arc beans. The default mode is intentionally conservative:
+
+```properties
+vaadin.copilot.flow-services.discovery=services
+vaadin.copilot.flow-services.packages=application
+vaadin.copilot.flow-services.include-scopes=application,singleton,dependent,vaadin-service,vaadin-session,vaadin-ui,vaadin-route
+```
+
+> [!NOTE]
+> Default discovery is conservative: only service-like beans from the root application archive are exposed.
+
+The default discovers service-like beans from the root application archive only. The following infrastructure packages are always excluded from automatic service discovery:
+
+- `com.vaadin.`
+- `com.github.mcollovati.quarkus.hilla.`
+- `io.quarkus.`
+- `io.smallrye.`
+- `io.vertx.`
+- `jakarta.`
+- `javax.`
+- `org.jboss.`
+- `org.eclipse.microprofile.`
+- `org.springframework.`
+
+## Discovery Modes
+
+| Mode       | Behavior                                                                 |
+|------------|--------------------------------------------------------------------------|
+| `none`     | Disable automatic discovery. Explicit includes still add matching beans. |
+| `services` | Discover service-like Arc, Vaadin-scoped, and Spring `@Service` beans.   |
+| `all`      | Discover all Arc application beans allowed by package and exclude rules. |
+
+## Package Modes
+
+| Mode          | Behavior                                                              |
+|---------------|-----------------------------------------------------------------------|
+| `application` | Limit automatic discovery to classes from the root application archive. |
+| `all`         | Allow automatic discovery from all discovered bean packages.           |
+
+Hard infrastructure excludes still apply in both modes.
+
+## Include And Exclude Overlays
+
+Include and exclude overlays are applied independently of the discovery mode.
+
+> [!IMPORTANT]
+> Include and exclude overlays always apply, independent of discovery mode. Excludes win over includes.
+
+```properties
+vaadin.copilot.flow-services.include-packages=com.example.shared
+vaadin.copilot.flow-services.exclude-packages=com.example.internal
+vaadin.copilot.flow-services.include-classes=com.example.admin.AdminFacade
+vaadin.copilot.flow-services.exclude-classes=com.example.internal.SecretFacade
+```
+
+Rules:
+
+- `include-packages` adds matching beans.
+- `include-classes` adds matching classes by fully qualified class name.
+- `exclude-packages` removes matching beans.
+- `exclude-classes` removes matching classes by fully qualified class name.
+- Exclude wins over include.
+
+## Scope Keys
+
+`vaadin.copilot.flow-services.include-scopes` accepts normalized scope keys.
+
+Built-in keys:
+
+| Key               | Scope annotations                                                              |
+|-------------------|--------------------------------------------------------------------------------|
+| `application`     | `jakarta.enterprise.context.ApplicationScoped`                                 |
+| `singleton`       | `jakarta.inject.Singleton`                                                     |
+| `dependent`       | `jakarta.enterprise.context.Dependent`                                         |
+| `request`         | `jakarta.enterprise.context.RequestScoped`                                     |
+| `session`         | `jakarta.enterprise.context.SessionScoped`                                     |
+| `conversation`    | `jakarta.enterprise.context.ConversationScoped`                                |
+| `vaadin-service`  | `com.vaadin.quarkus.annotation.VaadinServiceScoped`                            |
+| `vaadin-session`  | `com.vaadin.quarkus.annotation.VaadinSessionScoped`                            |
+| `vaadin-ui`       | `com.vaadin.quarkus.annotation.UIScoped`, `NormalUIScoped`                     |
+| `vaadin-route`    | `com.vaadin.quarkus.annotation.RouteScoped`, `NormalRouteScoped`               |
+
+> [!WARNING]
+> Custom CDI scope annotations are not discovered through `include-scopes` yet. Use `include-packages` or `include-classes` for those beans.
+
+## Runtime Bridge
+
+Vaadin Copilot calls internal Spring bridge methods. Quarkus-Hilla rewrites those calls at build time so they target `CopilotQuarkusIntegration` instead.
+
+> [!NOTE]
+> Bytecode transformers use string-based targets so Quarkus-Hilla does not require Copilot at compile time.
+
+The bridge provides safe Quarkus implementations for:
+
+- application context lookup
+- configuration property lookup
+- application class lookup
+- route security status
+- endpoint methods
+- Flow UI service methods
+- version information
+
+Unsupported Spring-specific methods return safe defaults.
+
+## Bytecode Patches
+
+The build-time transformer redirects Copilot calls without requiring Copilot at compile time.
+
+Patched areas:
+
+- `SpringBridge.callSpring*` calls are redirected to `CopilotQuarkusIntegration`.
+- `SpringBridge.isSpringAvailable(VaadinContext)` is redirected so Copilot enables Flow UI services in Quarkus.
+- `CustomComponents.isCustomComponent(String)` uses the context classloader aware class lookup from `SpringReplacements`.

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -20,6 +20,7 @@
         <awaitility.version>4.3.0</awaitility.version>
         <selenide.version>7.16.2</selenide.version>
         <selenide.browser>chrome</selenide.browser>
+        <vaadin.copilot.enable>false</vaadin.copilot.enable>
 
         <!--
             By default, skips Hilla plugin execution to prevent build errors for modules
@@ -93,6 +94,7 @@
                     <configuration>
                         <systemProperties>
                             <vaadin.build.enabled>${vaadin.build.enabled}</vaadin.build.enabled>
+                            <vaadin.copilot.enable>${vaadin.copilot.enable}</vaadin.copilot.enable>
                         </systemProperties>
                     </configuration>
                 </plugin>
@@ -118,6 +120,7 @@
                         <selenide.downloadsFolder>${project.build.directory}/selenide/downloads
                         </selenide.downloadsFolder>
                         <selenide.browser>${selenide.browser}</selenide.browser>
+                        <vaadin.copilot.enable>${vaadin.copilot.enable}</vaadin.copilot.enable>
                         <vaadin.reuseDevServer>false</vaadin.reuseDevServer>
                     </systemPropertyVariables>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
@@ -143,6 +146,7 @@
                                 <selenide.downloadsFolder>${project.build.directory}/selenide/downloads
                                 </selenide.downloadsFolder>
                                 <selenide.browser>${selenide.browser}</selenide.browser>
+                                <vaadin.copilot.enable>${vaadin.copilot.enable}</vaadin.copilot.enable>
                             </systemPropertyVariables>
                             <forkNode
                                     implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>

--- a/integration-tests/react-smoke-tests/pom.xml
+++ b/integration-tests/react-smoke-tests/pom.xml
@@ -53,6 +53,9 @@
                     <value>development</value>
                 </property>
             </activation>
+            <properties>
+                <vaadin.copilot.enable>true</vaadin.copilot.enable>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>com.vaadin</groupId>

--- a/integration-tests/react-smoke-tests/src/test/java/com/example/application/CopilotClickabilityTest.java
+++ b/integration-tests/react-smoke-tests/src/test/java/com/example/application/CopilotClickabilityTest.java
@@ -36,11 +36,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @Tag("development-only")
 class CopilotClickabilityTest extends AbstractTest {
 
-    @Override
-    protected boolean copilotEnabled() {
-        return true;
-    }
-
     @Test
     void copilotEnabled_rootViewControlsStayClickable() {
         assumeTrue("development".equals(System.getProperty("quarkus-hilla.test-mode")));

--- a/integration-tests/test-commons/src/main/java/com/github/mcollovati/quarkus/testing/AbstractTest.java
+++ b/integration-tests/test-commons/src/main/java/com/github/mcollovati/quarkus/testing/AbstractTest.java
@@ -58,9 +58,6 @@ public abstract class AbstractTest {
             System.setProperty("chromeoptions.args", "--remote-allow-origins=*");
         }
         Configuration.fastSetValue = true;
-
-        // Disable Copilot by default because it slows down page load because of license checking.
-        System.setProperty("vaadin.copilot.enable", Boolean.toString(copilotEnabled()));
     }
 
     protected final String getBaseURL() {
@@ -121,10 +118,6 @@ public abstract class AbstractTest {
 
     protected boolean runHeadless() {
         return !isJavaInDebugMode();
-    }
-
-    protected boolean copilotEnabled() {
-        return false;
     }
 
     static boolean isJavaInDebugMode() {


### PR DESCRIPTION
## Summary
- Expose Hilla `@BrowserCallable` / `@Endpoint` metadata to Vaadin Copilot through Quarkus-Hilla runtime APIs.
- Add Flow UI service discovery from Arc beans with `vaadin.copilot.flow-services.*` configuration.
- Patch Copilot Spring bridge calls and custom component class loading without making Copilot a compile-time requirement.
- Document supported behavior, limitations, and configuration for `25.1.2`.

## Tests
- `mvn spotless:apply -Pall-modules`
- `mvn -pl commons/runtime,commons/deployment -Dtest=*Copilot*Test -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check HEAD~1..HEAD`

## Follow-ups
- #133: Flow Java hot reload / hotswap support.
- #2132: Copilot Data and JPA helper support for Quarkus.
- #2133: Copilot Spring Security user switching for Quarkus.
- #2134: Copilot compatibility with Quarkus Spring extensions.

Closes #1913