### PR TITLE
fix(copilot): restrict integration to dev mode

### DIFF
--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/QuarkusHillaExtensionProcessor.java
@@ -254,6 +254,10 @@ class QuarkusHillaExtensionProcessor {
     @BuildStep
     void addMarkersForHillaJars(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> producer) {
         producer.produce(new AdditionalApplicationArchiveMarkerBuildItem("com/vaadin/hilla"));
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    void addMarkersForCopilotJars(BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> producer) {
         producer.produce(new AdditionalApplicationArchiveMarkerBuildItem("com/vaadin/copilot"));
         producer.produce(new AdditionalApplicationArchiveMarkerBuildItem("com/vaadin/copilot/SpringBridge.class"));
     }
@@ -332,7 +336,7 @@ class QuarkusHillaExtensionProcessor {
         servletProducer.produce(builder.build());
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = IsDevelopment.class)
     void generateCopilotApplicationMetadata(
             ApplicationArchivesBuildItem applicationArchives,
             BuildProducer<GeneratedResourceBuildItem> generatedResources) {
@@ -361,7 +365,7 @@ class QuarkusHillaExtensionProcessor {
                         .toResourceBytes()));
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = IsDevelopment.class)
     void preserveCopilotFlowServiceBeans(
             ApplicationArchivesBuildItem applicationArchives,
             CopilotConfiguration copilotConfiguration,
@@ -405,6 +409,11 @@ class QuarkusHillaExtensionProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     void replaceOffendingMethodCallsDevMode(BuildProducer<BytecodeTransformerBuildItem> producer) {
         OffendingMethodCallsReplacer.addClassVisitorsDevMode(producer);
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    void replaceCopilotMethodCalls(BuildProducer<BytecodeTransformerBuildItem> producer) {
+        OffendingMethodCallsReplacer.addCopilotClassVisitors(producer);
     }
 
     @BuildStep

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/OffendingMethodCallsReplacer.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/asm/OffendingMethodCallsReplacer.java
@@ -20,14 +20,11 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import com.vaadin.flow.server.VaadinContext;
-import com.vaadin.hilla.ApplicationContextProvider;
 import com.vaadin.hilla.AuthenticationUtil;
-import com.vaadin.hilla.EndpointCodeGenerator;
 import com.vaadin.hilla.EndpointInvoker;
 import com.vaadin.hilla.EndpointRegistry;
 import com.vaadin.hilla.EndpointUtil;
 import com.vaadin.hilla.Hotswapper;
-import com.vaadin.hilla.engine.EngineAutoConfiguration;
 import com.vaadin.hilla.push.PushEndpoint;
 import com.vaadin.hilla.push.PushMessageHandler;
 import com.vaadin.hilla.signals.internal.SecureSignalsRegistry;
@@ -41,7 +38,6 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import org.objectweb.asm.Opcodes;
-import org.springframework.context.ApplicationContext;
 import org.springframework.data.domain.Sort;
 
 import com.github.mcollovati.quarkus.hilla.CopilotQuarkusIntegration;
@@ -49,6 +45,11 @@ import com.github.mcollovati.quarkus.hilla.HillaReplacements;
 import com.github.mcollovati.quarkus.hilla.SpringReplacements;
 
 public class OffendingMethodCallsReplacer {
+
+    private static final String APPLICATION_CONTEXT = "org.springframework.context.ApplicationContext";
+    private static final String APPLICATION_CONTEXT_PROVIDER = "com.vaadin.hilla.ApplicationContextProvider";
+    private static final String ENDPOINT_CODE_GENERATOR = "com.vaadin.hilla.EndpointCodeGenerator";
+    private static final String ENGINE_AUTO_CONFIGURATION = "com.vaadin.hilla.engine.EngineAutoConfiguration";
 
     private static final Map.Entry<MethodSignature, MethodSignature> ClassUtils_getUserClass = Map.entry(
             MethodSignature.of("org/springframework/util/ClassUtils", "getUserClass"),
@@ -85,6 +86,12 @@ public class OffendingMethodCallsReplacer {
 
     public static void addClassVisitorsDevMode(BuildProducer<BytecodeTransformerBuildItem> producer) {
         producer.produce(transform(Hotswapper.class, "affectsEndpoints", Class_forName));
+    }
+
+    public static void addCopilotClassVisitors(BuildProducer<BytecodeTransformerBuildItem> producer) {
+        producer.produce(copilotSpringBridge_patch());
+        producer.produce(
+                transform("com.vaadin.copilot.customcomponent.CustomComponents", "isCustomComponent", Class_forName));
     }
 
     public static void addClassVisitors(BuildProducer<BytecodeTransformerBuildItem> producer) {
@@ -129,9 +136,6 @@ public class OffendingMethodCallsReplacer {
         }));
         producer.produce(applicationContextProvider_runOnContext_patch());
         producer.produce(endpointCodeGenerator_findBrowserCallables_replacement());
-        producer.produce(copilotSpringBridge_patch());
-        producer.produce(
-                transform("com.vaadin.copilot.customcomponent.CustomComponents", "isCustomComponent", Class_forName));
         producer.produce(new BytecodeTransformerBuildItem(
                 "com.vaadin.hilla.EndpointController",
                 (className, classVisitor) -> new EndpointControllerVisitor(classVisitor)));
@@ -153,56 +157,55 @@ public class OffendingMethodCallsReplacer {
     }
 
     private static BytecodeTransformerBuildItem applicationContextProvider_runOnContext_patch() {
-        return new BytecodeTransformerBuildItem(
-                ApplicationContextProvider.class.getName(), (className, classVisitor) -> {
-                    ClassTransformer transformer = new ClassTransformer(className);
-                    MethodDescriptor runOnContextMethod = MethodDescriptor.ofMethod(
-                            ApplicationContextProvider.class, "runOnContext", void.class, Consumer.class);
-                    transformer.removeMethod(runOnContextMethod);
-                    try (MethodCreator creator = transformer.addMethod(runOnContextMethod)) {
-                        creator.setModifiers(Opcodes.ACC_STATIC | Opcodes.ACC_PUBLIC);
-                        ResultHandle appCtxField = creator.readStaticField(FieldDescriptor.of(
-                                ApplicationContextProvider.class, "applicationContext", ApplicationContext.class));
-                        ResultHandle pendingActionsField = creator.readStaticField(
-                                FieldDescriptor.of(ApplicationContextProvider.class, "pendingActions", List.class));
-                        BranchResult ifNullAppCtx = creator.ifNull(appCtxField);
-                        try (BytecodeCreator trueBranch = ifNullAppCtx.trueBranch()) {
-                            trueBranch.invokeInterfaceMethod(
-                                    MethodDescriptor.ofMethod(List.class, "add", boolean.class, Object.class),
-                                    pendingActionsField,
-                                    creator.getMethodParam(0));
-                        }
-                        try (BytecodeCreator falseBranch = ifNullAppCtx.falseBranch()) {
-                            falseBranch.invokeInterfaceMethod(
-                                    MethodDescriptor.ofMethod(Consumer.class, "accept", void.class, Object.class),
-                                    creator.getMethodParam(0),
-                                    appCtxField);
-                        }
-                        creator.returnVoid();
-                    }
-                    return transformer.applyTo(classVisitor);
-                });
+        return new BytecodeTransformerBuildItem(APPLICATION_CONTEXT_PROVIDER, (className, classVisitor) -> {
+            ClassTransformer transformer = new ClassTransformer(className);
+            MethodDescriptor runOnContextMethod = MethodDescriptor.ofMethod(
+                    APPLICATION_CONTEXT_PROVIDER, "runOnContext", void.class.getName(), Consumer.class.getName());
+            transformer.removeMethod(runOnContextMethod);
+            try (MethodCreator creator = transformer.addMethod(runOnContextMethod)) {
+                creator.setModifiers(Opcodes.ACC_STATIC | Opcodes.ACC_PUBLIC);
+                ResultHandle appCtxField = creator.readStaticField(
+                        FieldDescriptor.of(APPLICATION_CONTEXT_PROVIDER, "applicationContext", APPLICATION_CONTEXT));
+                ResultHandle pendingActionsField = creator.readStaticField(
+                        FieldDescriptor.of(APPLICATION_CONTEXT_PROVIDER, "pendingActions", List.class));
+                BranchResult ifNullAppCtx = creator.ifNull(appCtxField);
+                try (BytecodeCreator trueBranch = ifNullAppCtx.trueBranch()) {
+                    trueBranch.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(List.class, "add", boolean.class, Object.class),
+                            pendingActionsField,
+                            creator.getMethodParam(0));
+                }
+                try (BytecodeCreator falseBranch = ifNullAppCtx.falseBranch()) {
+                    falseBranch.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(Consumer.class, "accept", void.class, Object.class),
+                            creator.getMethodParam(0),
+                            appCtxField);
+                }
+                creator.returnVoid();
+            }
+            return transformer.applyTo(classVisitor);
+        });
     }
 
     private static BytecodeTransformerBuildItem endpointCodeGenerator_findBrowserCallables_replacement() {
-        return new BytecodeTransformerBuildItem(EndpointCodeGenerator.class.getName(), (className, classVisitor) -> {
+        return new BytecodeTransformerBuildItem(ENDPOINT_CODE_GENERATOR, (className, classVisitor) -> {
             ClassTransformer transformer = new ClassTransformer(className);
             MethodDescriptor findBrowserCallablesMethod = MethodDescriptor.ofMethod(
                     className,
                     "findBrowserCallables",
-                    List.class,
-                    EngineAutoConfiguration.class,
-                    ApplicationContext.class);
+                    List.class.getName(),
+                    ENGINE_AUTO_CONFIGURATION,
+                    APPLICATION_CONTEXT);
             transformer.removeMethod(findBrowserCallablesMethod);
             try (MethodCreator creator = transformer.addMethod(findBrowserCallablesMethod)) {
                 creator.setModifiers(Opcodes.ACC_STATIC | Opcodes.ACC_PUBLIC);
                 creator.returnValue(creator.invokeStaticMethod(
                         MethodDescriptor.ofMethod(
-                                HillaReplacements.class,
+                                HillaReplacements.class.getName(),
                                 "findBrowserCallables",
-                                List.class,
-                                EngineAutoConfiguration.class,
-                                ApplicationContext.class),
+                                List.class.getName(),
+                                ENGINE_AUTO_CONFIGURATION,
+                                APPLICATION_CONTEXT),
                         creator.getMethodParam(0),
                         creator.getMethodParam(1)));
             }

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotCustomComponentsPatchTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotCustomComponentsPatchTest.java
@@ -15,18 +15,31 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.copilot;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Proxy;
+import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
 
-import io.quarkus.test.QuarkusExtensionTest;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+
+import com.github.mcollovati.quarkus.hilla.deployment.asm.OffendingMethodCallsReplacer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,9 +47,22 @@ class CopilotCustomComponentsPatchTest {
 
     private static final String HIDDEN_COMPONENT = "dev.codex.quarkushilla.hidden.HiddenComponent";
 
-    @RegisterExtension
-    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.extensionTest()
-            .setArchiveProducer(CopilotQuarkusIntegrationTestSupport::rootArchive);
+    @Test
+    void springBridgePatch_routesCallsToQuarkusIntegration() throws Exception {
+        Class<?> springBridge = transformedCopilotClass("com.vaadin.copilot.SpringBridge");
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            Thread.currentThread().setContextClassLoader(springBridge.getClassLoader());
+
+            Object versionInfo = springBridge.getMethod("getVersionInfo").invoke(null);
+
+            assertThat(versionInfo.getClass().getMethod("springBootVersion").invoke(versionInfo))
+                    .isEqualTo("Quarkus Hilla");
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        }
+    }
 
     @Test
     void customComponentsIsCustomComponent_loadsClassesFromThreadContextClassLoader() throws Exception {
@@ -46,11 +72,11 @@ class CopilotCustomComponentsPatchTest {
         try (URLClassLoader hiddenClassLoader =
                 new URLClassLoader(new java.net.URL[] {outputDirectory.toUri().toURL()}, null)) {
             Class<?> hiddenComponent = hiddenClassLoader.loadClass(HIDDEN_COMPONENT);
-            registerCustomComponent(hiddenComponent);
+            Class<?> customComponents = transformedCopilotClass("com.vaadin.copilot.customcomponent.CustomComponents");
+            registerCustomComponent(customComponents, hiddenComponent);
 
             Thread.currentThread().setContextClassLoader(hiddenClassLoader);
 
-            Class<?> customComponents = Class.forName("com.vaadin.copilot.customcomponent.CustomComponents");
             boolean customComponent = (boolean) customComponents
                     .getMethod("isCustomComponent", String.class)
                     .invoke(null, HIDDEN_COMPONENT);
@@ -81,8 +107,9 @@ class CopilotCustomComponentsPatchTest {
         return outputDirectory;
     }
 
-    private static void registerCustomComponent(Class<?> componentClass) throws Exception {
-        Class<?> customComponentType = Class.forName("com.vaadin.copilot.customcomponent.CustomComponent");
+    private static void registerCustomComponent(Class<?> customComponents, Class<?> componentClass) throws Exception {
+        Class<?> customComponentType = Class.forName(
+                "com.vaadin.copilot.customcomponent.CustomComponent", false, customComponents.getClassLoader());
         Object customComponent = Proxy.newProxyInstance(
                 customComponentType.getClassLoader(),
                 new Class<?>[] {customComponentType},
@@ -95,9 +122,80 @@ class CopilotCustomComponentsPatchTest {
                     default -> null;
                 });
 
-        Class<?> customComponents = Class.forName("com.vaadin.copilot.customcomponent.CustomComponents");
         java.lang.reflect.Method put = customComponents.getDeclaredMethod("put", Class.class, Supplier.class);
         put.setAccessible(true);
         put.invoke(null, componentClass, (Supplier<?>) () -> customComponent);
+    }
+
+    private static Class<?> transformedCopilotClass(String className) throws Exception {
+        List<BytecodeTransformerBuildItem> transformers = new ArrayList<>();
+        OffendingMethodCallsReplacer.addCopilotClassVisitors(transformers::add);
+        Optional<BytecodeTransformerBuildItem> transformer = transformers.stream()
+                .filter(item -> item.getClassToTransform().equals(className))
+                .findFirst();
+        if (transformer.isEmpty()) {
+            throw new AssertionError("No Copilot transformer registered for " + className);
+        }
+        URL[] urls = {copilotJar().toUri().toURL()};
+        URLClassLoader copilotClassLoader =
+                new URLClassLoader(urls, CopilotCustomComponentsPatchTest.class.getClassLoader());
+        Map<String, byte[]> transformedClasses = Map.of(className, transform(transformer.get(), copilotClassLoader));
+        return new TransformedClassLoader(copilotClassLoader, transformedClasses).loadClass(className);
+    }
+
+    private static byte[] transform(BytecodeTransformerBuildItem transformer, ClassLoader copilotClassLoader)
+            throws IOException {
+        String className = transformer.getClassToTransform();
+        String resourceName = className.replace('.', '/') + ".class";
+        try (InputStream input = Objects.requireNonNull(
+                copilotClassLoader.getResourceAsStream(resourceName), () -> "Cannot find " + resourceName)) {
+            ClassReader reader = new ClassReader(input);
+            ClassWriter writer = new ClassWriter(reader, ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS) {
+                @Override
+                protected String getCommonSuperClass(String type1, String type2) {
+                    return Object.class.getName().replace('.', '/');
+                }
+            };
+            ClassVisitor visitor = transformer.getVisitorFunction().apply(className, writer);
+            reader.accept(visitor, transformer.getClassReaderOptions());
+            return writer.toByteArray();
+        }
+    }
+
+    private static Path copilotJar() throws Exception {
+        return MavenArtifactResolver.builder()
+                .build()
+                .resolve(new DefaultArtifact("com.vaadin", "copilot", "jar", System.getProperty("vaadin.version")))
+                .getArtifact()
+                .getFile()
+                .toPath();
+    }
+
+    private static final class TransformedClassLoader extends ClassLoader {
+
+        private final Map<String, byte[]> transformedClasses;
+
+        private TransformedClassLoader(ClassLoader parent, Map<String, byte[]> transformedClasses) {
+            super(parent);
+            this.transformedClasses = transformedClasses;
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loaded = findLoadedClass(name);
+                if (loaded == null && transformedClasses.containsKey(name)) {
+                    byte[] classBytes = transformedClasses.get(name);
+                    loaded = defineClass(name, classBytes, 0, classBytes.length);
+                }
+                if (loaded == null) {
+                    loaded = super.loadClass(name, false);
+                }
+                if (resolve) {
+                    resolveClass(loaded);
+                }
+                return loaded;
+            }
+        }
     }
 }

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotDevModeBuildStepTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotDevModeBuildStepTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.copilot;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+
+import dev.codex.quarkushilla.copilot.app.CopilotTestBeans;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.value.registry.ValueRegistry;
+import io.quarkus.value.registry.ValueRegistry.RuntimeKey;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CopilotDevModeBuildStepTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest().withApplicationRoot(jar -> jar.addClasses(
+                    CopilotDevModeProbeServlet.class,
+                    CopilotTestBeans.class,
+                    CopilotTestBeans.AAlphabeticallyFirstHelper.class,
+                    CopilotTestBeans.ZzzAppShell.class,
+                    CopilotTestBeans.ApplicationScopedFlowService.class)
+            .addAsResource(new StringAsset("quarkus.http.port=0\n"), "application.properties"));
+
+    private static final RuntimeKey<URI> LOCAL_BASE_URI = RuntimeKey.key("quarkus.http.local-base-uri");
+
+    private URI baseUri;
+
+    @BeforeEach
+    void beforeEach(ValueRegistry valueRegistry) {
+        assertThat(valueRegistry.containsKey(LOCAL_BASE_URI)).isTrue();
+        baseUri = valueRegistry.get(LOCAL_BASE_URI);
+    }
+
+    @Test
+    void devModeBuildSteps_generateCopilotMetadataAndPreserveFlowServiceBeans() throws Exception {
+        assertThat(read("/copilot-dev-mode/application-class")).isEqualTo(CopilotTestBeans.ZzzAppShell.class.getName());
+        assertThat(read("/copilot-dev-mode/application-scoped-flow-service-bean"))
+                .isEqualTo("true");
+    }
+
+    private String read(String path) throws IOException {
+        try (Scanner scanner = new Scanner(baseUri.resolve(path).toURL().openStream(), StandardCharsets.UTF_8)) {
+            scanner.useDelimiter("\\A");
+            return scanner.hasNext() ? scanner.next() : "";
+        }
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotDevModeProbeServlet.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotDevModeProbeServlet.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.copilot;
+
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Set;
+
+import dev.codex.quarkushilla.copilot.app.CopilotTestBeans;
+
+import com.github.mcollovati.quarkus.hilla.CopilotQuarkusIntegration;
+
+@WebServlet(urlPatterns = "/copilot-dev-mode/*")
+class CopilotDevModeProbeServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        String path = request.getPathInfo();
+        if ("/application-class".equals(path)) {
+            response.getWriter()
+                    .write(CopilotQuarkusIntegration.getApplicationClass(null).getName());
+        } else if ("/application-scoped-flow-service-bean".equals(path)) {
+            response.getWriter().write(applicationScopedFlowServiceBean());
+        } else {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+        }
+    }
+
+    private String applicationScopedFlowServiceBean() {
+        BeanManager beanManager = CDI.current().getBeanManager();
+        Set<Bean<?>> beans = beanManager.getBeans(CopilotTestBeans.ApplicationScopedFlowService.class);
+        return Boolean.toString(!beans.isEmpty());
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotProductionBuildTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotProductionBuildTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.copilot;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.hilla.deployment.asm.OffendingMethodCallsReplacer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CopilotProductionBuildTest {
+
+    @Test
+    void productionBuild_doesNotRegisterCopilotTransformers() {
+        List<BytecodeTransformerBuildItem> transformers = new ArrayList<>();
+
+        OffendingMethodCallsReplacer.addClassVisitors(transformers::add);
+
+        assertThat(transformers)
+                .extracting(BytecodeTransformerBuildItem::getClassToTransform)
+                .doesNotContain(
+                        "com.vaadin.copilot.SpringBridge", "com.vaadin.copilot.customcomponent.CustomComponents");
+    }
+
+    @Test
+    void copilotBuildSteps_runOnlyInDevelopmentMode() {
+        assertThat(copilotBuildStep("addMarkersForCopilotJars").onlyIf()).containsExactly(IsDevelopment.class);
+        assertThat(copilotBuildStep("generateCopilotApplicationMetadata").onlyIf())
+                .containsExactly(IsDevelopment.class);
+        assertThat(copilotBuildStep("preserveCopilotFlowServiceBeans").onlyIf()).containsExactly(IsDevelopment.class);
+        assertThat(copilotBuildStep("replaceCopilotMethodCalls").onlyIf()).containsExactly(IsDevelopment.class);
+    }
+
+    @Test
+    void copilotBuildStep_registersCopilotTransformers() {
+        List<BytecodeTransformerBuildItem> transformers = new ArrayList<>();
+
+        OffendingMethodCallsReplacer.addCopilotClassVisitors(transformers::add);
+
+        assertThat(transformers)
+                .extracting(BytecodeTransformerBuildItem::getClassToTransform)
+                .containsExactly(
+                        "com.vaadin.copilot.SpringBridge", "com.vaadin.copilot.customcomponent.CustomComponents");
+    }
+
+    private static BuildStep copilotBuildStep(String methodName) {
+        try {
+            Class<?> processor =
+                    Class.forName("com.github.mcollovati.quarkus.hilla.deployment.QuarkusHillaExtensionProcessor");
+            Method method = Arrays.stream(processor.getDeclaredMethods())
+                    .filter(candidate -> candidate.getName().equals(methodName))
+                    .findFirst()
+                    .orElseThrow();
+            return method.getAnnotation(BuildStep.class);
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationDefaultTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationDefaultTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CopilotQuarkusIntegrationDefaultTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.extensionTest()
+    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.copilotExtensionTest()
             .setArchiveProducer(CopilotQuarkusIntegrationTestSupport::rootArchive)
             .addAdditionalDependency(CopilotQuarkusIntegrationTestSupport.dependencyArchive());
 
@@ -70,9 +70,9 @@ class CopilotQuarkusIntegrationDefaultTest {
     }
 
     @Test
-    void springBridgePatch_routesCopilotCallsToQuarkusIntegration() {
-        assertThat(CopilotQuarkusIntegrationTestSupport.springBridgeAvailable()).isTrue();
-        assertThat(CopilotQuarkusIntegrationTestSupport.springBridgeFlowServiceMethods())
+    void quarkusIntegration_routesCopilotCallsToApplicationMetadata() {
+        assertThat(CopilotQuarkusIntegration.isAvailable(null)).isTrue();
+        assertThat(CopilotQuarkusIntegrationTestSupport.flowServiceMethods())
                 .contains(method(CopilotTestBeans.ApplicationScopedFlowService.class, "applicationMethod"));
     }
 

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationDiscoveryAllTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationDiscoveryAllTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CopilotQuarkusIntegrationDiscoveryAllTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.extensionTest()
+    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.copilotExtensionTest()
             .overrideConfigKey("vaadin.copilot.flow-services.discovery", "all")
             .setArchiveProducer(CopilotQuarkusIntegrationTestSupport::rootArchive);
 

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationExcludePackagesTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationExcludePackagesTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CopilotQuarkusIntegrationExcludePackagesTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.extensionTest()
+    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.copilotExtensionTest()
             .overrideConfigKey("vaadin.copilot.flow-services.discovery", "none")
             .overrideConfigKey(
                     "vaadin.copilot.flow-services.include-packages", "dev.codex.quarkushilla.copilot.included")

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationIncludeScopesTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationIncludeScopesTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CopilotQuarkusIntegrationIncludeScopesTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.extensionTest()
+    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.copilotExtensionTest()
             .overrideConfigKey("vaadin.copilot.flow-services.include-scopes", "request")
             .setArchiveProducer(CopilotQuarkusIntegrationTestSupport::rootArchive);
 

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationIncludesExcludesTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationIncludesExcludesTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CopilotQuarkusIntegrationIncludesExcludesTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.extensionTest()
+    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.copilotExtensionTest()
             .overrideConfigKey("vaadin.copilot.flow-services.discovery", "none")
             .overrideConfigKey(
                     "vaadin.copilot.flow-services.include-packages", "dev.codex.quarkushilla.copilot.included")

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationPackagesAllTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationPackagesAllTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CopilotQuarkusIntegrationPackagesAllTest {
 
     @RegisterExtension
-    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.extensionTest()
+    static final QuarkusExtensionTest config = CopilotQuarkusIntegrationTestSupport.copilotExtensionTest()
             .overrideConfigKey("vaadin.copilot.flow-services.packages", "all")
             .setArchiveProducer(CopilotQuarkusIntegrationTestSupport::rootArchive)
             .addAdditionalDependency(CopilotQuarkusIntegrationTestSupport.dependencyArchive());

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationTestSupport.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/copilot/CopilotQuarkusIntegrationTestSupport.java
@@ -16,9 +16,11 @@
 package com.github.mcollovati.quarkus.hilla.deployment.copilot;
 
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.vaadin.flow.server.VaadinContext;
 import dev.codex.quarkushilla.copilot.app.CopilotTestBeans;
@@ -27,8 +29,10 @@ import dev.codex.quarkushilla.copilot.included.IncludedTestBeans;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusExtensionTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 
+import com.github.mcollovati.quarkus.hilla.CopilotApplicationMetadata;
 import com.github.mcollovati.quarkus.hilla.CopilotQuarkusIntegration;
 
 public final class CopilotQuarkusIntegrationTestSupport {
@@ -48,33 +52,19 @@ public final class CopilotQuarkusIntegrationTestSupport {
 
     private CopilotQuarkusIntegrationTestSupport() {}
 
-    public static QuarkusExtensionTest extensionTest() {
+    public static QuarkusExtensionTest copilotExtensionTest() {
         return new QuarkusExtensionTest()
                 .setForcedDependencies(
                         List.of(Dependency.of("com.vaadin", "copilot", System.getProperty("vaadin.version"))))
+                .overrideConfigKey("quarkus.arc.remove-unused-beans", "false")
+                .overrideConfigKey("quarkus.http.test-port", "0")
                 .overrideConfigKey("quarkus.class-loading.removed-artifacts", REMOVED_OPTIONAL_ARTIFACTS);
     }
 
     public static JavaArchive rootArchive() {
         return ShrinkWrap.create(JavaArchive.class)
-                .addClasses(
-                        CopilotQuarkusIntegrationTestSupport.class,
-                        CopilotTestBeans.class,
-                        CopilotTestBeans.AAlphabeticallyFirstHelper.class,
-                        CopilotTestBeans.ZzzAppShell.class,
-                        CopilotTestBeans.ApplicationScopedFlowService.class,
-                        CopilotTestBeans.SingletonFlowService.class,
-                        CopilotTestBeans.DependentFlowService.class,
-                        CopilotTestBeans.RequestScopedFlowService.class,
-                        CopilotTestBeans.VaadinServiceScopedFlowService.class,
-                        CopilotTestBeans.VaadinSessionScopedFlowService.class,
-                        CopilotTestBeans.VaadinUiScopedFlowService.class,
-                        CopilotTestBeans.VaadinRouteScopedFlowService.class,
-                        CopilotTestBeans.BrowserCallableEndpoint.class,
-                        CopilotTestBeans.LegacyEndpoint.class,
-                        IncludedTestBeans.class,
-                        IncludedTestBeans.IncludedPackageService.class,
-                        IncludedTestBeans.ExcludedIncludedService.class);
+                .addClasses(rootClasses())
+                .addAsResource(copilotApplicationMetadata(), CopilotApplicationMetadata.RESOURCE);
     }
 
     public static JavaArchive dependencyArchive() {
@@ -115,6 +105,38 @@ public final class CopilotQuarkusIntegrationTestSupport {
 
     public static String methodId(Class<?> serviceClass, String methodName) {
         return serviceClass.getName() + "#" + methodName;
+    }
+
+    private static Class<?>[] rootClasses() {
+        return new Class<?>[] {
+            CopilotQuarkusIntegrationTestSupport.class,
+            CopilotTestBeans.class,
+            CopilotTestBeans.AAlphabeticallyFirstHelper.class,
+            CopilotTestBeans.ZzzAppShell.class,
+            CopilotTestBeans.ApplicationScopedFlowService.class,
+            CopilotTestBeans.SingletonFlowService.class,
+            CopilotTestBeans.DependentFlowService.class,
+            CopilotTestBeans.RequestScopedFlowService.class,
+            CopilotTestBeans.VaadinServiceScopedFlowService.class,
+            CopilotTestBeans.VaadinSessionScopedFlowService.class,
+            CopilotTestBeans.VaadinUiScopedFlowService.class,
+            CopilotTestBeans.VaadinRouteScopedFlowService.class,
+            CopilotTestBeans.BrowserCallableEndpoint.class,
+            CopilotTestBeans.LegacyEndpoint.class,
+            IncludedTestBeans.class,
+            IncludedTestBeans.IncludedPackageService.class,
+            IncludedTestBeans.ExcludedIncludedService.class
+        };
+    }
+
+    private static StringAsset copilotApplicationMetadata() {
+        String content = new String(
+                CopilotApplicationMetadata.of(
+                                CopilotTestBeans.ZzzAppShell.class.getName(),
+                                Stream.of(rootClasses()).map(Class::getName).collect(Collectors.toSet()))
+                        .toResourceBytes(),
+                StandardCharsets.UTF_8);
+        return new StringAsset(content);
     }
 
     private static Set<String> methodIds(Iterable<?> serviceMethodInfos) {


### PR DESCRIPTION
## Summary

- Restricts Vaadin Copilot archive markers, metadata generation, unremovable bean preservation, and Copilot bytecode transformers to Quarkus development mode.
- Keeps normal production builds from registering transformers for `com.vaadin.copilot.SpringBridge` and `com.vaadin.copilot.customcomponent.CustomComponents`.
- Updates Copilot tests to provide test metadata directly and adds production-gate coverage for the Copilot build steps.

## Root Cause

Copilot integration is documented as dev-mode behavior, but some Copilot build steps and transformers were registered in normal builds. Applications depending on `quarkus-hilla 25.2.0-beta1` could therefore hit Quarkus transformer warnings for Copilot classes whose application archive was not available.

## Validation

- `mvn -pl commons/runtime,commons/deployment -Dtest='*Copilot*Test' -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test -Dstyle.color=never`
- `mvn -pl commons/deployment -Dtest=CopilotProductionBuildTest,CopilotCustomComponentsPatchTest test -Dstyle.color=never`
- `mvn -pl commons/deployment spotless:check -Pall-modules -Dstyle.color=never`
- `git diff --check`
