### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <quarkus.version>3.36.0</quarkus.version>
+        <quarkus.version>3.36.3</quarkus.version>
         <!--
             For backward compatibility of GH actions workflows
             To be removed in the future
@@ -60,8 +60,8 @@
 
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
-        <maven-failsafe-plugin.version>3.5.5</maven-failsafe-plugin.version>
-        <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
+        <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
+        <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
         <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
@@ -71,7 +71,7 @@
         <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <versions-maven-plugin.version>2.16.1</versions-maven-plugin.version>
-        <jandex-maven-plugin.version>3.5.3</jandex-maven-plugin.version>
+        <jandex-maven-plugin.version>3.6.0</jandex-maven-plugin.version>
         <jreleaser-maven-plugin.version>1.24.0</jreleaser-maven-plugin.version>
         <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>


### PR DESCRIPTION
## Changes
- Bump Quarkus from 3.36.0 to 3.36.3.
- Bump Jandex Maven Plugin from 3.5.3 to 3.6.0.
- Bump Maven Failsafe Plugin from 3.5.5 to 3.5.6.
- Bump Maven Dependency Plugin from 3.10.0 to 3.11.0.

## Supersedes
- #2121
- #2120
- #2113
- #2109

## Not included
- #2130 Spotless 3.7.0, because E2E checks are failing.
- #2096 npm dependencies, because the PR is still open and conflicted.
- Quarkus 3.37.0, to keep this on the latest 3.36 patch for the 25.2 release prep.

## Validation
- mvn -B -ntp -Dmaven.repo.local=/tmp/quarkus-hilla-m2-main-deps -DskipTests -Dmaven.javadoc.skip=false install