### PR TITLE
fix(security): classify failed TypeScript form logins as errors

### DIFF
--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaFormAuthenticationMechanism.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaFormAuthenticationMechanism.java
@@ -18,6 +18,7 @@ package com.github.mcollovati.quarkus.hilla.security;
 import java.util.Optional;
 import java.util.Set;
 
+import io.quarkus.arc.ClientProxy;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.AuthenticationRequest;
@@ -31,6 +32,8 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 
 public class HillaFormAuthenticationMechanism implements HttpAuthenticationMechanism {
+    private static final String AUTHENTICATION_MECHANISM_KEY = HttpAuthenticationMechanism.class.getName();
+
     private final Config config;
 
     FormAuthenticationMechanism delegate;
@@ -67,7 +70,13 @@ public class HillaFormAuthenticationMechanism implements HttpAuthenticationMecha
                 }
             });
         }
-        return delegate.authenticate(context, identityProviderManager);
+        Uni<SecurityIdentity> authentication = delegate.authenticate(context, identityProviderManager);
+        // FormAuthenticationMechanism selects itself for challenge handling. Restore this wrapper so TypeScript login
+        // failures pass through getChallenge and are not converted into successful responses.
+        if (ClientProxy.unwrap(context.get(AUTHENTICATION_MECHANISM_KEY)) == ClientProxy.unwrap(delegate)) {
+            context.put(AUTHENTICATION_MECHANISM_KEY, this);
+        }
+        return authentication;
     }
 
     @Override
@@ -75,7 +84,6 @@ public class HillaFormAuthenticationMechanism implements HttpAuthenticationMecha
         if ("typescript".equals(context.request().getHeader("source"))) {
             context.put("typescript-login-failure", true);
         }
-        ;
         return delegate.getChallenge(context);
     }
 

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/HillaFormAuthenticationMechanismTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/HillaFormAuthenticationMechanismTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.security;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.vertx.http.runtime.security.FormAuthenticationMechanism;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HillaFormAuthenticationMechanismTest {
+
+    private static final String AUTHENTICATION_MECHANISM_KEY = HttpAuthenticationMechanism.class.getName();
+
+    @Test
+    void authenticate_delegateProxySelectsContextualInstance_restoresWrapper() {
+        FormAuthenticationMechanism contextualDelegate = mock(FormAuthenticationMechanism.class);
+        FormAuthenticationMechanism delegate =
+                mock(FormAuthenticationMechanism.class, Mockito.withSettings().extraInterfaces(ClientProxy.class));
+        when(((ClientProxy) delegate).arc_contextualInstance()).thenReturn(contextualDelegate);
+        AtomicReference<Object> selectedMechanism = new AtomicReference<>();
+        RoutingContext context = routingContext(selectedMechanism);
+        doAnswer(invocation -> {
+                    selectedMechanism.set(contextualDelegate);
+                    return Uni.createFrom().nullItem();
+                })
+                .when(delegate)
+                .authenticate(eq(context), any());
+        HillaFormAuthenticationMechanism wrapper = mechanism(delegate);
+
+        wrapper.authenticate(context, mock(IdentityProviderManager.class));
+
+        assertSame(wrapper, selectedMechanism.get());
+    }
+
+    @Test
+    void authenticate_foreignMechanismSelected_doesNotOverwriteIt() {
+        FormAuthenticationMechanism delegate = mock(FormAuthenticationMechanism.class);
+        HttpAuthenticationMechanism foreignMechanism = mock(HttpAuthenticationMechanism.class);
+        AtomicReference<Object> selectedMechanism = new AtomicReference<>();
+        RoutingContext context = routingContext(selectedMechanism);
+        doAnswer(invocation -> {
+                    selectedMechanism.set(foreignMechanism);
+                    return Uni.createFrom().nullItem();
+                })
+                .when(delegate)
+                .authenticate(eq(context), any());
+        HillaFormAuthenticationMechanism wrapper = mechanism(delegate);
+
+        wrapper.authenticate(context, mock(IdentityProviderManager.class));
+
+        assertSame(foreignMechanism, selectedMechanism.get());
+    }
+
+    private RoutingContext routingContext(AtomicReference<Object> selectedMechanism) {
+        RoutingContext context = mock(RoutingContext.class);
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        when(context.normalizedPath()).thenReturn("/login");
+        when(context.request()).thenReturn(request);
+        when(context.get(AUTHENTICATION_MECHANISM_KEY)).thenAnswer(invocation -> selectedMechanism.get());
+        when(context.put(eq(AUTHENTICATION_MECHANISM_KEY), any())).thenAnswer(invocation -> {
+            selectedMechanism.set(invocation.getArgument(1));
+            return context;
+        });
+        return context;
+    }
+
+    private HillaFormAuthenticationMechanism mechanism(FormAuthenticationMechanism delegate) {
+        return new HillaFormAuthenticationMechanism(
+                delegate, new HillaFormAuthenticationMechanism.Config("auth", "/", "/logout", null, false));
+    }
+}

--- a/integration-tests/security-form-tests/src/main/frontend/views/login.tsx
+++ b/integration-tests/security-form-tests/src/main/frontend/views/login.tsx
@@ -24,14 +24,13 @@ export default function LoginView() {
       noForgotPassword
       i18n={loginI18n}
       onLogin={async ({ detail: { username, password } }) => {
-        const { defaultUrl, error, redirectUrl } = await login(username, password);
+        const { defaultUrl, error, redirectUrl } = await login(username, password, { navigate: () => undefined });
 
         if (error) {
           loginError.value = true;
         } else {
           const url = redirectUrl ?? defaultUrl ?? '/';
-          const path = new URL(url, document.baseURI).pathname;
-          document.location = path;
+          window.location.replace(new URL(url, document.baseURI));
         }
       }}
     />

--- a/integration-tests/security-form-tests/src/test/java/com/example/application/FormAuthenticationProtocolTest.java
+++ b/integration-tests/security-form-tests/src/test/java/com/example/application/FormAuthenticationProtocolTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application;
+
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+class FormAuthenticationProtocolTest {
+
+    private static final String LOGIN_FORM = "username=%s&password=%s";
+
+    @TestHTTPResource("/")
+    URI baseUri;
+
+    @Test
+    void typescriptLogin_invalidCredentials_returnsAuthenticationFailure() throws Exception {
+        HttpResponse<Void> response = login(newClient(), "unknown", "wrong", true);
+
+        assertThat(response.statusCode()).isEqualTo(401);
+        assertThat(response.headers().firstValue("Result")).isEmpty();
+        assertThat(response.headers().firstValue("Default-url")).isEmpty();
+        assertThat(response.headers().firstValue("Saved-url")).isEmpty();
+        assertThat(response.headers().firstValue("Location")).isEmpty();
+    }
+
+    @Test
+    void formLogin_invalidCredentials_redirectsToConfiguredErrorPageWithQuery() throws Exception {
+        HttpResponse<Void> response = login(newClient(), "unknown", "wrong", false);
+
+        assertThat(response.statusCode()).isEqualTo(302);
+        assertRedirect(response, "/login", "error");
+        assertThat(response.headers().firstValue("Result")).isEmpty();
+    }
+
+    @Test
+    void typescriptLogin_validCredentials_returnsSuccessAndConfiguredLandingPage() throws Exception {
+        HttpResponse<Void> response = login(newClient(), "user", "user", true);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.headers().firstValue("Result")).hasValue("success");
+        assertThat(response.headers().firstValue("Default-url")).hasValue("/hilla-protected");
+        assertThat(response.headers().firstValue("Location")).isEmpty();
+    }
+
+    @Test
+    void formLogin_validCredentials_redirectsToConfiguredLandingPage() throws Exception {
+        HttpResponse<Void> response = login(newClient(), "user", "user", false);
+
+        assertThat(response.statusCode()).isEqualTo(302);
+        assertRedirect(response, "/hilla-protected", null);
+        assertThat(response.headers().firstValue("Result")).isEmpty();
+    }
+
+    @Test
+    void typescriptLogin_savedRequest_returnsOriginalUrlIncludingQuery() throws Exception {
+        HttpClient client = newClient();
+        assertLoginChallenge(client, "/flow-protected?tab=details");
+
+        HttpResponse<Void> response = login(client, "user", "user", true);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.headers().firstValue("Result")).hasValue("success");
+        assertThat(response.headers().firstValue("Default-url")).hasValue("/hilla-protected");
+        assertThat(response.headers().firstValue("Saved-url"))
+                .hasValueSatisfying(savedUrl -> assertUri(savedUrl, "/flow-protected", "tab=details"));
+        assertThat(response.headers().firstValue("Location")).isEmpty();
+    }
+
+    @Test
+    void typescriptLogin_invalidThenValid_preservesSavedRequestIncludingQuery() throws Exception {
+        HttpClient client = newClient();
+        assertLoginChallenge(client, "/flow-protected?tab=details");
+
+        HttpResponse<Void> failedLogin = login(client, "user", "wrong", true);
+        assertThat(failedLogin.statusCode()).isEqualTo(401);
+        assertThat(failedLogin.headers().firstValue("Result")).isEmpty();
+        assertThat(failedLogin.headers().firstValue("Default-url")).isEmpty();
+        assertThat(failedLogin.headers().firstValue("Saved-url")).isEmpty();
+        assertThat(failedLogin.headers().firstValue("Location")).isEmpty();
+
+        HttpResponse<Void> successfulLogin = login(client, "user", "user", true);
+        assertThat(successfulLogin.statusCode()).isEqualTo(200);
+        assertThat(successfulLogin.headers().firstValue("Result")).hasValue("success");
+        assertThat(successfulLogin.headers().firstValue("Saved-url"))
+                .hasValueSatisfying(savedUrl -> assertUri(savedUrl, "/flow-protected", "tab=details"));
+    }
+
+    @Test
+    void formLogin_savedRequest_redirectsToOriginalUrlIncludingQuery() throws Exception {
+        HttpClient client = newClient();
+        assertLoginChallenge(client, "/flow-protected?tab=details");
+
+        HttpResponse<Void> response = login(client, "user", "user", false);
+
+        assertThat(response.statusCode()).isEqualTo(302);
+        assertRedirect(response, "/flow-protected", "tab=details");
+        assertThat(response.headers().firstValue("Result")).isEmpty();
+    }
+
+    private HttpClient newClient() {
+        CookieManager cookies = new CookieManager(null, CookiePolicy.ACCEPT_ALL);
+        return HttpClient.newBuilder()
+                .cookieHandler(cookies)
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build();
+    }
+
+    private void assertLoginChallenge(HttpClient client, String path) throws IOException, InterruptedException {
+        HttpRequest request =
+                HttpRequest.newBuilder(baseUri.resolve(path)).GET().build();
+        HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+
+        assertThat(response.statusCode()).isEqualTo(302);
+        assertRedirect(response, "/login", null);
+    }
+
+    private HttpResponse<Void> login(HttpClient client, String username, String password, boolean typescript)
+            throws IOException, InterruptedException {
+        HttpRequest.Builder request = HttpRequest.newBuilder(baseUri.resolve("login"))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(LOGIN_FORM.formatted(username, password)));
+        if (typescript) {
+            request.header("source", "typescript");
+        }
+        return client.send(request.build(), HttpResponse.BodyHandlers.discarding());
+    }
+
+    private void assertRedirect(HttpResponse<?> response, String expectedPath, String expectedQuery) {
+        assertThat(response.headers().firstValue("Location"))
+                .hasValueSatisfying(location -> assertUri(location, expectedPath, expectedQuery));
+    }
+
+    private void assertUri(String location, String expectedPath, String expectedQuery) {
+        URI uri = URI.create(location);
+        assertThat(uri.getPath()).isEqualTo(expectedPath);
+        assertThat(uri.getQuery()).isEqualTo(expectedQuery);
+    }
+}

--- a/integration-tests/security-form-tests/src/test/java/com/example/application/SecurityTest.java
+++ b/integration-tests/security-form-tests/src/test/java/com/example/application/SecurityTest.java
@@ -15,6 +15,7 @@
  */
 package com.example.application;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -36,6 +37,8 @@ import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
+import static com.codeborne.selenide.Selenide.Wait;
+import static com.codeborne.selenide.Selenide.executeJavaScript;
 import static com.example.application.SecurityTest.MenuItem.FLOW_ADMIN;
 import static com.example.application.SecurityTest.MenuItem.FLOW_AUTHENTICATED;
 import static com.example.application.SecurityTest.MenuItem.FLOW_PUBLIC;
@@ -103,6 +106,23 @@ class SecurityTest extends AbstractTest {
     @Test
     void anonymous_openProtectedFlowView_loginViewDisplayed() {
         openProtectedPage("flow-admin", true);
+    }
+
+    @Test
+    void anonymous_invalidCredentials_errorDisplayedAndSavedTargetOpenedAfterRetry() {
+        openProtectedPage("flow-protected?tab=details", true);
+
+        SelenideElement loginForm = submitLogin("user", "wrong");
+        Wait().until(ignored -> Boolean.TRUE.equals(executeJavaScript("return arguments[0].error", loginForm)));
+        URI currentLocation = URI.create(WebDriverRunner.url());
+        assertThat(currentLocation.getPath()).isEqualTo("/login");
+        assertThat(currentLocation.getQuery()).isNull();
+
+        submitLogin("user", "user");
+        $("vaadin-app-layout footer vaadin-avatar").shouldBe(visible, Duration.ofSeconds(10));
+        $("vaadin-app-layout h2").shouldHave(text(FLOW_AUTHENTICATED.toString()));
+        currentLocation = URI.create(WebDriverRunner.url());
+        assertThat(currentLocation.getPath()).isEqualTo("/flow-protected");
     }
 
     @Test
@@ -205,10 +225,15 @@ class SecurityTest extends AbstractTest {
     }
 
     private void login(String username, String password) {
+        submitLogin(username, password);
+        $("vaadin-app-layout footer vaadin-avatar").shouldBe(visible, Duration.ofSeconds(10));
+    }
+
+    private SelenideElement submitLogin(String username, String password) {
         SelenideElement loginForm = $("vaadin-login-overlay").shouldBe(visible);
         loginForm.$("vaadin-text-field#vaadinLoginUsername").setValue(username);
         loginForm.$("vaadin-password-field#vaadinLoginPassword").setValue(password);
         loginForm.$("vaadin-button[slot=submit]").click();
-        $("vaadin-app-layout footer vaadin-avatar").shouldBe(visible, Duration.ofSeconds(10));
+        return loginForm;
     }
 }

--- a/integration-tests/security-form-tests/src/test/java/com/example/application/SecurityTest.java
+++ b/integration-tests/security-form-tests/src/test/java/com/example/application/SecurityTest.java
@@ -123,6 +123,7 @@ class SecurityTest extends AbstractTest {
         $("vaadin-app-layout h2").shouldHave(text(FLOW_AUTHENTICATED.toString()));
         currentLocation = URI.create(WebDriverRunner.url());
         assertThat(currentLocation.getPath()).isEqualTo("/flow-protected");
+        assertThat(currentLocation.getQuery()).isEqualTo("tab=details");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Classify failed TypeScript form logins as errors instead of successful responses.
- Preserve native form redirects, configured landing pages, and saved-request behavior.
- Add unit, HTTP protocol, and browser regression coverage for failure, retry, and redirect flows.

## Root cause

Quarkus `FormAuthenticationMechanism` registers itself in the `RoutingContext` as the selected challenge mechanism. This bypassed `HillaFormAuthenticationMechanism.getChallenge()`, so TypeScript login failures were not marked and the response adapter converted the error redirect into `200 Result: success`.

The wrapper is now rebound only when the selected mechanism is the form delegate. `ClientProxy.unwrap` keeps the identity check safe for CDI proxies without replacing unrelated authentication mechanisms.

## Validation

- Unit tests: 2/2 passed.
- HTTP protocol tests: 7/7 passed.
- Browser tests: 12/12 passed.
- Full focused reactor: 39/39 passed.
- `mvn -Pall-modules -pl commons/runtime,integration-tests/security-form-tests spotless:check`
- `git diff --check`

Closes #2201

