### PR TITLE
chore(deps): bump 24.9 dependencies

### DIFF
--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/vaadinplugin/VaadinPlugin.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/vaadinplugin/VaadinPlugin.java
@@ -18,7 +18,6 @@ package com.github.mcollovati.quarkus.hilla.deployment.vaadinplugin;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.TimeoutException;
 
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.dependency.JavaScript;
@@ -120,7 +119,7 @@ public final class VaadinPlugin {
                 && BundleValidationUtil.needsBundleBuild(pluginAdapter.servletResourceOutputDirectory())) {
             try {
                 BuildFrontendUtil.runFrontendBuild(pluginAdapter);
-            } catch (URISyntaxException | TimeoutException exception) {
+            } catch (URISyntaxException exception) {
                 throw new BuildException(exception.getMessage(), exception, List.of());
             }
         }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -18,7 +18,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
 
         <awaitility.version>4.3.0</awaitility.version>
-        <selenide.version>7.15.1</selenide.version>
+        <selenide.version>7.16.2</selenide.version>
 
         <!--
             By default, skips Hilla plugin execution to prevent build errors for modules

--- a/pom.xml
+++ b/pom.xml
@@ -42,14 +42,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <quarkus.version>3.32.3</quarkus.version>
+        <quarkus.version>3.32.4</quarkus.version>
         <!--
             For backward compatibility of GH actions workflows
             To be removed in the future
         -->
-        <hilla.version>24.9.3</hilla.version>
-        <flow.version>24.9.15</flow.version>
-        <vaadin.version>24.9.17</vaadin.version>
+        <hilla.version>24.9.18</hilla.version>
+        <flow.version>24.9.21</flow.version>
+        <vaadin.version>24.9.18</vaadin.version>
         <vaadin.quarkus.version>2.2.4</vaadin.quarkus.version>
 
         <!--
@@ -59,7 +59,7 @@
 
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <maven-failsafe-plugin.version>3.5.5</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
         <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
         <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
@@ -71,7 +71,7 @@
         <jreleaser-maven-plugin.version>1.24.0</jreleaser-maven-plugin.version>
         <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
-        <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
+        <spotless-maven-plugin.version>3.6.0</spotless-maven-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
 
     </properties>


### PR DESCRIPTION
## Summary
- bump Hilla 24.9.3 -> 24.9.18, Flow 24.9.15 -> 24.9.21, Vaadin 24.9.17 -> 24.9.18
- bump Selenide 7.15.1 -> 7.16.2, Failsafe 3.5.5 -> 3.5.6, Spotless 3.4.0 -> 3.6.0
- bump Quarkus patch-only: 3.32.3 -> 3.32.4; Maven Central metadata currently shows 3.32.4 as latest 3.32.x patch
- adjust VaadinPlugin for Flow 24.9.19+ frontend build API signature

## Superseded PRs
- #2101
- #2111
- #2118
- #2119

## Not included
- #2117: Quarkus minor bump; branch stays on existing 3.32 line

## Validation
- mvn -V -e -B -ntp -DskipTests -Dmaven.javadoc.skip=false install