### PR TITLE
chore(deps): bump 25.1 dependencies

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -18,7 +18,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
 
         <awaitility.version>4.3.0</awaitility.version>
-        <selenide.version>7.16.0</selenide.version>
+        <selenide.version>7.16.2</selenide.version>
         <selenide.browser>chrome</selenide.browser>
         <vaadin.copilot.enable>false</vaadin.copilot.enable>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,14 +42,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <quarkus.version>3.35.1</quarkus.version>
+        <quarkus.version>3.35.4</quarkus.version>
         <!--
             For backward compatibility of GH actions workflows
             To be removed in the future
         -->
-        <hilla.version>25.1-SNAPSHOT</hilla.version>
-        <flow.version>${hilla.version}</flow.version>
-        <vaadin.version>${hilla.version}</vaadin.version>
+        <hilla.version>25.1.7</hilla.version>
+        <flow.version>25.1.11</flow.version>
+        <vaadin.version>25.1.8</vaadin.version>
 
         <!--
         <jackson.version>2.18.1</jackson.version>


### PR DESCRIPTION
## Summary
- bump Hilla 25.1-SNAPSHOT -> 25.1.7, Flow 25.1-SNAPSHOT -> 25.1.11, Vaadin 25.1-SNAPSHOT -> 25.1.8
- bump Selenide 7.16.0 -> 7.16.2
- bump Quarkus patch-only: 3.35.1 -> 3.35.4; Maven Central metadata currently shows 3.35.4 as latest 3.35.x patch

## Superseded PRs
- #2125
- #2127
- #2128
- #2129

## Not included
- #2126: Quarkus minor bump; branch stays on existing 3.35 line

## Validation
- mvn -V -e -B -ntp -DskipTests -Dmaven.javadoc.skip=false install