### PR TITLE
ci(npm-deps): sync npm files with Vaadin updates

### DIFF
--- a/.github/workflows/apply-vaadin-npm-deps.yaml
+++ b/.github/workflows/apply-vaadin-npm-deps.yaml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: vaadin-npm-sync-apply-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
+  cancel-in-progress: true
+
 jobs:
   apply:
     name: Commit generated NPM dependencies
@@ -30,17 +34,38 @@ jobs:
                  "head_ref=" + .head.ref,
                  "head_repo=" + .head.repo.full_name,
                  "base_ref=" + .base.ref,
-                 "author=" + .user.login' pull-request.json >> "$GITHUB_OUTPUT"
+                 "author=" + .user.login,
+                 "state=" + .state' pull-request.json >> "$GITHUB_OUTPUT"
       - name: Validate workflow provenance
         env:
           BASE_REF: ${{ steps.pull-request.outputs.base_ref }}
           HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
+          STATE: ${{ steps.pull-request.outputs.state }}
           SOURCE_BASE_REF: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
           SOURCE_HEAD_SHA: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
         run: |
+          [[ "$STATE" == "open" ]]
           [[ "$BASE_REF" != "main" ]]
           [[ "$BASE_REF" == "$SOURCE_BASE_REF" ]]
           [[ "$HEAD_SHA" == "$SOURCE_HEAD_SHA" ]]
+      - name: Validate source workflow freshness
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          SOURCE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh api \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/prepare-vaadin-npm-deps.yaml/runs?event=pull_request_target&per_page=100" \
+            > prepare-runs.json
+          read -r latest_run_id latest_run_attempt < <(
+            jq -r --argjson pr "$PR_NUMBER" \
+              '[.workflow_runs[] | select(any(.pull_requests[]?; .number == $pr))]
+               | max_by(.id)
+               | "\(.id) \(.run_attempt)"' prepare-runs.json
+          )
+          [[ "$SOURCE_RUN_ID" == "$latest_run_id" ]]
+          [[ "$SOURCE_RUN_ATTEMPT" == "$latest_run_attempt" ]]
       - name: Publish failed generation gate
         if: github.event.workflow_run.conclusion != 'success'
         env:

--- a/.github/workflows/apply-vaadin-npm-deps.yaml
+++ b/.github/workflows/apply-vaadin-npm-deps.yaml
@@ -8,8 +8,8 @@ on:
 permissions:
   actions: read
   checks: write
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   apply:
@@ -63,66 +63,6 @@ jobs:
           artifact_id=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/artifacts" \
             --jq '.artifacts[] | select(.name == "vaadin-npm-sync") | .id' | head -1)
           echo "id=$artifact_id" >> "$GITHUB_OUTPUT"
-      - name: Download synchronization state
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: vaadin-npm-sync-state
-          path: sync-state
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ github.event.workflow_run.id }}
-      - name: Validate synchronization state
-        id: sync-state
-        env:
-          EXPECTED_HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
-        run: |
-          head_sha=$(jq -er '.headSha' sync-state/vaadin-npm-sync-state.json)
-          relevant=$(jq -er '.relevant | tostring' sync-state/vaadin-npm-sync-state.json)
-          [[ "$head_sha" == "$EXPECTED_HEAD_SHA" ]]
-          [[ "$relevant" == "true" || "$relevant" == "false" ]]
-          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
-      - name: Update pull request sync status
-        if: steps.sync-state.outputs.relevant == 'true'
-        id: pr-status
-        continue-on-error: true
-        env:
-          ARTIFACT_ID: ${{ steps.artifact.outputs.id }}
-          GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
-          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-        run: |
-          short_sha="${HEAD_SHA:0:12}"
-          commit_url="https://github.com/${GITHUB_REPOSITORY}/commit/${HEAD_SHA}"
-          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
-
-          if [[ "$RUN_CONCLUSION" != "success" ]]; then
-            status="❌ Generation failed for"
-          elif [[ -n "$ARTIFACT_ID" ]]; then
-            status="⏳ Generated NPM update; bot commit pending for"
-          else
-            status="✅ Synchronized and validated"
-          fi
-
-          printf -v block '%s\n%s\n%s [`%s`](%s). [Workflow run](%s)\n%s' \
-            '<!-- vaadin-npm-sync:start -->' \
-            '### NPM dependency sync' \
-            "$status" "$short_sha" "$commit_url" "$run_url" \
-            '<!-- vaadin-npm-sync:end -->'
-
-          current_body=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.body // ""')
-          updated_body=$(jq -nr --arg body "$current_body" --arg block "$block" '
-            ($body
-              | gsub("(?s)<!-- vaadin-npm-sync:start -->.*?<!-- vaadin-npm-sync:end -->"; "")
-              | sub("[[:space:]]+$"; ""))
-            + "\n\n" + $block
-          ')
-          gh api --method PATCH "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
-            --raw-field body="$updated_body" > /dev/null
-      - name: Warn about pull request status failure
-        if: steps.pr-status.outcome == 'failure'
-        run: echo '::warning::Unable to update NPM synchronization block in pull request description.'
       - name: Report failed generation
         if: github.event.workflow_run.conclusion != 'success'
         run: exit 1
@@ -141,7 +81,6 @@ jobs:
             --raw-field 'output[summary]=No generated NPM dependency changes are pending.'
       - name: Checkout exact Dependabot revision
         if: steps.artifact.outputs.id != ''
-        id: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ steps.pull-request.outputs.head_sha }}
@@ -149,7 +88,6 @@ jobs:
           persist-credentials: false
       - name: Download generated patch
         if: steps.artifact.outputs.id != ''
-        id: patch-artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: vaadin-npm-sync
@@ -159,7 +97,6 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
       - name: Validate and apply patch
         if: steps.artifact.outputs.id != ''
-        id: patch
         env:
           AUTHOR: ${{ steps.pull-request.outputs.author }}
           EXPECTED_HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
@@ -185,18 +122,18 @@ jobs:
           invalid=$(git diff --cached --name-only | grep -Ev '(^|/)package[^/]*\.json$' || true)
           [[ -z "$invalid" ]]
           ! git diff --cached --quiet
-      - name: Generate bot token
+      - name: Generate content token
         if: steps.artifact.outputs.id != ''
-        id: app-token
+        id: content-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.QUARKUS_HILLA_BOT_ID }}
           private-key: ${{ secrets.QUARKUS_HILLA_BOT_PRIVATE_KEY }}
+          permission-contents: write
       - name: Commit and push generated dependencies
         if: steps.artifact.outputs.id != ''
-        id: push
         env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_TOKEN: ${{ steps.content-token.outputs.token }}
           EXPECTED_HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
           HEAD_REF: ${{ steps.pull-request.outputs.head_ref }}
         run: |
@@ -205,24 +142,40 @@ jobs:
           git commit -m "chore(npm-deps): update npm dependencies"
           git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push --force-with-lease="${HEAD_REF}:${EXPECTED_HEAD_SHA}" origin "HEAD:${HEAD_REF}"
-      - name: Report generated update application failure
-        if: >-
-          always() && steps.artifact.outputs.id != '' &&
-          (steps.checkout.outcome == 'failure' ||
-           steps.patch-artifact.outcome == 'failure' ||
-           steps.patch.outcome == 'failure' ||
-           steps.app-token.outcome == 'failure' ||
-           steps.push.outcome == 'failure')
-        continue-on-error: true
+      - name: Generate pull request token
+        if: steps.artifact.outputs.id != ''
+        id: pull-request-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.QUARKUS_HILLA_BOT_ID }}
+          private-key: ${{ secrets.QUARKUS_HILLA_BOT_PRIVATE_KEY }}
+          permission-pull-requests: write
+      - name: Update pull request metadata and comment
+        if: steps.artifact.outputs.id != ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.pull-request-token.outputs.token }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
-          current_body=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.body // ""')
-          pending='⏳ Generated NPM update; bot commit pending for'
-          failed='❌ Applying generated NPM update failed for'
-          updated_body="${current_body/$pending/$failed}"
-          if [[ "$updated_body" != "$current_body" ]]; then
-            gh api --method PATCH "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
-              --raw-field body="$updated_body" > /dev/null
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > pull-request-after-push.json
+          title=$(jq -r '.title' pull-request-after-push.json)
+          body=$(jq -r '.body // ""' pull-request-after-push.json)
+
+          if [[ "$title" != *"npm dependencies"* ]]; then
+            title="$title + npm dependencies"
           fi
+
+          marker='<!-- npm-dependencies-updated -->'
+          if [[ "$body" != *"$marker"* ]]; then
+            printf -v note '\n\n%s\n%s' "$marker" \
+              'This PR also updates generated npm dependencies to match the Vaadin/Hilla version.'
+            body+="$note"
+          fi
+
+          gh api --method PATCH "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+            --raw-field title="$title" --raw-field body="$body" > /dev/null
+
+          commit_sha=$(git rev-parse HEAD)
+          commit_url="https://github.com/${GITHUB_REPOSITORY}/commit/${commit_sha}"
+          gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+            --raw-field body="✅ Updated npm dependencies in [\`${commit_sha:0:12}\`]($commit_url). Validation is running for the new revision." \
+            > /dev/null

--- a/.github/workflows/apply-vaadin-npm-deps.yaml
+++ b/.github/workflows/apply-vaadin-npm-deps.yaml
@@ -51,18 +51,20 @@ jobs:
       - name: Validate source workflow freshness
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ steps.pull-request.outputs.head_ref }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
           SOURCE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
-          gh api \
-            "repos/$GITHUB_REPOSITORY/actions/workflows/prepare-vaadin-npm-deps.yaml/runs?event=pull_request_target&per_page=100" \
-            > prepare-runs.json
           read -r latest_run_id latest_run_attempt < <(
-            jq -r --argjson pr "$PR_NUMBER" \
-              '[.workflow_runs[] | select(any(.pull_requests[]?; .number == $pr))]
-               | max_by(.id)
-               | "\(.id) \(.run_attempt)"' prepare-runs.json
+            gh api --method GET --paginate \
+              "repos/$GITHUB_REPOSITORY/actions/workflows/prepare-vaadin-npm-deps.yaml/runs" \
+              -f event=pull_request_target -f branch="$HEAD_REF" -F per_page=100 \
+              --jq '.workflow_runs[]' \
+              | jq -rs --argjson pr "$PR_NUMBER" \
+                '[.[] | select(any(.pull_requests[]?; .number == $pr))]
+                 | max_by(.id)
+                 | "\(.id) \(.run_attempt)"'
           )
           [[ "$SOURCE_RUN_ID" == "$latest_run_id" ]]
           [[ "$SOURCE_RUN_ATTEMPT" == "$latest_run_attempt" ]]
@@ -79,20 +81,50 @@ jobs:
             --raw-field conclusion=failure \
             --raw-field 'output[title]=NPM dependency generation failed' \
             --raw-field 'output[summary]=Inspect Prepare Vaadin NPM dependency sync workflow.'
-      - name: Find generated patch
-        id: artifact
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-        run: |
-          artifact_id=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/artifacts" \
-            --jq '.artifacts[] | select(.name == "vaadin-npm-sync") | .id' | head -1)
-          echo "id=$artifact_id" >> "$GITHUB_OUTPUT"
       - name: Report failed generation
         if: github.event.workflow_run.conclusion != 'success'
         run: exit 1
+      - name: Download synchronization result
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: vaadin-npm-sync-${{ github.event.workflow_run.run_attempt }}
+          path: ${{ runner.temp }}/vaadin-npm-sync
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Validate synchronization result
+        id: result
+        env:
+          EXPECTED_HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
+          EXPECTED_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          EXPECTED_RUN_ID: ${{ github.event.workflow_run.id }}
+          RESULT_DIR: ${{ runner.temp }}/vaadin-npm-sync
+        run: |
+          jq -e '
+            type == "object" and
+            (.relevant | type == "boolean") and
+            (.changed | type == "boolean") and
+            (.head_sha | type == "string") and
+            (.run_id | type == "number") and
+            (.run_attempt | type == "number")
+          ' "$RESULT_DIR/result.json" > /dev/null
+
+          [[ "$(jq -r '.head_sha' "$RESULT_DIR/result.json")" == "$EXPECTED_HEAD_SHA" ]]
+          [[ "$(jq -r '.run_id' "$RESULT_DIR/result.json")" == "$EXPECTED_RUN_ID" ]]
+          [[ "$(jq -r '.run_attempt' "$RESULT_DIR/result.json")" == "$EXPECTED_RUN_ATTEMPT" ]]
+
+          relevant=$(jq -r '.relevant' "$RESULT_DIR/result.json")
+          changed=$(jq -r '.changed' "$RESULT_DIR/result.json")
+          if [[ "$changed" == "true" ]]; then
+            [[ "$relevant" == "true" ]]
+            [[ -f "$RESULT_DIR/npm-deps.patch" ]]
+          else
+            [[ "$changed" == "false" ]]
+            [[ ! -e "$RESULT_DIR/npm-deps.patch" ]]
+          fi
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
       - name: Report synchronized revision
-        if: steps.artifact.outputs.id == ''
+        if: steps.result.outputs.changed == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
@@ -105,50 +137,42 @@ jobs:
             --raw-field 'output[title]=NPM dependencies synchronized' \
             --raw-field 'output[summary]=No generated NPM dependency changes are pending.'
       - name: Checkout exact Dependabot revision
-        if: steps.artifact.outputs.id != ''
+        if: steps.result.outputs.changed == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ steps.pull-request.outputs.head_sha }}
           fetch-depth: 0
           persist-credentials: false
-      - name: Download generated patch
-        if: steps.artifact.outputs.id != ''
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: vaadin-npm-sync
-          path: generated
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ github.event.workflow_run.id }}
       - name: Validate and apply patch
-        if: steps.artifact.outputs.id != ''
+        if: steps.result.outputs.changed == 'true'
         env:
           AUTHOR: ${{ steps.pull-request.outputs.author }}
           EXPECTED_HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
           HEAD_REF: ${{ steps.pull-request.outputs.head_ref }}
           HEAD_REPO: ${{ steps.pull-request.outputs.head_repo }}
+          RESULT_DIR: ${{ runner.temp }}/vaadin-npm-sync
         run: |
           [[ "$AUTHOR" == "dependabot[bot]" ]]
           [[ "$HEAD_REPO" == "$GITHUB_REPOSITORY" ]]
           [[ "$HEAD_REF" == dependabot/maven/* ]]
-          [[ "$(cat generated/head-sha)" == "$EXPECTED_HEAD_SHA" ]]
+          [[ "$(jq -r '.head_sha' "$RESULT_DIR/result.json")" == "$EXPECTED_HEAD_SHA" ]]
 
-          invalid=$(git apply --numstat generated/npm-deps.patch | cut -f3- | grep -Ev '(^|/)package[^/]*\.json$' || true)
+          invalid=$(git apply --numstat "$RESULT_DIR/npm-deps.patch" | cut -f3- | grep -Ev '(^|/)package[^/]*\.json$' || true)
           if [[ -n "$invalid" ]]; then
             echo "Patch contains invalid paths:" >&2
             echo "$invalid" >&2
             exit 1
           fi
 
-          git apply --check generated/npm-deps.patch
-          git apply generated/npm-deps.patch
+          git apply --check "$RESULT_DIR/npm-deps.patch"
+          git apply "$RESULT_DIR/npm-deps.patch"
           git add -- ':(glob)**/package*.json'
 
           invalid=$(git diff --cached --name-only | grep -Ev '(^|/)package[^/]*\.json$' || true)
           [[ -z "$invalid" ]]
           ! git diff --cached --quiet
       - name: Generate content token
-        if: steps.artifact.outputs.id != ''
+        if: steps.result.outputs.changed == 'true'
         id: content-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
@@ -156,7 +180,7 @@ jobs:
           private-key: ${{ secrets.QUARKUS_HILLA_BOT_PRIVATE_KEY }}
           permission-contents: write
       - name: Commit and push generated dependencies
-        if: steps.artifact.outputs.id != ''
+        if: steps.result.outputs.changed == 'true'
         env:
           APP_TOKEN: ${{ steps.content-token.outputs.token }}
           EXPECTED_HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
@@ -168,7 +192,7 @@ jobs:
           git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push --force-with-lease="${HEAD_REF}:${EXPECTED_HEAD_SHA}" origin "HEAD:${HEAD_REF}"
       - name: Generate pull request token
-        if: steps.artifact.outputs.id != ''
+        if: steps.result.outputs.changed == 'true'
         id: pull-request-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
@@ -176,7 +200,7 @@ jobs:
           private-key: ${{ secrets.QUARKUS_HILLA_BOT_PRIVATE_KEY }}
           permission-pull-requests: write
       - name: Update pull request metadata and comment
-        if: steps.artifact.outputs.id != ''
+        if: steps.result.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.pull-request-token.outputs.token }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/apply-vaadin-npm-deps.yaml
+++ b/.github/workflows/apply-vaadin-npm-deps.yaml
@@ -1,0 +1,141 @@
+name: Apply Vaadin NPM dependency sync
+
+on:
+  workflow_run:
+    workflows: ["Prepare Vaadin NPM dependency sync"]
+    types: [completed]
+
+permissions:
+  actions: read
+  checks: write
+  contents: write
+  pull-requests: read
+
+jobs:
+  apply:
+    name: Commit generated NPM dependencies
+    if: >-
+      github.event.workflow_run.event == 'pull_request_target' &&
+      github.event.workflow_run.pull_requests[0] != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read current pull request
+        id: pull-request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > pull-request.json
+          jq -r '"head_sha=" + .head.sha,
+                 "head_ref=" + .head.ref,
+                 "head_repo=" + .head.repo.full_name,
+                 "base_ref=" + .base.ref,
+                 "author=" + .user.login' pull-request.json >> "$GITHUB_OUTPUT"
+      - name: Validate workflow provenance
+        env:
+          BASE_REF: ${{ steps.pull-request.outputs.base_ref }}
+          HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
+          SOURCE_BASE_REF: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
+          SOURCE_HEAD_SHA: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
+        run: |
+          [[ "$BASE_REF" != "main" ]]
+          [[ "$BASE_REF" == "$SOURCE_BASE_REF" ]]
+          [[ "$HEAD_SHA" == "$SOURCE_HEAD_SHA" ]]
+      - name: Find generated patch
+        id: artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          artifact_id=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/artifacts" \
+            --jq '.artifacts[] | select(.name == "vaadin-npm-sync") | .id' | head -1)
+          echo "id=$artifact_id" >> "$GITHUB_OUTPUT"
+      - name: Report failed generation
+        if: github.event.workflow_run.conclusion != 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
+        run: |
+          gh api --method POST "repos/$GITHUB_REPOSITORY/check-runs" \
+            --raw-field name='NPM dependency sync gate' \
+            --raw-field head_sha="$HEAD_SHA" \
+            --raw-field status=completed \
+            --raw-field conclusion=failure \
+            --raw-field 'output[title]=NPM dependency generation failed' \
+            --raw-field 'output[summary]=Inspect Prepare Vaadin NPM dependency sync workflow.'
+          exit 1
+      - name: Report synchronized revision
+        if: steps.artifact.outputs.id == ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
+        run: |
+          gh api --method POST "repos/$GITHUB_REPOSITORY/check-runs" \
+            --raw-field name='NPM dependency sync gate' \
+            --raw-field head_sha="$HEAD_SHA" \
+            --raw-field status=completed \
+            --raw-field conclusion=success \
+            --raw-field 'output[title]=NPM dependencies synchronized' \
+            --raw-field 'output[summary]=No generated NPM dependency changes are pending.'
+      - name: Checkout exact Dependabot revision
+        if: steps.artifact.outputs.id != ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ steps.pull-request.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Download generated patch
+        if: steps.artifact.outputs.id != ''
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: vaadin-npm-sync
+          path: generated
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Validate and apply patch
+        if: steps.artifact.outputs.id != ''
+        env:
+          AUTHOR: ${{ steps.pull-request.outputs.author }}
+          EXPECTED_HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
+          HEAD_REF: ${{ steps.pull-request.outputs.head_ref }}
+          HEAD_REPO: ${{ steps.pull-request.outputs.head_repo }}
+        run: |
+          [[ "$AUTHOR" == "dependabot[bot]" ]]
+          [[ "$HEAD_REPO" == "$GITHUB_REPOSITORY" ]]
+          [[ "$HEAD_REF" == dependabot/maven/* ]]
+          [[ "$(cat generated/head-sha)" == "$EXPECTED_HEAD_SHA" ]]
+
+          invalid=$(git apply --numstat generated/npm-deps.patch | cut -f3- | grep -Ev '(^|/)package[^/]*\.json$' || true)
+          if [[ -n "$invalid" ]]; then
+            echo "Patch contains invalid paths:" >&2
+            echo "$invalid" >&2
+            exit 1
+          fi
+
+          git apply --check generated/npm-deps.patch
+          git apply generated/npm-deps.patch
+          git add -- ':(glob)**/package*.json'
+
+          invalid=$(git diff --cached --name-only | grep -Ev '(^|/)package[^/]*\.json$' || true)
+          [[ -z "$invalid" ]]
+          ! git diff --cached --quiet
+      - name: Generate bot token
+        if: steps.artifact.outputs.id != ''
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.QUARKUS_HILLA_BOT_ID }}
+          private-key: ${{ secrets.QUARKUS_HILLA_BOT_PRIVATE_KEY }}
+      - name: Commit and push generated dependencies
+        if: steps.artifact.outputs.id != ''
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          EXPECTED_HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
+          HEAD_REF: ${{ steps.pull-request.outputs.head_ref }}
+        run: |
+          git config user.name "quarkus-hilla-bot[bot]"
+          git config user.email "141157179+quarkus-hilla-bot[bot]@users.noreply.github.com"
+          git commit -m "chore(npm-deps): update npm dependencies"
+          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force-with-lease="${HEAD_REF}:${EXPECTED_HEAD_SHA}" origin "HEAD:${HEAD_REF}"

--- a/.github/workflows/apply-vaadin-npm-deps.yaml
+++ b/.github/workflows/apply-vaadin-npm-deps.yaml
@@ -9,7 +9,7 @@ permissions:
   actions: read
   checks: write
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   apply:
@@ -41,16 +41,7 @@ jobs:
           [[ "$BASE_REF" != "main" ]]
           [[ "$BASE_REF" == "$SOURCE_BASE_REF" ]]
           [[ "$HEAD_SHA" == "$SOURCE_HEAD_SHA" ]]
-      - name: Find generated patch
-        id: artifact
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-        run: |
-          artifact_id=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/artifacts" \
-            --jq '.artifacts[] | select(.name == "vaadin-npm-sync") | .id' | head -1)
-          echo "id=$artifact_id" >> "$GITHUB_OUTPUT"
-      - name: Report failed generation
+      - name: Publish failed generation gate
         if: github.event.workflow_run.conclusion != 'success'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -63,7 +54,78 @@ jobs:
             --raw-field conclusion=failure \
             --raw-field 'output[title]=NPM dependency generation failed' \
             --raw-field 'output[summary]=Inspect Prepare Vaadin NPM dependency sync workflow.'
-          exit 1
+      - name: Find generated patch
+        id: artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          artifact_id=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/artifacts" \
+            --jq '.artifacts[] | select(.name == "vaadin-npm-sync") | .id' | head -1)
+          echo "id=$artifact_id" >> "$GITHUB_OUTPUT"
+      - name: Download synchronization state
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: vaadin-npm-sync-state
+          path: sync-state
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Validate synchronization state
+        id: sync-state
+        env:
+          EXPECTED_HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
+        run: |
+          head_sha=$(jq -er '.headSha' sync-state/vaadin-npm-sync-state.json)
+          relevant=$(jq -er '.relevant | tostring' sync-state/vaadin-npm-sync-state.json)
+          [[ "$head_sha" == "$EXPECTED_HEAD_SHA" ]]
+          [[ "$relevant" == "true" || "$relevant" == "false" ]]
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+      - name: Update pull request sync status
+        if: steps.sync-state.outputs.relevant == 'true'
+        id: pr-status
+        continue-on-error: true
+        env:
+          ARTIFACT_ID: ${{ steps.artifact.outputs.id }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          short_sha="${HEAD_SHA:0:12}"
+          commit_url="https://github.com/${GITHUB_REPOSITORY}/commit/${HEAD_SHA}"
+          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
+
+          if [[ "$RUN_CONCLUSION" != "success" ]]; then
+            status="❌ Generation failed for"
+          elif [[ -n "$ARTIFACT_ID" ]]; then
+            status="⏳ Generated NPM update; bot commit pending for"
+          else
+            status="✅ Synchronized and validated"
+          fi
+
+          printf -v block '%s\n%s\n%s [`%s`](%s). [Workflow run](%s)\n%s' \
+            '<!-- vaadin-npm-sync:start -->' \
+            '### NPM dependency sync' \
+            "$status" "$short_sha" "$commit_url" "$run_url" \
+            '<!-- vaadin-npm-sync:end -->'
+
+          current_body=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.body // ""')
+          updated_body=$(jq -nr --arg body "$current_body" --arg block "$block" '
+            ($body
+              | gsub("(?s)<!-- vaadin-npm-sync:start -->.*?<!-- vaadin-npm-sync:end -->"; "")
+              | sub("[[:space:]]+$"; ""))
+            + "\n\n" + $block
+          ')
+          gh api --method PATCH "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+            --raw-field body="$updated_body" > /dev/null
+      - name: Warn about pull request status failure
+        if: steps.pr-status.outcome == 'failure'
+        run: echo '::warning::Unable to update NPM synchronization block in pull request description.'
+      - name: Report failed generation
+        if: github.event.workflow_run.conclusion != 'success'
+        run: exit 1
       - name: Report synchronized revision
         if: steps.artifact.outputs.id == ''
         env:
@@ -79,6 +141,7 @@ jobs:
             --raw-field 'output[summary]=No generated NPM dependency changes are pending.'
       - name: Checkout exact Dependabot revision
         if: steps.artifact.outputs.id != ''
+        id: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ steps.pull-request.outputs.head_sha }}
@@ -86,6 +149,7 @@ jobs:
           persist-credentials: false
       - name: Download generated patch
         if: steps.artifact.outputs.id != ''
+        id: patch-artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: vaadin-npm-sync
@@ -95,6 +159,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
       - name: Validate and apply patch
         if: steps.artifact.outputs.id != ''
+        id: patch
         env:
           AUTHOR: ${{ steps.pull-request.outputs.author }}
           EXPECTED_HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
@@ -129,6 +194,7 @@ jobs:
           private-key: ${{ secrets.QUARKUS_HILLA_BOT_PRIVATE_KEY }}
       - name: Commit and push generated dependencies
         if: steps.artifact.outputs.id != ''
+        id: push
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           EXPECTED_HEAD_SHA: ${{ steps.pull-request.outputs.head_sha }}
@@ -139,3 +205,24 @@ jobs:
           git commit -m "chore(npm-deps): update npm dependencies"
           git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push --force-with-lease="${HEAD_REF}:${EXPECTED_HEAD_SHA}" origin "HEAD:${HEAD_REF}"
+      - name: Report generated update application failure
+        if: >-
+          always() && steps.artifact.outputs.id != '' &&
+          (steps.checkout.outcome == 'failure' ||
+           steps.patch-artifact.outcome == 'failure' ||
+           steps.patch.outcome == 'failure' ||
+           steps.app-token.outcome == 'failure' ||
+           steps.push.outcome == 'failure')
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          current_body=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.body // ""')
+          pending='⏳ Generated NPM update; bot commit pending for'
+          failed='❌ Applying generated NPM update failed for'
+          updated_body="${current_body/$pending/$failed}"
+          if [[ "$updated_body" != "$current_body" ]]; then
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+              --raw-field body="$updated_body" > /dev/null
+          fi

--- a/.github/workflows/prepare-vaadin-npm-deps.yaml
+++ b/.github/workflows/prepare-vaadin-npm-deps.yaml
@@ -49,29 +49,29 @@ jobs:
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
   generate:
     name: Generate NPM dependency patch
-    if: needs.classify.outputs.relevant == 'true'
+    if: always() && needs.classify.result == 'success'
     needs: classify
     runs-on: ubuntu-latest
-    outputs:
-      changed: ${{ steps.patch.outputs.changed }}
     steps:
       - name: Checkout Dependabot revision
+        if: needs.classify.outputs.relevant == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
       - name: Setup Java
+        if: needs.classify.outputs.relevant == 'true'
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           java-version: 21
           distribution: temurin
       - name: Generate frontend dependencies
+        if: needs.classify.outputs.relevant == 'true'
         run: mvn -V -e -ntp install -Pall-modules -Dflatten.skip=true -DskipTests
       - name: Create restricted patch
+        if: needs.classify.outputs.relevant == 'true'
         id: patch
-        env:
-          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           git add -- ':(glob)**/package*.json'
 
@@ -102,15 +102,37 @@ jobs:
           fi
 
           git diff --cached --binary > npm-deps.patch
-          printf '%s\n' "$EXPECTED_HEAD_SHA" > head-sha
           echo "changed=true" >> "$GITHUB_OUTPUT"
-      - name: Upload NPM dependency patch
-        if: steps.patch.outputs.changed == 'true'
+      - name: Create synchronization result
+        env:
+          CHANGED: ${{ steps.patch.outputs.changed || 'false' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RELEVANT: ${{ needs.classify.outputs.relevant }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          [[ "$RELEVANT" == "true" || "$RELEVANT" == "false" ]]
+          [[ "$CHANGED" == "true" || "$CHANGED" == "false" ]]
+          [[ "$RELEVANT" == "true" || "$CHANGED" == "false" ]]
+
+          mkdir generated
+          jq -n \
+            --argjson relevant "$RELEVANT" \
+            --argjson changed "$CHANGED" \
+            --arg head_sha "$HEAD_SHA" \
+            --argjson run_id "$RUN_ID" \
+            --argjson run_attempt "$RUN_ATTEMPT" \
+            '{relevant: $relevant, changed: $changed, head_sha: $head_sha,
+              run_id: $run_id, run_attempt: $run_attempt}' \
+            > generated/result.json
+
+          if [[ "$CHANGED" == "true" ]]; then
+            cp npm-deps.patch generated/npm-deps.patch
+          fi
+      - name: Upload NPM dependency synchronization result
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: vaadin-npm-sync
-          path: |
-            npm-deps.patch
-            head-sha
+          name: vaadin-npm-sync-${{ github.run_attempt }}
+          path: generated
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/prepare-vaadin-npm-deps.yaml
+++ b/.github/workflows/prepare-vaadin-npm-deps.yaml
@@ -1,0 +1,117 @@
+name: Prepare Vaadin NPM dependency sync
+
+on:
+  pull_request_target:
+    branches: ["25.2", "25.1"]
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: vaadin-npm-sync-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    name: Classify dependency update
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.classify.outputs.relevant }}
+    steps:
+      - name: Fetch Dependabot metadata
+        if: >-
+          github.event.pull_request.user.login == 'dependabot[bot]' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.event.pull_request.head.ref, 'dependabot/maven/')
+        id: dependabot
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        with:
+          skip-commit-verification: true
+      - name: Classify update
+        id: classify
+        env:
+          DEPENDENCIES: ${{ steps.dependabot.outputs.dependency-names }}
+          PACKAGE_ECOSYSTEM: ${{ steps.dependabot.outputs.package-ecosystem }}
+        run: |
+          relevant=false
+          if [[ "$PACKAGE_ECOSYSTEM" == "maven" ]]; then
+            IFS=',' read -ra dependencies <<< "$DEPENDENCIES"
+            for dependency in "${dependencies[@]}"; do
+              dependency="${dependency//[[:space:]]/}"
+              if [[ "$dependency" == com.vaadin:* || "$dependency" == com.vaadin.hilla:* ]]; then
+                relevant=true
+                break
+              fi
+            done
+          fi
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+
+  generate:
+    name: Generate NPM dependency patch
+    if: needs.classify.outputs.relevant == 'true'
+    needs: classify
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.patch.outputs.changed }}
+    steps:
+      - name: Checkout Dependabot revision
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Java
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        with:
+          java-version: 21
+          distribution: temurin
+      - name: Generate frontend dependencies
+        run: mvn -V -e -ntp install -Pall-modules -Dflatten.skip=true -DskipTests
+      - name: Create restricted patch
+        id: patch
+        env:
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git add -- ':(glob)**/package*.json'
+
+          unexpected=$(git diff --name-only -- . ':(exclude,glob)**/package*.json')
+          if [[ -n "$unexpected" ]]; then
+            echo "Build changed files outside package manifests:" >&2
+            echo "$unexpected" >&2
+            exit 1
+          fi
+
+          unexpected_untracked=$(git ls-files --others --exclude-standard | grep -Ev '(^|/)package[^/]*\.json$' || true)
+          if [[ -n "$unexpected_untracked" ]]; then
+            echo "Build created unexpected untracked files:" >&2
+            echo "$unexpected_untracked" >&2
+            exit 1
+          fi
+
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          invalid=$(git diff --cached --name-only | grep -Ev '(^|/)package[^/]*\.json$' || true)
+          if [[ -n "$invalid" ]]; then
+            echo "Patch contains invalid paths:" >&2
+            echo "$invalid" >&2
+            exit 1
+          fi
+
+          git diff --cached --binary > npm-deps.patch
+          printf '%s\n' "$EXPECTED_HEAD_SHA" > head-sha
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+      - name: Upload NPM dependency patch
+        if: steps.patch.outputs.changed == 'true'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: vaadin-npm-sync
+          path: |
+            npm-deps.patch
+            head-sha
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/prepare-vaadin-npm-deps.yaml
+++ b/.github/workflows/prepare-vaadin-npm-deps.yaml
@@ -47,6 +47,20 @@ jobs:
             done
           fi
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+      - name: Write synchronization state
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RELEVANT: ${{ steps.classify.outputs.relevant }}
+        run: |
+          jq -n --arg headSha "$HEAD_SHA" --argjson relevant "$RELEVANT" \
+            '{headSha: $headSha, relevant: $relevant}' > vaadin-npm-sync-state.json
+      - name: Upload synchronization state
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: vaadin-npm-sync-state
+          path: vaadin-npm-sync-state.json
+          if-no-files-found: error
+          retention-days: 1
 
   generate:
     name: Generate NPM dependency patch

--- a/.github/workflows/prepare-vaadin-npm-deps.yaml
+++ b/.github/workflows/prepare-vaadin-npm-deps.yaml
@@ -47,21 +47,6 @@ jobs:
             done
           fi
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
-      - name: Write synchronization state
-        env:
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RELEVANT: ${{ steps.classify.outputs.relevant }}
-        run: |
-          jq -n --arg headSha "$HEAD_SHA" --argjson relevant "$RELEVANT" \
-            '{headSha: $headSha, relevant: $relevant}' > vaadin-npm-sync-state.json
-      - name: Upload synchronization state
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-        with:
-          name: vaadin-npm-sync-state
-          path: vaadin-npm-sync-state.json
-          if-no-files-found: error
-          retention-days: 1
-
   generate:
     name: Generate NPM dependency patch
     if: needs.classify.outputs.relevant == 'true'

--- a/.github/workflows/update-npm-deps.yaml
+++ b/.github/workflows/update-npm-deps.yaml
@@ -12,35 +12,19 @@ on:
           - "25.2"
           - "25.1"
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 2 * * 1'
 permissions:
   contents: read
 jobs:
-  compute-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Compute matrix
-        id: set-matrix
-        env:
-          CMD_TARGET_BRANCH: ${{ inputs.target-branch }}
-        run: |
-          if [[ -z "$CMD_TARGET_BRANCH" ]]; then
-            echo 'matrix={ "branch": ["main","25.2","25.1"] }' >> "$GITHUB_OUTPUT"
-          else
-            echo 'matrix={ "branch": ["'$CMD_TARGET_BRANCH'"] }' >> "$GITHUB_OUTPUT"
-          fi
   update-npm-deps:
     permissions:
       pull-requests: write
       contents: write
     runs-on: ubuntu-latest
-    needs: [compute-matrix]
     name: Update NPM dependencies
-    strategy:
-      fail-fast: false
-      matrix: ${{fromJson(needs.compute-matrix.outputs.matrix)}}
+    env:
+      TARGET_BRANCH: ${{ inputs.target-branch || 'main' }}
+      UPDATE_BRANCH: ${{ format('chore/update_npm_deps_{0}', inputs.target-branch || 'main') }}
     steps:
       - name: Generate token
         uses: tibdex/github-app-token@v2
@@ -51,7 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: refs/heads/${{ matrix.branch }}
+          ref: refs/heads/${{ env.TARGET_BRANCH }}
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
       - name: Setup Java
@@ -63,7 +47,8 @@ jobs:
         id: searchpr
         run: |
           existingPR=$(gh pr list --author "app/quarkus-hilla-bot" --json id,title,baseRefName,headRefName,number | \
-            jq '.[] | select( .baseRefName == "${{ matrix.branch }}" and .headRefName == "chore/update_npm_deps_${{ matrix.branch }}" ) | .number')
+            jq --arg target "$TARGET_BRANCH" --arg update "$UPDATE_BRANCH" \
+              '.[] | select(.baseRefName == $target and .headRefName == $update) | .number')
           echo "prNumber=${existingPR:-0}" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -72,7 +57,7 @@ jobs:
         run: |
           gh pr checkout ${{ steps.searchpr.outputs.prNumber }}
           git -c user.name="quarkus-hilla-bot[bot]" -c user.email="141157179+quarkus-hilla-bot[bot]@users.noreply.github.com" \
-            rebase ${{ matrix.branch }}
+            rebase "$TARGET_BRANCH"
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Build
@@ -87,15 +72,15 @@ jobs:
           commit_user_name: "quarkus-hilla-bot[bot]"
           commit_user_email: "141157179+quarkus-hilla-bot[bot]@users.noreply.github.com"
           commit_author: "quarkus-hilla-bot[bot] <quarkus-hilla-bot[bot]@141157179+users.noreply.github.com>"
-          branch: "chore/update_npm_deps_${{ matrix.branch }}"
+          branch: ${{ env.UPDATE_BRANCH }}
           create_branch: ${{ steps.searchpr.outputs.prNumber == '0' }}
           file_pattern: ':(glob)**/package*.json'
           push_options: '--force-with-lease'
       - name: Create PR
         if: ${{ steps.commit-changes.outputs.changes_detected == 'true' && steps.searchpr.outputs.prNumber == '0' }}
         run: |
-          gh pr create --head chore/update_npm_deps_${{ matrix.branch }} --base ${{ matrix.branch }} \
-            --title "chore(npm-deps): update npm dependencies (${{ matrix.branch }})" \
+          gh pr create --head "$UPDATE_BRANCH" --base "$TARGET_BRANCH" \
+            --title "chore(npm-deps): update npm dependencies ($TARGET_BRANCH)" \
             --body "" --label "dependencies" >> "$GITHUB_STEP_SUMMARY" 2>&1
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/docs/bump-project-version.md
+++ b/docs/bump-project-version.md
@@ -54,9 +54,20 @@ The Maven properties are bumped via `mvn versions:set-property`:
 The previous version `C` is added as a target/branch entry alongside `main`, so the maintenance branch keeps running CI:
 
 - `release.yaml` — `on.workflow_dispatch.inputs.target-branch.options`
-- `update-npm-deps.yaml` — same options list, plus the embedded matrix in `jobs.compute-matrix.steps[0].run`
+- `update-npm-deps.yaml` — same options list for manual recovery runs; its weekly schedule remains limited to `main`
+- `prepare-vaadin-npm-deps.yaml` — `on.pull_request_target.branches`
 - `validation.yaml` — `on.push.branches`
 - `validation-nightly.yaml` — `jobs.snapshot-main.strategy.matrix.branch`
+
+Vaadin/Hilla Dependabot updates on maintenance branches trigger `prepare-vaadin-npm-deps.yaml`. It regenerates the
+frontend package manifests and passes them to the privileged `apply-vaadin-npm-deps.yaml` workflow, which commits the
+generated files into the same Dependabot pull request. The preparation workflow runs pull request code with read-only
+permissions; write credentials remain isolated in the applying workflow. The applying workflow writes the merge-gate
+check directly to the pull request head revision, independent of the target branch's workflow files.
+
+Configure `NPM dependency sync gate` as a required status check for every active maintenance branch. Until the check
+reports success, the original Dependabot revision has no successful gate. The check passes only after the bot commit has
+been validated on the new revision. Without the required-check rule, GitHub does not enforce this merge gate.
 
 ### `.github/dependabot.yml`
 

--- a/docs/bump-project-version.md
+++ b/docs/bump-project-version.md
@@ -63,9 +63,9 @@ Vaadin/Hilla Dependabot updates on maintenance branches trigger `prepare-vaadin-
 frontend package manifests and passes them to the privileged `apply-vaadin-npm-deps.yaml` workflow, which commits the
 generated files into the same Dependabot pull request. The preparation workflow runs pull request code with read-only
 permissions; write credentials remain isolated in the applying workflow. The applying workflow writes the merge-gate
-check directly to the pull request head revision, independent of the target branch's workflow files. It also maintains
-an idempotent NPM synchronization status block in the Dependabot pull request description, including the validated
-revision and workflow-run link.
+check directly to the pull request head revision, independent of the target branch's workflow files. After pushing
+generated dependencies, it adds `+ npm dependencies` to the pull request title, appends a short note to the pull request
+description and posts a comment linking the bot commit.
 
 Configure `NPM dependency sync gate` as a required status check for every active maintenance branch. Until the check
 reports success, the original Dependabot revision has no successful gate. The check passes only after the bot commit has

--- a/docs/bump-project-version.md
+++ b/docs/bump-project-version.md
@@ -63,7 +63,9 @@ Vaadin/Hilla Dependabot updates on maintenance branches trigger `prepare-vaadin-
 frontend package manifests and passes them to the privileged `apply-vaadin-npm-deps.yaml` workflow, which commits the
 generated files into the same Dependabot pull request. The preparation workflow runs pull request code with read-only
 permissions; write credentials remain isolated in the applying workflow. The applying workflow writes the merge-gate
-check directly to the pull request head revision, independent of the target branch's workflow files.
+check directly to the pull request head revision, independent of the target branch's workflow files. It also maintains
+an idempotent NPM synchronization status block in the Dependabot pull request description, including the validated
+revision and workflow-run link.
 
 Configure `NPM dependency sync gate` as a required status check for every active maintenance branch. Until the check
 reports success, the original Dependabot revision has no successful gate. The check passes only after the bot commit has

--- a/etc/UpdateProjectVersion.java
+++ b/etc/UpdateProjectVersion.java
@@ -92,7 +92,9 @@ class UpdateProjectVersion implements Runnable {
             patch(workflows.resolve("release.yaml"),
                     c -> insertOptionAfterMain(c, currentVersion));
             patch(workflows.resolve("update-npm-deps.yaml"),
-                    c -> insertInRunScript(insertOptionAfterMain(c, currentVersion), currentVersion));
+                    c -> insertOptionAfterMain(c, currentVersion));
+            patch(workflows.resolve("prepare-vaadin-npm-deps.yaml"),
+                    c -> insertQuotedFlowArrayItemFirst(c, "branches", currentVersion));
             patch(workflows.resolve("validation.yaml"),
                     c -> insertFlowArrayItemAfterMain(c, "branches", currentVersion));
             patch(workflows.resolve("validation-nightly.yaml"),
@@ -257,20 +259,17 @@ class UpdateProjectVersion implements Runnable {
         return content.replace(marker, marker + inserted);
     }
 
-    /**
-     * Replaces the literal {@code "main"} token in the {@code compute-matrix} run script with
-     * {@code "main","<version>"}. Used for {@code update-npm-deps.yaml}.
-     */
-    static String insertInRunScript(String content, String version) {
-        String token = "\"main\"";
-        String replacement = "\"main\",\"" + version + "\"";
-        if (content.contains(replacement)) {
+    /** Inserts {@code "<version>"} at the start of a quoted YAML flow array. */
+    static String insertQuotedFlowArrayItemFirst(String content, String key, String version) {
+        String marker = key + ": [";
+        String inserted = marker + "\"" + version + "\", ";
+        if (content.contains(inserted)) {
             return content;
         }
-        if (!content.contains(token)) {
-            return content;
+        if (!content.contains(marker)) {
+            throw new IllegalStateException("Cannot find flow array '" + key + ": [...]' to insert version into");
         }
-        return content.replace(token, replacement);
+        return content.replace(marker, inserted);
     }
 
     /**


### PR DESCRIPTION
## Summary

- regenerate NPM package manifests inside Vaadin/Hilla Dependabot PRs on maintenance branches
- keep standalone scheduled NPM updates weekly and limited to `main`
- process exactly one target branch per standalone run; no branch matrix
- isolate untrusted generation from privileged artifact application
- publish `NPM dependency sync gate` against the exact PR head SHA
- after a successful bot push, add `+ npm dependencies` to the title, append a short body note, and post a commit-linked comment
- reject closed PRs and stale or superseded preparation runs before gate publication or write access
- keep future maintenance branches wired through `UpdateProjectVersion.java`

## Merge gate rollout

Repository currently has no branch protection or rulesets. After merging this PR, an administrator must require the `NPM dependency sync gate` check on `25.2` and `25.1`. Until that remote rule exists, GitHub does not enforce merge blocking.

## Validation

- `actionlint` 1.7.12 on all changed workflows
- `git diff --check`
- `UpdateProjectVersion.java` dry run for `25.4`
- independent workflow security and permission reviews

## Why two workflows?

The split is an intentional privilege boundary. `Prepare Vaadin NPM dependency sync` runs Maven code from the Dependabot pull request with read-only permissions and without write credentials. Dependabot-triggered `pull_request_target` runs cannot access the normal Actions secrets required to create the bot token.

`Apply Vaadin NPM dependency sync` therefore starts through the trusted `workflow_run` event after preparation completes. It can access the bot secrets, but never executes pull request code. Before applying the artifact, it validates pull request provenance, open state, source-run freshness, exact head SHA, changed paths, and patch applicability.

Combining both stages would either make the bot credentials unavailable or place untrusted build execution and repository write credentials in the same privileged workflow. The two-workflow design avoids both outcomes.

## Security model

Write tokens are created only after artifact validation and split by purpose: `contents: write` for commit/push, then `pull-requests: write` after a successful push for title, body note, and comment.

Implementation co-authored with OpenAI Codex.