### PR TITLE
test(signals): stabilize signal update assertions

### DIFF
--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/signals/SecureNumberSignalService.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/signals/SecureNumberSignalService.java
@@ -25,8 +25,8 @@ import com.vaadin.hilla.BrowserCallable;
 @BrowserCallable
 public class SecureNumberSignalService {
 
-    private final SharedNumberSignal userCounter = new SharedNumberSignal(20d);
-    private final SharedNumberSignal adminCounter = new SharedNumberSignal(30d);
+    private volatile SharedNumberSignal userCounter = new SharedNumberSignal(20d);
+    private volatile SharedNumberSignal adminCounter = new SharedNumberSignal(30d);
 
     @PermitAll
     public SharedNumberSignal userCounter() {
@@ -40,7 +40,8 @@ public class SecureNumberSignalService {
 
     @AnonymousAllowed
     public void resetCounters() {
-        userCounter.set(20d);
-        adminCounter.set(30d);
+        // Avoid emitting reset commands into stale subscribers left by Hilla issue #5722.
+        userCounter = new SharedNumberSignal(20d);
+        adminCounter = new SharedNumberSignal(30d);
     }
 }

--- a/integration-tests/custom-prefix-tests/src/test/java/com/example/application/SignalsTest.java
+++ b/integration-tests/custom-prefix-tests/src/test/java/com/example/application/SignalsTest.java
@@ -27,6 +27,7 @@ import org.openqa.selenium.WindowType;
 
 import com.github.mcollovati.quarkus.testing.AbstractTest;
 
+import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.id;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selenide.$;
@@ -48,16 +49,20 @@ public class SignalsTest extends AbstractTest {
     public void shouldUpdateValue_both_on_browser_and_server() {
         for (int i = 0; i < 5; i++) {
             var currentSharedValue = getSharedValue();
+            var expectedSharedValue = currentSharedValue + 2;
             clickButton("increaseSharedValue");
-            assertEquals(currentSharedValue + 2, getSharedValue(), 0.0);
-            assertEquals(getSharedValue(), fetchSharedValue(), 0.0);
+            waitUntilSharedValue(expectedSharedValue);
+            assertEquals(expectedSharedValue, getSharedValue(), 0.0);
+            assertEquals(expectedSharedValue, fetchSharedValue(expectedSharedValue), 0.0);
         }
 
         for (int i = 0; i < 5; i++) {
             var currentCounterValue = getCounterValue();
+            var expectedCounterValue = currentCounterValue + 1;
             clickButton("incrementCounter");
-            assertEquals(currentCounterValue + 1, getCounterValue());
-            assertEquals(getCounterValue(), fetchCounterValue());
+            waitUntilCounterValue(expectedCounterValue);
+            assertEquals(expectedCounterValue, getCounterValue());
+            assertEquals(expectedCounterValue, fetchCounterValue(expectedCounterValue));
         }
     }
 
@@ -92,16 +97,18 @@ public class SignalsTest extends AbstractTest {
             // press reset button on the second window
             secondWindowDriver.findElement(By.id("reset")).click();
 
-            secondWindowSharedValue = Double.parseDouble(
-                    secondWindowDriver.findElement(By.id("sharedValue")).getText());
+            waitUntilSharedValue(0.5);
+            secondWindowSharedValue = getSharedValue();
             assertEquals(0.5, secondWindowSharedValue, 0.0);
 
-            secondWindowCounterValue = Long.parseLong(
-                    secondWindowDriver.findElement(By.id("counter")).getText());
+            waitUntilCounterValue(0);
+            secondWindowCounterValue = getCounterValue();
             assertEquals(0, secondWindowCounterValue);
 
             // check that the first window is also updated:
             Selenide.switchTo().window(firstWindowHandle);
+            waitUntilSharedValue(0.5);
+            waitUntilCounterValue(0);
             assertEquals(0.5, getSharedValue(), 0.0);
             assertEquals(0, getCounterValue());
 
@@ -119,21 +126,39 @@ public class SignalsTest extends AbstractTest {
         return Long.parseLong($(By.id("counter")).shouldNotBe(Condition.empty).getText());
     }
 
-    private double fetchSharedValue() {
-        clickButton("fetchSharedValue");
-        return Double.parseDouble($("span[id=\"sharedValueFromServer\"]")
-                .shouldNotBe(Condition.empty)
-                .getText());
+    private void waitUntilSharedValue(double expectedValue) {
+        $(By.id("sharedValue")).shouldHave(exactText(Double.toString(expectedValue)), Duration.ofSeconds(10));
     }
 
-    private long fetchCounterValue() {
-        clickButton("fetchCounterValue");
-        return Long.parseLong($("span[id=\"counterValueFromServer\"]")
-                .shouldNotBe(Condition.empty)
-                .getText());
+    private void waitUntilCounterValue(long expectedValue) {
+        $(By.id("counter")).shouldHave(exactText(Long.toString(expectedValue)), Duration.ofSeconds(10));
+    }
+
+    private double fetchSharedValue(double expectedValue) {
+        return Wait().withTimeout(Duration.ofSeconds(10)).until(driver -> {
+            clickButton("fetchSharedValue");
+            var fetchedValue = Double.parseDouble($("span[id=\"sharedValueFromServer\"]")
+                    .shouldNotBe(Condition.empty)
+                    .getText());
+            return Double.compare(fetchedValue, expectedValue) == 0 ? fetchedValue : null;
+        });
+    }
+
+    private long fetchCounterValue(long expectedValue) {
+        return Wait().withTimeout(Duration.ofSeconds(10)).until(driver -> {
+            clickButton("fetchCounterValue");
+            var fetchedValue = Long.parseLong($("span[id=\"counterValueFromServer\"]")
+                    .shouldNotBe(Condition.empty)
+                    .getText());
+            return fetchedValue == expectedValue ? fetchedValue : null;
+        });
     }
 
     private void clickButton(String id) {
-        $$("vaadin-button").findBy(id(id)).click();
+        $$("vaadin-button")
+                .findBy(id(id))
+                .shouldBe(Condition.visible, Duration.ofSeconds(10))
+                .shouldBe(Condition.enabled)
+                .click();
     }
 }

--- a/integration-tests/react-smoke-tests/src/test/java/com/example/application/SignalsTest.java
+++ b/integration-tests/react-smoke-tests/src/test/java/com/example/application/SignalsTest.java
@@ -28,6 +28,7 @@ import org.openqa.selenium.WindowType;
 
 import com.github.mcollovati.quarkus.testing.AbstractTest;
 
+import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.id;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selenide.$;
@@ -49,16 +50,20 @@ public class SignalsTest extends AbstractTest {
     public void shouldUpdateValue_both_on_browser_and_server() {
         for (int i = 0; i < 5; i++) {
             var currentSharedValue = getSharedValue();
+            var expectedSharedValue = currentSharedValue + 2;
             clickButton("increaseSharedValue");
-            assertEquals(currentSharedValue + 2, getSharedValue(), 0.0);
-            assertEquals(getSharedValue(), fetchSharedValue(), 0.0);
+            waitUntilSharedValue(expectedSharedValue);
+            assertEquals(expectedSharedValue, getSharedValue(), 0.0);
+            assertEquals(expectedSharedValue, fetchSharedValue(expectedSharedValue), 0.0);
         }
 
         for (int i = 0; i < 5; i++) {
             var currentCounterValue = getCounterValue();
+            var expectedCounterValue = currentCounterValue + 1;
             clickButton("incrementCounter");
-            assertEquals(currentCounterValue + 1, getCounterValue());
-            assertEquals(getCounterValue(), fetchCounterValue());
+            waitUntilCounterValue(expectedCounterValue);
+            assertEquals(expectedCounterValue, getCounterValue());
+            assertEquals(expectedCounterValue, fetchCounterValue(expectedCounterValue));
         }
     }
 
@@ -95,16 +100,18 @@ public class SignalsTest extends AbstractTest {
             // press reset button on the second window
             secondWindowDriver.findElement(By.id("reset")).click();
 
-            secondWindowSharedValue = Double.parseDouble(
-                    secondWindowDriver.findElement(By.id("sharedValue")).getText());
+            waitUntilSharedValue(0.5);
+            secondWindowSharedValue = getSharedValue();
             assertEquals(0.5, secondWindowSharedValue, 0.0);
 
-            secondWindowCounterValue = Long.parseLong(
-                    secondWindowDriver.findElement(By.id("counter")).getText());
+            waitUntilCounterValue(0);
+            secondWindowCounterValue = getCounterValue();
             assertEquals(0, secondWindowCounterValue);
 
             // check that the first window is also updated:
             Selenide.switchTo().window(firstWindowHandle);
+            waitUntilSharedValue(0.5);
+            waitUntilCounterValue(0);
             assertEquals(0.5, getSharedValue(), 0.0);
             assertEquals(0, getCounterValue());
         } finally {
@@ -124,21 +131,39 @@ public class SignalsTest extends AbstractTest {
         return Long.parseLong($(By.id("counter")).shouldNotBe(Condition.empty).getText());
     }
 
-    private double fetchSharedValue() {
-        clickButton("fetchSharedValue");
-        return Double.parseDouble($("span[id=\"sharedValueFromServer\"]")
-                .shouldNotBe(Condition.empty)
-                .getText());
+    private void waitUntilSharedValue(double expectedValue) {
+        $(By.id("sharedValue")).shouldHave(exactText(Double.toString(expectedValue)), Duration.ofSeconds(10));
     }
 
-    private long fetchCounterValue() {
-        clickButton("fetchCounterValue");
-        return Long.parseLong($("span[id=\"counterValueFromServer\"]")
-                .shouldNotBe(Condition.empty)
-                .getText());
+    private void waitUntilCounterValue(long expectedValue) {
+        $(By.id("counter")).shouldHave(exactText(Long.toString(expectedValue)), Duration.ofSeconds(10));
+    }
+
+    private double fetchSharedValue(double expectedValue) {
+        return Wait().withTimeout(Duration.ofSeconds(10)).until(driver -> {
+            clickButton("fetchSharedValue");
+            var fetchedValue = Double.parseDouble($("span[id=\"sharedValueFromServer\"]")
+                    .shouldNotBe(Condition.empty)
+                    .getText());
+            return Double.compare(fetchedValue, expectedValue) == 0 ? fetchedValue : null;
+        });
+    }
+
+    private long fetchCounterValue(long expectedValue) {
+        return Wait().withTimeout(Duration.ofSeconds(10)).until(driver -> {
+            clickButton("fetchCounterValue");
+            var fetchedValue = Long.parseLong($("span[id=\"counterValueFromServer\"]")
+                    .shouldNotBe(Condition.empty)
+                    .getText());
+            return fetchedValue == expectedValue ? fetchedValue : null;
+        });
     }
 
     private void clickButton(String id) {
-        $$("vaadin-button").findBy(id(id)).click();
+        $$("vaadin-button")
+                .findBy(id(id))
+                .shouldBe(Condition.visible, Duration.ofSeconds(10))
+                .shouldBe(Condition.enabled)
+                .click();
     }
 }


### PR DESCRIPTION
## Summary
- Replace the security test signals during reset so stale Hilla subscribers do not receive reset commands from a reused signal instance.
- Wait for browser-side signal propagation before asserting values.
- Retry server-side fetches until the propagated signal value is visible.
- Apply the same timing guard to custom-prefix and React smoke signal tests.

## Context
This targets the race seen in the 25.3 upgrade PR embedded-plugin job: `SignalsNativeIT.shouldUpdateValue_both_on_browser_and_server` in `quarkus-hilla-custom-prefix-tests` observed the server-side value before the browser signal update had propagated (`expected <4> but was <3>`).

The security-test reset change is related to the Hilla stale subscription issue tracked in vaadin/hilla#5722 and our earlier workaround context in #2141.

## Review follow-up
A review pass caught that fetching once and then polling the rendered server span could still race. The helpers now retry the actual server fetch until the expected value is returned.

## Validation
- `mvn -B -ntp spotless:apply -Pall-modules`
- `mvn -B -ntp -pl commons/deployment -Dtest=SignalsSecurityTest test`
- `mvn -B -ntp verify -pl integration-tests/custom-prefix-tests -am -Pit-tests,production,embedded-plugin -Dvaadin.build.enabled=true -Dquarkus-hilla.test-mode=production -Dit.test=SignalsNativeIT -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -Dselenide.browser=chrome`

Note: the same focused embedded-plugin command without `-Dselenide.browser=chrome` fails locally before test assertions because Safari remote automation is disabled on this Mac.