### PR TITLE
test(signals): work around Hilla subscription leak

### DIFF
--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SignalsSecurityTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/SignalsSecurityTest.java
@@ -205,7 +205,15 @@ class SignalsSecurityTest {
                 .build();
         try (Session ignored = ContainerProvider.getWebSocketContainer().connectToServer(client, cec, connectURI)) {
             client.assertMessageReceived(10, TimeUnit.SECONDS, "CONNECT");
-            consumer.accept(client, clientSignalId);
+            try {
+                consumer.accept(client, clientSignalId);
+            } finally {
+                // Work around https://github.com/vaadin/hilla/issues/5722
+                // until https://github.com/mcollovati/quarkus-hilla/issues/2140:
+                // closing the websocket can leave Hilla signal subscribers active
+                // long enough for the next server-side reset to emit a null command.
+                client.cancel();
+            }
         } catch (Exception e) {
             Assertions.fail("PUSH communication failed", e);
         }


### PR DESCRIPTION
## Summary

Adds an explicit unsubscribe for `HillaPushClient` in `SignalsSecurityTest` before the websocket session is closed.

This keeps the security coverage enabled while working around an upstream Hilla full-stack signals bug where a lingering subscriber can receive a `null` command after a later server-side `SharedNumberSignal.set(...)` reset.

## Tracking

- Upstream bug: https://github.com/vaadin/hilla/issues/5722
- Local cleanup tracker: https://github.com/mcollovati/quarkus-hilla/issues/2140

## Validation

- `git diff --check`

Focused Maven verification was attempted earlier, but this local worktree had stale target output from the Hilla 25.2.0 override investigation. A clean test run should be used before merge.
