### PR TITLE
chore(deps): bump dependencies (25.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <versions-maven-plugin.version>2.16.1</versions-maven-plugin.version>
         <jandex-maven-plugin.version>3.6.0</jandex-maven-plugin.version>
-        <jreleaser-maven-plugin.version>1.24.0</jreleaser-maven-plugin.version>
+        <jreleaser-maven-plugin.version>1.25.0</jreleaser-maven-plugin.version>
         <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
         <spotless-maven-plugin.version>3.8.0</spotless-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <jreleaser-maven-plugin.version>1.24.0</jreleaser-maven-plugin.version>
         <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
-        <spotless-maven-plugin.version>3.7.0</spotless-maven-plugin.version>
+        <spotless-maven-plugin.version>3.8.0</spotless-maven-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
 
     </properties>


### PR DESCRIPTION
## Summary
- update `25.2` with dependency updates already merged to `main`

## Included commits
- `23b85f1f` chore(deps-dev): bump com.diffplug.spotless:spotless-maven-plugin (#2153)
- `b4b4971a` chore(deps): bump org.jreleaser:jreleaser-maven-plugin (#2155)

## Validation
- not run locally; changes already passed on `main`, PR checks run on `25.2`