### PR TITLE
chore(ci): drop branch 25.0 from automation workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,17 +40,4 @@ updates:
         update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"
-  - package-ecosystem: "maven"
-    directory: "/"
-    target-branch: "25.0"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "com.vaadin.hilla:*"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
-      - dependency-name: "com.vaadin:*"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,6 @@ on:
           - main
           - "25.2"
           - "25.1"
-          - "25.0"
       version:
         description: "Version to release (e.g. 1.1.0 or 1.2.0-alpha1)"
         required: true

--- a/.github/workflows/update-npm-deps.yaml
+++ b/.github/workflows/update-npm-deps.yaml
@@ -11,7 +11,6 @@ on:
           - main
           - "25.2"
           - "25.1"
-          - "25.0"
   schedule:
     - cron: '0 2 * * *'
 permissions:
@@ -28,7 +27,7 @@ jobs:
           CMD_TARGET_BRANCH: ${{ inputs.target-branch }}
         run: |
           if [[ -z "$CMD_TARGET_BRANCH" ]]; then
-            echo 'matrix={ "branch": ["main","25.2","25.1","25.0"] }' >> "$GITHUB_OUTPUT"
+            echo 'matrix={ "branch": ["main","25.2","25.1"] }' >> "$GITHUB_OUTPUT"
           else
             echo 'matrix={ "branch": ["'$CMD_TARGET_BRANCH'"] }' >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/validation-nightly.yaml
+++ b/.github/workflows/validation-nightly.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [main, "25.2", "25.1", "25.0"]
+        branch: [main, "25.2", "25.1"]
         java: [21, 25]
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -1,7 +1,7 @@
 name: Quarkus Hilla Validation
 on:
   push:
-    branches: [main, "25.2", "25.1", "25.0"]
+    branches: [main, "25.2", "25.1"]
   workflow_dispatch:
   pull_request_target:
     types: [opened, synchronize, reopened, edited]


### PR DESCRIPTION
Remove 25.0 from GitHub Actions workflows (validation, nightly, release, npm-deps) and delete its Dependabot configuration entry.