### PR TITLE
chore(deps): bump 25.0 dependencies

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -18,7 +18,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
 
         <awaitility.version>4.3.0</awaitility.version>
-        <selenide.version>7.14.0</selenide.version>
+        <selenide.version>7.16.2</selenide.version>
 
         <!--
             By default, skips Hilla plugin execution to prevent build errors for modules

--- a/pom.xml
+++ b/pom.xml
@@ -42,14 +42,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <quarkus.version>3.31.2</quarkus.version>
+        <quarkus.version>3.31.4</quarkus.version>
         <!--
             For backward compatibility of GH actions workflows
             To be removed in the future
         -->
-        <hilla.version>25.0.6</hilla.version>
-        <flow.version>25.0.12</flow.version>
-        <vaadin.version>25.0.8</vaadin.version>
+        <hilla.version>25.0.13</hilla.version>
+        <flow.version>25.0.14</flow.version>
+        <vaadin.version>25.0.12</vaadin.version>
 
         <!--
         <jackson.version>2.18.1</jackson.version>
@@ -74,7 +74,7 @@
         <jreleaser-maven-plugin.version>1.23.0</jreleaser-maven-plugin.version>
         <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
-        <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
+        <spotless-maven-plugin.version>3.6.0</spotless-maven-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
 
     </properties>


### PR DESCRIPTION
## Summary
- bump Hilla 25.0.6 -> 25.0.13, Flow 25.0.12 -> 25.0.14, Vaadin 25.0.8 -> 25.0.12
- bump Selenide 7.14.0 -> 7.16.2, Spotless 3.4.0 -> 3.6.0
- bump Quarkus patch-only: 3.31.2 -> 3.31.4; Maven Central metadata currently shows 3.31.4 as latest 3.31.x patch

## Superseded PRs
- #2055
- #2092
- #2095
- #2114
- #2115

## Validation
- mvn -V -e -B -ntp -DskipTests -Dmaven.javadoc.skip=false install