### PR TITLE
test(signals): wait for server fetch updates

### DIFF
--- a/integration-tests/custom-prefix-tests/src/test/java/com/example/application/SignalsTest.java
+++ b/integration-tests/custom-prefix-tests/src/test/java/com/example/application/SignalsTest.java
@@ -48,16 +48,18 @@ public class SignalsTest extends AbstractTest {
     public void shouldUpdateValue_both_on_browser_and_server() {
         for (int i = 0; i < 5; i++) {
             var currentSharedValue = getSharedValue();
+            var expectedSharedValue = currentSharedValue + 2;
             clickButton("increaseSharedValue");
-            assertEquals(currentSharedValue + 2, getSharedValue(), 0.0);
-            assertEquals(getSharedValue(), fetchSharedValue(), 0.0);
+            assertEquals(expectedSharedValue, getSharedValue(), 0.0);
+            assertSharedValueFromServer(expectedSharedValue);
         }
 
         for (int i = 0; i < 5; i++) {
             var currentCounterValue = getCounterValue();
+            var expectedCounterValue = currentCounterValue + 1;
             clickButton("incrementCounter");
-            assertEquals(currentCounterValue + 1, getCounterValue());
-            assertEquals(getCounterValue(), fetchCounterValue());
+            assertEquals(expectedCounterValue, getCounterValue());
+            assertCounterValueFromServer(expectedCounterValue);
         }
     }
 
@@ -126,11 +128,27 @@ public class SignalsTest extends AbstractTest {
                 .getText());
     }
 
+    private void assertSharedValueFromServer(double expectedValue) {
+        var actualValue = Wait().until(d -> {
+            var value = fetchSharedValue();
+            return value == expectedValue ? value : null;
+        });
+        assertEquals(expectedValue, actualValue, 0.0);
+    }
+
     private long fetchCounterValue() {
         clickButton("fetchCounterValue");
         return Long.parseLong($("span[id=\"counterValueFromServer\"]")
                 .shouldNotBe(Condition.empty)
                 .getText());
+    }
+
+    private void assertCounterValueFromServer(long expectedValue) {
+        var actualValue = Wait().until(d -> {
+            var value = fetchCounterValue();
+            return value == expectedValue ? value : null;
+        });
+        assertEquals(expectedValue, actualValue);
     }
 
     private void clickButton(String id) {

--- a/integration-tests/react-smoke-tests/src/test/java/com/example/application/SignalsTest.java
+++ b/integration-tests/react-smoke-tests/src/test/java/com/example/application/SignalsTest.java
@@ -49,16 +49,18 @@ public class SignalsTest extends AbstractTest {
     public void shouldUpdateValue_both_on_browser_and_server() {
         for (int i = 0; i < 5; i++) {
             var currentSharedValue = getSharedValue();
+            var expectedSharedValue = currentSharedValue + 2;
             clickButton("increaseSharedValue");
-            assertEquals(currentSharedValue + 2, getSharedValue(), 0.0);
-            assertEquals(getSharedValue(), fetchSharedValue(), 0.0);
+            assertEquals(expectedSharedValue, getSharedValue(), 0.0);
+            assertSharedValueFromServer(expectedSharedValue);
         }
 
         for (int i = 0; i < 5; i++) {
             var currentCounterValue = getCounterValue();
+            var expectedCounterValue = currentCounterValue + 1;
             clickButton("incrementCounter");
-            assertEquals(currentCounterValue + 1, getCounterValue());
-            assertEquals(getCounterValue(), fetchCounterValue());
+            assertEquals(expectedCounterValue, getCounterValue());
+            assertCounterValueFromServer(expectedCounterValue);
         }
     }
 
@@ -131,11 +133,27 @@ public class SignalsTest extends AbstractTest {
                 .getText());
     }
 
+    private void assertSharedValueFromServer(double expectedValue) {
+        var actualValue = Wait().until(d -> {
+            var value = fetchSharedValue();
+            return value == expectedValue ? value : null;
+        });
+        assertEquals(expectedValue, actualValue, 0.0);
+    }
+
     private long fetchCounterValue() {
         clickButton("fetchCounterValue");
         return Long.parseLong($("span[id=\"counterValueFromServer\"]")
                 .shouldNotBe(Condition.empty)
                 .getText());
+    }
+
+    private void assertCounterValueFromServer(long expectedValue) {
+        var actualValue = Wait().until(d -> {
+            var value = fetchCounterValue();
+            return value == expectedValue ? value : null;
+        });
+        assertEquals(expectedValue, actualValue);
     }
 
     private void clickButton(String id) {


### PR DESCRIPTION
## Summary
- wait until server-side fetch buttons observe the expected Signals value after client-side signal updates
- apply the same stabilization to React smoke and custom-prefix Signals tests

## Validation
- `git diff --check`
- `mvn -Pall-modules -pl :quarkus-hilla-custom-prefix-tests,:quarkus-hilla-react-smoke-tests spotless:check -ntp`
- `mvn -V -e -B -ntp verify -pl :quarkus-hilla-custom-prefix-tests -Dmaven.javadoc.skip=false -DtrimStackTrace=false -Pit-tests,production,embedded-plugin -Dvaadin.build.enabled=true -Dselenide.browser=chrome -Dselenide.browserBinary='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' -Dit.test=SignalsNativeIT`
