### PR TITLE
chore(deps): align JUnit test runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         -->
         <jakarta.ee.version>11.0.0</jakarta.ee.version>
         <assertj.version>3.27.7</assertj.version>
+        <junit.version>6.1.1</junit.version>
         <jspecify.version>1.0.0</jspecify.version>
 
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -81,6 +82,17 @@
     </properties>
     <dependencyManagement>
         <dependencies>
+            <!--
+            Align JUnit test runtime with Vaadin-managed JUnit Jupiter.
+            Quarkus may otherwise manage JUnit Platform to an incompatible version.
+            -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!--
             Pin Jakarta EE API until Vaadin updates to Jakarta EE 11
             -->


### PR DESCRIPTION
## Summary
- import `org.junit:junit-bom` at `6.1.1`
- align JUnit Jupiter, Platform, Engine, and Launcher versions for the test runtime
- fix the Quarkus 3.37 validation failure where `junit-jupiter-api` stayed on `6.0.3` while Engine/Platform resolved to `6.1.0`

## Why
Quarkus 3.37 validation currently fails during JUnit test discovery with:

- `org.junit.jupiter.api: 6.0.3`
- `org.junit.jupiter.engine: 6.1.0`
- `org.junit.platform.commons: 6.1.0`
- `org.junit.platform.engine: 6.1.0`
- `org.junit.platform.launcher: 6.1.0`

Using the complete JUnit BOM keeps the JUnit modules aligned instead of pinning only one artifact and risking another split later.

This is separate from the Hilla signals subscription leak tracked in #2140 / vaadin/hilla#5722. That issue affected `SignalsSecurityTest`; this PR addresses the JUnit classpath alignment failure seen in the Quarkus 3.37 dependency PRs.

## Validation
- `git diff --check`
- `mvn -B -ntp spotless:check -Pall-modules`
- `mvn -B -ntp -Dquarkus.version=3.37.0 -pl :quarkus-hilla-smoke-tests -am -DincludeGroupIds=org.junit.jupiter,org.junit.platform -Dverbose dependency:tree -DskipTests -Pit-tests | rg "org\\.junit\\.(jupiter|platform)"`
  - resolved JUnit Jupiter and Platform artifacts to `6.1.1`
- `mvn -B -ntp -Dquarkus.version=3.37.0 -pl :quarkus-hilla-smoke-tests -am test -Pit-tests -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -DtrimStackTrace=false`
- `mvn -B -ntp -Dquarkus.version=3.37.0 -pl :quarkus-hilla-smoke-tests -am verify -Pit-tests -DskipITs=false -Dmaven.javadoc.skip=false -DtrimStackTrace=false -Dselenide.headless=true`
  - passed JUnit discovery and started Quarkus 3.37 / Failsafe ITs
  - failed later in local macOS Safari UI assertions (`SmokeNativeIT` / `PushNativeIT`), unrelated to the original JUnit classpath alignment error
