### PR TITLE
fix(security): preserve Hilla client route hierarchy

### DIFF
--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/FileRoutesManifestBuildItem.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/FileRoutesManifestBuildItem.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.security;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+final class FileRoutesManifestBuildItem extends SimpleBuildItem {
+
+    private final boolean expected;
+
+    FileRoutesManifestBuildItem(boolean expected) {
+        this.expected = expected;
+    }
+
+    boolean isExpected() {
+        return expected;
+    }
+}

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/FileRoutesManifestClassifier.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/FileRoutesManifestClassifier.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import com.vaadin.flow.internal.FrontendUtils;
 import com.vaadin.flow.internal.StringUtil;
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
 final class FileRoutesManifestClassifier {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FileRoutesManifestClassifier.class);
+    private static final Pattern WITH_FILE_ROUTES_CALL = Pattern.compile("withFileRoutes\\s*\\(");
 
     private FileRoutesManifestClassifier() {}
 
@@ -49,7 +51,7 @@ final class FileRoutesManifestClassifier {
 
         try {
             String routes = StringUtil.removeComments(Files.readString(customRoutes));
-            return routes.contains("withFileRoutes(");
+            return WITH_FILE_ROUTES_CALL.matcher(routes).find();
         } catch (IOException exception) {
             LOGGER.warn(
                     "Cannot inspect custom React router {}; expecting generated file routes", customRoutes, exception);

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/FileRoutesManifestClassifier.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/FileRoutesManifestClassifier.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.security;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import com.vaadin.flow.internal.FrontendUtils;
+import com.vaadin.flow.internal.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class FileRoutesManifestClassifier {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileRoutesManifestClassifier.class);
+
+    private FileRoutesManifestClassifier() {}
+
+    static boolean isManifestExpected(File frontendDirectory, Optional<Boolean> reactEnabledOverride) {
+        boolean reactEnabled =
+                reactEnabledOverride.orElseGet(() -> FrontendUtils.isReactRouterRequired(frontendDirectory));
+        if (!reactEnabled) {
+            return false;
+        }
+
+        Path routesTsx = frontendDirectory.toPath().resolve("routes.tsx");
+        Path routesTs = frontendDirectory.toPath().resolve("routes.ts");
+        Path customRoutes =
+                Files.isRegularFile(routesTsx) ? routesTsx : Files.isRegularFile(routesTs) ? routesTs : null;
+        if (customRoutes == null) {
+            return FrontendUtils.isHillaViewsUsed(frontendDirectory);
+        }
+
+        try {
+            String routes = StringUtil.removeComments(Files.readString(customRoutes));
+            return routes.contains("withFileRoutes(");
+        } catch (IOException exception) {
+            LOGGER.warn(
+                    "Cannot inspect custom React router {}; expecting generated file routes", customRoutes, exception);
+            return true;
+        }
+    }
+}

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
@@ -50,7 +50,10 @@ class QuarkusHillaSecurityProcessor {
 
     @BuildStep
     FileRoutesManifestBuildItem fileRoutesManifestExpected(
-            VaadinBuildTimeConfig vaadinConfig, CurateOutcomeBuildItem curateOutcome) {
+            AuthFormBuildItem authForm, VaadinBuildTimeConfig vaadinConfig, CurateOutcomeBuildItem curateOutcome) {
+        if (!authForm.isEnabled()) {
+            return new FileRoutesManifestBuildItem(false);
+        }
         var applicationModule = curateOutcome.getApplicationModel().getApplicationModule();
         if (applicationModule == null) {
             // Vaadin can recover workspace information from its generated

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
@@ -16,11 +16,15 @@
 package com.github.mcollovati.quarkus.hilla.deployment.security;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
 import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
 import com.vaadin.flow.server.auth.DefaultAccessCheckDecisionResolver;
+import com.vaadin.quarkus.deployment.vaadinplugin.VaadinBuildTimeConfig;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -31,6 +35,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.DotName;
@@ -42,6 +47,35 @@ import com.github.mcollovati.quarkus.hilla.security.HillaSecurityRecorder;
 import com.github.mcollovati.quarkus.hilla.security.QuarkusNavigationAccessControl;
 
 class QuarkusHillaSecurityProcessor {
+
+    @BuildStep
+    FileRoutesManifestBuildItem fileRoutesManifestExpected(
+            VaadinBuildTimeConfig vaadinConfig, CurateOutcomeBuildItem curateOutcome) {
+        var applicationModule = curateOutcome.getApplicationModel().getApplicationModule();
+        if (applicationModule == null) {
+            // Vaadin can recover workspace information from its generated
+            // metadata. If it is unavailable here, classification is not
+            // possible, so keep route security fail-closed.
+            return new FileRoutesManifestBuildItem(true);
+        }
+        File configuredFrontend = vaadinConfig.frontendDirectory();
+        File frontendDirectory =
+                resolveFrontendDirectory(applicationModule.getModuleDir().toPath(), configuredFrontend);
+        return new FileRoutesManifestBuildItem(
+                FileRoutesManifestClassifier.isManifestExpected(frontendDirectory, vaadinConfig.reactEnabled()));
+    }
+
+    static File resolveFrontendDirectory(Path moduleDirectory, File configuredFrontend) {
+        Path configuredPath = configuredFrontend.toPath();
+        Path frontendDirectory = configuredPath.isAbsolute() ? configuredPath : moduleDirectory.resolve(configuredPath);
+        if (configuredPath.equals(Path.of("src", "main", "frontend")) && !Files.isDirectory(frontendDirectory)) {
+            Path legacyFrontendDirectory = moduleDirectory.resolve("frontend");
+            if (Files.isDirectory(legacyFrontendDirectory)) {
+                return legacyFrontendDirectory.toFile();
+            }
+        }
+        return frontendDirectory.toFile();
+    }
 
     @BuildStep
     AuthFormBuildItem authFormEnabledBuildItem() {
@@ -84,9 +118,12 @@ class QuarkusHillaSecurityProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
     void configureHillaSecurityComponents(
-            AuthFormBuildItem authFormBuildItem, HillaSecurityRecorder recorder, BeanContainerBuildItem beanContainer) {
+            AuthFormBuildItem authFormBuildItem,
+            FileRoutesManifestBuildItem fileRoutesManifest,
+            HillaSecurityRecorder recorder,
+            BeanContainerBuildItem beanContainer) {
         if (authFormBuildItem.isEnabled()) {
-            recorder.configureHttpSecurityPolicy(beanContainer.getValue());
+            recorder.configureHttpSecurityPolicy(beanContainer.getValue(), fileRoutesManifest.isExpected());
         }
     }
 

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/FileRoutesManifestClassifierTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/FileRoutesManifestClassifierTest.java
@@ -47,6 +47,15 @@ class FileRoutesManifestClassifierTest {
     }
 
     @Test
+    void hybridCustomRouterWithWhitespaceBeforeCallExpectsManifest() throws Exception {
+        Files.writeString(
+                frontendDirectory.resolve("routes.tsx"),
+                "export const routes = new RouterConfigurationBuilder().withFileRoutes\n  (fileRoutes).build();");
+
+        assertThat(classify(Optional.of(true))).isTrue();
+    }
+
+    @Test
     void pureCustomReactRouterCompositionDoesNotExpectManifest() throws Exception {
         Files.writeString(
                 frontendDirectory.resolve("routes.tsx"), "export const routes = withReactRoutes(customRoutes);");

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/FileRoutesManifestClassifierTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/FileRoutesManifestClassifierTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.security;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileRoutesManifestClassifierTest {
+
+    @TempDir
+    Path frontendDirectory;
+
+    @Test
+    void defaultReactRouterWithHillaViewExpectsManifest() throws Exception {
+        Path views = Files.createDirectories(frontendDirectory.resolve("views"));
+        Files.writeString(views.resolve("DashboardView.tsx"), "export default function DashboardView() {}");
+
+        assertThat(classify(Optional.of(true))).isTrue();
+    }
+
+    @Test
+    void hybridCustomRouterExpectsManifest() throws Exception {
+        Files.writeString(
+                frontendDirectory.resolve("routes.tsx"),
+                "export const routes = [customRoute, ...withFileRoutes(fileRoutes)];");
+
+        assertThat(classify(Optional.of(true))).isTrue();
+    }
+
+    @Test
+    void pureCustomReactRouterCompositionDoesNotExpectManifest() throws Exception {
+        Files.writeString(
+                frontendDirectory.resolve("routes.tsx"), "export const routes = withReactRoutes(customRoutes);");
+
+        assertThat(classify(Optional.of(true))).isFalse();
+    }
+
+    @Test
+    void pureCustomReactRouterDoesNotExpectManifest() throws Exception {
+        Path views = Files.createDirectories(frontendDirectory.resolve("views"));
+        Files.writeString(views.resolve("DashboardView.tsx"), "export default function DashboardView() {}");
+        Files.writeString(
+                frontendDirectory.resolve("routes.tsx"),
+                "export const router = createBrowserRouter([{ path: '/', element: <Home /> }]);");
+
+        assertThat(classify(Optional.of(true))).isFalse();
+    }
+
+    @Test
+    void commentedFileRoutesCompositionDoesNotMakeCustomRouterHybrid() throws Exception {
+        Files.writeString(
+                frontendDirectory.resolve("routes.tsx"),
+                "// withFileRoutes(fileRoutes)\nexport const router = createBrowserRouter(customRoutes);");
+
+        assertThat(classify(Optional.of(true))).isFalse();
+    }
+
+    @Test
+    void litRouterDoesNotExpectManifest() throws Exception {
+        Files.writeString(frontendDirectory.resolve("index.ts"), "import { Router } from '@vaadin/router';");
+
+        assertThat(classify(Optional.empty())).isFalse();
+    }
+
+    private boolean classify(Optional<Boolean> reactEnabledOverride) {
+        return FileRoutesManifestClassifier.isManifestExpected(frontendDirectory.toFile(), reactEnabledOverride);
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessorTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessorTest.java
@@ -15,16 +15,42 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.security;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
 import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
+import io.quarkus.bootstrap.model.ApplicationModelBuilder;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
 import org.jboss.jandex.DotName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class QuarkusHillaSecurityProcessorTest {
+
+    @TempDir
+    Path moduleDirectory;
+
+    @Test
+    void unavailableApplicationModuleExpectsManifestToFailClosed() {
+        var applicationModel = new ApplicationModelBuilder()
+                .setAppArtifact(ResolvedDependencyBuilder.newInstance()
+                        .setGroupId("org.acme")
+                        .setArtifactId("app")
+                        .setVersion("1.0"))
+                .build();
+        CurateOutcomeBuildItem curateOutcome = new CurateOutcomeBuildItem(applicationModel);
+
+        FileRoutesManifestBuildItem result =
+                new QuarkusHillaSecurityProcessor().fileRoutesManifestExpected(null, curateOutcome);
+
+        assertThat(result.isExpected()).isTrue();
+    }
 
     @Test
     void formAuthentication_registersAnnotatedCheckerForDefaultDeny() {
@@ -37,5 +63,46 @@ class QuarkusHillaSecurityProcessorTest {
         assertThat(accessCheckers)
                 .extracting(NavigationAccessCheckerBuildItem::getAccessChecker)
                 .containsExactly(DotName.createSimple(AnnotatedViewAccessChecker.class));
+    }
+
+    @Test
+    void defaultMissingFrontendDirectoryUsesLegacyFrontendDirectory() throws Exception {
+        Path legacyFrontend = Files.createDirectory(moduleDirectory.resolve("frontend"));
+
+        File resolved =
+                QuarkusHillaSecurityProcessor.resolveFrontendDirectory(moduleDirectory, new File("src/main/frontend"));
+
+        assertThat(resolved.toPath()).isEqualTo(legacyFrontend);
+    }
+
+    @Test
+    void existingDefaultFrontendDirectoryWinsOverLegacyFrontendDirectory() throws Exception {
+        Path defaultFrontend = Files.createDirectories(moduleDirectory.resolve("src/main/frontend"));
+        Files.createDirectory(moduleDirectory.resolve("frontend"));
+
+        File resolved =
+                QuarkusHillaSecurityProcessor.resolveFrontendDirectory(moduleDirectory, new File("src/main/frontend"));
+
+        assertThat(resolved.toPath()).isEqualTo(defaultFrontend);
+    }
+
+    @Test
+    void customRelativeFrontendDirectoryRemainsConfigured() throws Exception {
+        Files.createDirectory(moduleDirectory.resolve("frontend"));
+
+        File resolved = QuarkusHillaSecurityProcessor.resolveFrontendDirectory(moduleDirectory, new File("web/client"));
+
+        assertThat(resolved.toPath()).isEqualTo(moduleDirectory.resolve("web/client"));
+    }
+
+    @Test
+    void absoluteFrontendDirectoryRemainsConfigured() throws Exception {
+        Files.createDirectory(moduleDirectory.resolve("frontend"));
+        Path absoluteFrontend = moduleDirectory.resolve("external-client").toAbsolutePath();
+
+        File resolved =
+                QuarkusHillaSecurityProcessor.resolveFrontendDirectory(moduleDirectory, absoluteFrontend.toFile());
+
+        assertThat(resolved.toPath()).isEqualTo(absoluteFrontend);
     }
 }

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessorTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessorTest.java
@@ -46,10 +46,18 @@ class QuarkusHillaSecurityProcessorTest {
                 .build();
         CurateOutcomeBuildItem curateOutcome = new CurateOutcomeBuildItem(applicationModel);
 
-        FileRoutesManifestBuildItem result =
-                new QuarkusHillaSecurityProcessor().fileRoutesManifestExpected(null, curateOutcome);
+        FileRoutesManifestBuildItem result = new QuarkusHillaSecurityProcessor()
+                .fileRoutesManifestExpected(new AuthFormBuildItem(true), null, curateOutcome);
 
         assertThat(result.isExpected()).isTrue();
+    }
+
+    @Test
+    void disabledFormAuthenticationSkipsManifestClassification() {
+        FileRoutesManifestBuildItem result = new QuarkusHillaSecurityProcessor()
+                .fileRoutesManifestExpected(new AuthFormBuildItem(false), null, null);
+
+        assertThat(result.isExpected()).isFalse();
     }
 
     @Test

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/ReactRouterCompatibilityTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/ReactRouterCompatibilityTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.security;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReactRouterCompatibilityTest {
+
+    @Test
+    void reactRouterVersionChangeRequiresRouteMatcherReview() throws IOException {
+        try (var packageLock = getClass().getClassLoader().getResourceAsStream("vaadin-dev-bundle/package-lock.json")) {
+            assertNotNull(packageLock, "Vaadin frontend dependency lock is missing");
+            String content = new String(packageLock.readAllBytes(), StandardCharsets.UTF_8);
+            var matcher = Pattern.compile(
+                            "\\\"node_modules/react-router\\\"\\s*:\\s*\\{\\s*\\\"version\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"")
+                    .matcher(content);
+
+            assertTrue(matcher.find(), "React Router version is missing from Vaadin frontend dependency lock");
+            assertEquals("8.3.0", matcher.group(1), "Revalidate RoutePatternMatcher against new React Router source");
+        }
+    }
+}

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/AuthorizationDecision.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/AuthorizationDecision.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.security;
+
+/**
+ * Result of evaluating one authorization source.
+ *
+ * <p>{@link #NO_MATCH} means that the source does not apply and allows the
+ * caller to consult another source. It must not be treated as an allow or a
+ * deny decision.
+ */
+enum AuthorizationDecision {
+    /** Authorization source does not apply to the evaluated target. */
+    NO_MATCH,
+
+    /** Authorization source explicitly allows access. */
+    ALLOW,
+
+    /** Authorization source explicitly denies access. */
+    DENY
+}

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/AuthorizationDecision.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/AuthorizationDecision.java
@@ -23,12 +23,18 @@ package com.github.mcollovati.quarkus.hilla.security;
  * deny decision.
  */
 enum AuthorizationDecision {
-    /** Authorization source does not apply to the evaluated target. */
+    /**
+     * Authorization source does not apply to the evaluated target.
+     */
     NO_MATCH,
 
-    /** Authorization source explicitly allows access. */
+    /**
+     * Authorization source explicitly allows access.
+     */
     ALLOW,
 
-    /** Authorization source explicitly denies access. */
+    /**
+     * Authorization source explicitly denies access.
+     */
     DENY
 }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicy.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicy.java
@@ -157,6 +157,7 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
 
     void setFileRoutesManifestExpected(boolean fileRoutesManifestExpected) {
         this.fileRoutesManifestExpected = fileRoutesManifestExpected;
+        initializeRouteUtil();
     }
 
     /**
@@ -274,7 +275,13 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
 
     void onVaadinServiceInit(@Observes ServiceInitEvent serviceInitEvent) {
         vaadinService = serviceInitEvent.getSource();
-        routeUtil = new RouteUtil(vaadinService, fileRoutesManifestExpected);
+        initializeRouteUtil();
         webIconsRequestMatcher = new WebIconsRequestMatcher(vaadinService, getUrlMapping());
+    }
+
+    private void initializeRouteUtil() {
+        if (vaadinService != null) {
+            routeUtil = new RouteUtil(vaadinService, fileRoutesManifestExpected);
+        }
     }
 }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicy.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicy.java
@@ -101,18 +101,33 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
         if ((permittedPath != null && permittedPath)
                 || isFrameworkInternalRequest(request)
                 || isAnonymousEndpoint(request)
-                || isAnonymousRoute(tryCreateNavigationContext(request), request.normalizedPath())
                 || isCustomWebIcon(request)) {
             return CheckResult.permit();
         }
         return identity.flatMap(secIdentity -> {
-            if (isAllowedHillaView(request, secIdentity)) return CheckResult.permit();
-            return authenticatedHttpSecurityPolicy.checkPermission(request, identity, requestContext);
+            NavigationContext flowNavigation = tryCreateNavigationContext(request);
+            if (flowNavigation != null) {
+                if (isAnonymousFlowRoute(flowNavigation, request.normalizedPath())) {
+                    return CheckResult.permit();
+                }
+                // Flow performs its role-aware check during navigation. At the
+                // HTTP boundary, preserve existing behavior: non-public Flow
+                // routes require authentication.
+                return authenticatedHttpSecurityPolicy.checkPermission(request, identity, requestContext);
+            }
+            if (routeUtil == null) {
+                getLogger().warn("Hilla routes cannot be evaluated before VaadinService initialization");
+                return CheckResult.deny();
+            }
+            AuthorizationDecision hillaDecision = routeUtil.checkRouteAccess(request, secIdentity);
+            return switch (hillaDecision) {
+                case ALLOW -> CheckResult.permit();
+                case DENY -> CheckResult.deny();
+                // This policy only owns Flow and generated Hilla routes. Other
+                // paths remain available to Quarkus HTTP authorization rules.
+                case NO_MATCH -> CheckResult.permit();
+            };
         });
-    }
-
-    private boolean isAllowedHillaView(RoutingContext request, SecurityIdentity secIdentity) {
-        return routeUtil.isRouteAllowed(request, secIdentity);
     }
 
     private boolean isCustomWebIcon(RoutingContext request) {
@@ -156,15 +171,10 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
         return QuarkusHandlerHelper.isFrameworkInternalRequest(vaadinMapping, request);
     }
 
-    private boolean isAnonymousRoute(NavigationContext navigationContext, String path) {
-
+    private boolean isAnonymousFlowRoute(NavigationContext navigationContext, String path) {
         if (vaadinService == null) {
             getLogger().warn("VaadinService not set. Cannot determine server route for {}", path);
-            return true;
-        }
-        if (navigationContext == null) {
-            getLogger().trace("No route defined for {}", path);
-            return true;
+            return false;
         }
         boolean productionMode = vaadinService.getDeploymentConfiguration().isProductionMode();
 
@@ -176,10 +186,20 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
             } else {
                 getLogger().info(message, path);
             }
-            return true;
+            return false;
         }
 
-        AccessCheckResult result = accessControl.checkAccess(navigationContext, productionMode);
+        AccessCheckResult result;
+        try {
+            result = accessControl.checkAccess(navigationContext, productionMode);
+        } catch (RuntimeException exception) {
+            getLogger().warn("Cannot determine whether Flow route {} is public", path, exception);
+            return false;
+        }
+        if (result == null) {
+            getLogger().warn("Flow route access evaluation returned no result for {}", path);
+            return false;
+        }
         boolean isAllowed = result.decision() == AccessCheckDecision.ALLOW;
         if (isAllowed) {
             getLogger().debug("{} refers to a public view", path);

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicy.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicy.java
@@ -101,17 +101,18 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
     @Override
     public Uni<CheckResult> checkPermission(
             RoutingContext request, Uni<SecurityIdentity> identity, AuthorizationRequestContext requestContext) {
-        Boolean permittedPath = permitAllMatcher.match(request.request().path()).getValue();
+        String normalizedPath = request.normalizedPath();
+        Boolean permittedPath = permitAllMatcher.match(normalizedPath).getValue();
         if ((permittedPath != null && permittedPath)
                 || isFrameworkInternalRequest(request)
                 || isAnonymousEndpoint(request)
-                || isCustomWebIcon(request)) {
+                || isCustomWebIcon(normalizedPath)) {
             return CheckResult.permit();
         }
         return identity.flatMap(secIdentity -> {
             NavigationContext flowNavigation = tryCreateNavigationContext(request);
             if (flowNavigation != null) {
-                if (isAnonymousFlowRoute(flowNavigation, request.normalizedPath())) {
+                if (isAnonymousFlowRoute(flowNavigation, normalizedPath)) {
                     return CheckResult.permit();
                 }
                 // Flow performs its role-aware check during navigation. At the
@@ -134,9 +135,8 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
         });
     }
 
-    private boolean isCustomWebIcon(RoutingContext request) {
-        return webIconsRequestMatcher != null
-                && webIconsRequestMatcher.isWebIconRequest(request.request().path());
+    private boolean isCustomWebIcon(String normalizedPath) {
+        return webIconsRequestMatcher != null && webIconsRequestMatcher.isWebIconRequest(normalizedPath);
     }
 
     private boolean isAnonymousEndpoint(RoutingContext request) {

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicy.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicy.java
@@ -67,6 +67,7 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
     // Stay fail-closed until runtime initialization applies the build-time
     // classification.
     private boolean fileRoutesManifestExpected = true;
+    private boolean fileRoutesManifestClassificationApplied;
 
     public HillaSecurityPolicy(
             NavigationAccessControl accessControl,
@@ -134,7 +135,8 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
     }
 
     private boolean isCustomWebIcon(RoutingContext request) {
-        return webIconsRequestMatcher.isWebIconRequest(request.request().path());
+        return webIconsRequestMatcher != null
+                && webIconsRequestMatcher.isWebIconRequest(request.request().path());
     }
 
     private boolean isAnonymousEndpoint(RoutingContext request) {
@@ -157,6 +159,7 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
 
     void setFileRoutesManifestExpected(boolean fileRoutesManifestExpected) {
         this.fileRoutesManifestExpected = fileRoutesManifestExpected;
+        this.fileRoutesManifestClassificationApplied = true;
         initializeRouteUtil();
     }
 
@@ -276,12 +279,22 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
     void onVaadinServiceInit(@Observes ServiceInitEvent serviceInitEvent) {
         vaadinService = serviceInitEvent.getSource();
         initializeRouteUtil();
-        webIconsRequestMatcher = new WebIconsRequestMatcher(vaadinService, getUrlMapping());
+        webIconsRequestMatcher = createWebIconsRequestMatcher(vaadinService);
     }
 
     private void initializeRouteUtil() {
-        if (vaadinService != null) {
-            routeUtil = new RouteUtil(vaadinService, fileRoutesManifestExpected);
+        if (vaadinService != null && fileRoutesManifestClassificationApplied) {
+            RouteUtil initializedRouteUtil = createRouteUtil(vaadinService, fileRoutesManifestExpected);
+            initializedRouteUtil.initializeProductionSnapshot();
+            routeUtil = initializedRouteUtil;
         }
+    }
+
+    RouteUtil createRouteUtil(VaadinService service, boolean manifestExpected) {
+        return new RouteUtil(service, manifestExpected);
+    }
+
+    WebIconsRequestMatcher createWebIconsRequestMatcher(VaadinService service) {
+        return new WebIconsRequestMatcher(service, getUrlMapping());
     }
 }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicy.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicy.java
@@ -64,6 +64,7 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
     private VaadinService vaadinService;
     private RouteUtil routeUtil;
     private WebIconsRequestMatcher webIconsRequestMatcher;
+    private boolean fileRoutesManifestExpected;
 
     public HillaSecurityPolicy(
             NavigationAccessControl accessControl,
@@ -152,6 +153,10 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
         buildPathMatcher(builder -> paths.forEach(p -> builder.addPath(PathUtil.normalizeWildcard(p), true)));
     }
 
+    void setFileRoutesManifestExpected(boolean fileRoutesManifestExpected) {
+        this.fileRoutesManifestExpected = fileRoutesManifestExpected;
+    }
+
     /**
      * Checks whether the request is an internal request.
      *
@@ -172,10 +177,6 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
     }
 
     private boolean isAnonymousFlowRoute(NavigationContext navigationContext, String path) {
-        if (vaadinService == null) {
-            getLogger().warn("VaadinService not set. Cannot determine server route for {}", path);
-            return false;
-        }
         boolean productionMode = vaadinService.getDeploymentConfiguration().isProductionMode();
 
         if (!accessControl.isEnabled()) {
@@ -271,7 +272,7 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
 
     void onVaadinServiceInit(@Observes ServiceInitEvent serviceInitEvent) {
         vaadinService = serviceInitEvent.getSource();
-        routeUtil = new RouteUtil(vaadinService);
+        routeUtil = new RouteUtil(vaadinService, fileRoutesManifestExpected);
         webIconsRequestMatcher = new WebIconsRequestMatcher(vaadinService, getUrlMapping());
     }
 }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicy.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicy.java
@@ -17,6 +17,7 @@ package com.github.mcollovati.quarkus.hilla.security;
 
 import jakarta.enterprise.event.Observes;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -41,6 +42,7 @@ import io.quarkus.runtime.Startup;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.security.AuthenticatedHttpSecurityPolicy;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
 import io.quarkus.vertx.http.runtime.security.ImmutablePathMatcher;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.MultiMap;
@@ -101,7 +103,19 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
     @Override
     public Uni<CheckResult> checkPermission(
             RoutingContext request, Uni<SecurityIdentity> identity, AuthorizationRequestContext requestContext) {
-        String normalizedPath = request.normalizedPath();
+        String routerPath;
+        String normalizedPath;
+        String servletRouterPath;
+        String servletNormalizedPath;
+        try {
+            routerPath = request.normalizedPath();
+            normalizedPath = HttpSecurityUtils.normalizePath(routerPath);
+            servletRouterPath = QuarkusHandlerHelper.getRequestPathInsideContext(request);
+            servletNormalizedPath = HttpSecurityUtils.normalizePath(servletRouterPath);
+        } catch (RuntimeException exception) {
+            getLogger().warn("Cannot normalize request path; denying access", exception);
+            return CheckResult.deny();
+        }
         Boolean permittedPath = permitAllMatcher.match(normalizedPath).getValue();
         if ((permittedPath != null && permittedPath)
                 || isFrameworkInternalRequest(request)
@@ -110,11 +124,12 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
             return CheckResult.permit();
         }
         return identity.flatMap(secIdentity -> {
-            NavigationContext flowNavigation = tryCreateNavigationContext(request);
-            if (flowNavigation != null) {
-                if (isAnonymousFlowRoute(flowNavigation, normalizedPath)) {
-                    return CheckResult.permit();
-                }
+            FlowRouteAccess flowAccess =
+                    checkFlowRouteAccess(request, normalizedPath, routerPath, servletNormalizedPath, servletRouterPath);
+            if (flowAccess == FlowRouteAccess.ANONYMOUS) {
+                return CheckResult.permit();
+            }
+            if (flowAccess == FlowRouteAccess.AUTHENTICATION_REQUIRED) {
                 // Flow performs its role-aware check during navigation. At the
                 // HTTP boundary, preserve existing behavior: non-public Flow
                 // routes require authentication.
@@ -124,7 +139,7 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
                 getLogger().warn("Hilla routes cannot be evaluated before VaadinService initialization");
                 return CheckResult.deny();
             }
-            AuthorizationDecision hillaDecision = routeUtil.checkRouteAccess(request, secIdentity);
+            AuthorizationDecision hillaDecision = routeUtil.checkRouteAccess(normalizedPath, routerPath, secIdentity);
             return switch (hillaDecision) {
                 case ALLOW -> CheckResult.permit();
                 case DENY -> CheckResult.deny();
@@ -133,6 +148,27 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
                 case NO_MATCH -> CheckResult.permit();
             };
         });
+    }
+
+    private FlowRouteAccess checkFlowRouteAccess(RoutingContext request, String... candidatePaths) {
+        Set<String> distinctPaths = new LinkedHashSet<>();
+        for (String candidatePath : candidatePaths) {
+            if (candidatePath != null) {
+                distinctPaths.add(candidatePath);
+            }
+        }
+
+        boolean matched = false;
+        for (String candidatePath : distinctPaths) {
+            NavigationContext navigationContext = tryCreateNavigationContext(request, candidatePath);
+            if (navigationContext != null) {
+                matched = true;
+                if (!isAnonymousFlowRoute(navigationContext, candidatePath)) {
+                    return FlowRouteAccess.AUTHENTICATION_REQUIRED;
+                }
+            }
+        }
+        return matched ? FlowRouteAccess.ANONYMOUS : FlowRouteAccess.NO_MATCH;
     }
 
     private boolean isCustomWebIcon(String normalizedPath) {
@@ -216,10 +252,9 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
         return isAllowed;
     }
 
-    private NavigationContext tryCreateNavigationContext(RoutingContext request) {
+    private NavigationContext tryCreateNavigationContext(RoutingContext request, String requestedPath) {
 
         String vaadinMapping = getUrlMapping();
-        String requestedPath = QuarkusHandlerHelper.getRequestPathInsideContext(request);
         if (vaadinService == null) {
             return null;
         }
@@ -296,5 +331,11 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
 
     WebIconsRequestMatcher createWebIconsRequestMatcher(VaadinService service) {
         return new WebIconsRequestMatcher(service, getUrlMapping());
+    }
+
+    private enum FlowRouteAccess {
+        NO_MATCH,
+        ANONYMOUS,
+        AUTHENTICATION_REQUIRED
     }
 }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicy.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicy.java
@@ -64,7 +64,9 @@ public class HillaSecurityPolicy implements HttpSecurityPolicy {
     private VaadinService vaadinService;
     private RouteUtil routeUtil;
     private WebIconsRequestMatcher webIconsRequestMatcher;
-    private boolean fileRoutesManifestExpected;
+    // Stay fail-closed until runtime initialization applies the build-time
+    // classification.
+    private boolean fileRoutesManifestExpected = true;
 
     public HillaSecurityPolicy(
             NavigationAccessControl accessControl,

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityRecorder.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityRecorder.java
@@ -49,10 +49,11 @@ public class HillaSecurityRecorder {
         };
     }
 
-    public void configureHttpSecurityPolicy(BeanContainer container) {
+    public void configureHttpSecurityPolicy(BeanContainer container, boolean fileRoutesManifestExpected) {
         Config config = ConfigProvider.getConfig();
         HillaSecurityPolicy policy = container.beanInstance(HillaSecurityPolicy.class);
         policy.withFormLogin(config);
+        policy.setFileRoutesManifestExpected(fileRoutesManifestExpected);
         markSecurityPolicyUsed();
     }
 

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RoutePatternMatcher.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RoutePatternMatcher.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.security;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Matches server request paths against Hilla file-router route patterns. */
+final class RoutePatternMatcher {
+
+    private static final Pattern DYNAMIC_SEGMENT = Pattern.compile("^:([\\w-]+)(\\?)?(.*)$");
+    private static final Pattern OPTIONAL_STATIC_SEGMENT = Pattern.compile("^[\\w-]+\\?$");
+
+    /*
+     * Scores are React Router's branch-ranking weights multiplied by two to
+     * represent its 3.5 partial-parameter value as an integer. Each consumed
+     * segment includes the branch base score. Higher scores win.
+     */
+    private static final int NO_MATCH_SCORE = Integer.MIN_VALUE;
+    private static final int WILDCARD_SCORE = -2;
+    private static final int EMPTY_ROUTE_SCORE = 4;
+    private static final int INDEX_ROUTE_SCORE = 4;
+    private static final int DYNAMIC_SEGMENT_SCORE = 8;
+    private static final int PARTIAL_DYNAMIC_SEGMENT_SCORE = 9;
+    private static final int STATIC_SEGMENT_SCORE = 22;
+
+    private RoutePatternMatcher() {}
+
+    static <T> CompiledRoute<T> compile(String route, T target) {
+        return compile(route, false, target);
+    }
+
+    static <T> CompiledRoute<T> compile(String route, boolean index, T target) {
+        return new CompiledRoute<>(route, routeSegments(route), index, target);
+    }
+
+    static <T> List<CompiledRoute<T>> bestMatches(List<CompiledRoute<T>> availableRoutes, String path) {
+        List<CompiledRoute<T>> matches = new ArrayList<>(bestMatchesForPath(availableRoutes, path));
+        String clientPath = clientRouterPath(path);
+        if (!path.equals(clientPath)) {
+            Set<CompiledRoute<T>> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+            seen.addAll(matches);
+            for (CompiledRoute<T> route : bestMatchesForPath(availableRoutes, clientPath)) {
+                if (seen.add(route)) {
+                    matches.add(route);
+                }
+            }
+        }
+        return List.copyOf(matches);
+    }
+
+    private static <T> List<CompiledRoute<T>> bestMatchesForPath(List<CompiledRoute<T>> availableRoutes, String path) {
+        List<CompiledRoute<T>> bestMatches = new ArrayList<>();
+        List<String> pathSegments = segments(path);
+        int bestScore = NO_MATCH_SCORE;
+        for (CompiledRoute<T> route : availableRoutes) {
+            int score = matchScore(route.segments(), pathSegments, 0, 0);
+            if (score == NO_MATCH_SCORE) {
+                continue;
+            }
+            if (route.index()) {
+                score += INDEX_ROUTE_SCORE;
+            }
+            if (score > bestScore) {
+                bestMatches.clear();
+                bestScore = score;
+            }
+            // React Router resolves a remaining tie by sibling declaration
+            // order. Return every tied branch so authorization cannot depend
+            // on generated-file ordering; caller requires all to allow.
+            if (score == bestScore) {
+                bestMatches.add(route);
+            }
+        }
+        return List.copyOf(bestMatches);
+    }
+
+    private static int matchScore(
+            List<SegmentPattern> routeSegments, List<String> pathSegments, int routeIndex, int pathIndex) {
+        if (routeIndex == routeSegments.size()) {
+            if (pathIndex != pathSegments.size()) {
+                return NO_MATCH_SCORE;
+            }
+            return pathSegments.isEmpty() ? EMPTY_ROUTE_SCORE : 0;
+        }
+
+        SegmentPattern segmentPattern = routeSegments.get(routeIndex);
+        if (segmentPattern.type() == SegmentType.WILDCARD) {
+            if (routeIndex == routeSegments.size() - 1) {
+                return WILDCARD_SCORE;
+            }
+            int matched =
+                    remainingSegmentsCanBeOmitted(routeSegments, routeIndex + 1) ? WILDCARD_SCORE : NO_MATCH_SCORE;
+            if (pathIndex < pathSegments.size() && "*".equals(pathSegments.get(pathIndex))) {
+                int remaining = matchScore(routeSegments, pathSegments, routeIndex + 1, pathIndex + 1);
+                if (remaining != NO_MATCH_SCORE) {
+                    matched = Math.max(matched, remaining + WILDCARD_SCORE);
+                }
+            }
+            return matched;
+        }
+
+        int skipped = segmentPattern.optional() && segmentPattern.canBeOmitted()
+                ? matchScore(routeSegments, pathSegments, routeIndex + 1, pathIndex)
+                : NO_MATCH_SCORE;
+        if (pathIndex == pathSegments.size()) {
+            return skipped;
+        }
+
+        String pathSegment = pathSegments.get(pathIndex);
+        int segmentScore = segmentScore(segmentPattern, pathSegment);
+        if (segmentScore == NO_MATCH_SCORE) {
+            return skipped;
+        }
+        int remaining = matchScore(routeSegments, pathSegments, routeIndex + 1, pathIndex + 1);
+        return remaining == NO_MATCH_SCORE ? skipped : Math.max(skipped, remaining + segmentScore);
+    }
+
+    private static int segmentScore(SegmentPattern pattern, String pathSegment) {
+        if (pattern.type() == SegmentType.DYNAMIC && pattern.matchesDynamic(pathSegment)) {
+            return pattern.value().isEmpty() ? DYNAMIC_SEGMENT_SCORE : PARTIAL_DYNAMIC_SEGMENT_SCORE;
+        }
+        if (pattern.type() == SegmentType.STATIC && pattern.value().equalsIgnoreCase(pathSegment)) {
+            return STATIC_SEGMENT_SCORE;
+        }
+        return NO_MATCH_SCORE;
+    }
+
+    private static boolean remainingSegmentsCanBeOmitted(List<SegmentPattern> routeSegments, int routeIndex) {
+        for (int index = routeIndex; index < routeSegments.size(); index++) {
+            SegmentPattern remaining = routeSegments.get(index);
+            if (!remaining.optional() || !remaining.canBeOmitted()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static List<SegmentPattern> routeSegments(String route) {
+        String normalizedRoute = route;
+        // React Router treats any trailing splat without a slash as if the
+        // missing slash were present, including patterns such as :id*.
+        if (normalizedRoute != null
+                && normalizedRoute.endsWith("*")
+                && !"*".equals(normalizedRoute)
+                && !normalizedRoute.endsWith("/*")) {
+            normalizedRoute = normalizedRoute.substring(0, normalizedRoute.length() - 1) + "/*";
+        }
+        List<String> segments = segments(normalizedRoute);
+        List<SegmentPattern> patterns = new ArrayList<>(segments.size());
+        for (String segment : segments) {
+            patterns.add(segmentPattern(segment));
+        }
+        return List.copyOf(patterns);
+    }
+
+    private static SegmentPattern segmentPattern(String routeSegment) {
+        if ("*".equals(routeSegment)) {
+            return new SegmentPattern(SegmentType.WILDCARD, "", false);
+        }
+        Matcher dynamic = DYNAMIC_SEGMENT.matcher(routeSegment);
+        if (dynamic.matches()) {
+            return new SegmentPattern(SegmentType.DYNAMIC, dynamic.group(3), dynamic.group(2) != null);
+        }
+        if (OPTIONAL_STATIC_SEGMENT.matcher(routeSegment).matches()) {
+            return new SegmentPattern(SegmentType.STATIC, routeSegment.substring(0, routeSegment.length() - 1), true);
+        }
+        return new SegmentPattern(SegmentType.STATIC, routeSegment, false);
+    }
+
+    private static List<String> segments(String path) {
+        if (path == null || path.isBlank() || "/".equals(path)) {
+            return List.of();
+        }
+        int start = 0;
+        int end = path.length();
+        while (start < end && path.charAt(start) == '/') {
+            start++;
+        }
+        while (end > start && path.charAt(end - 1) == '/') {
+            end--;
+        }
+        return start == end
+                ? List.of()
+                : Arrays.asList(path.substring(start, end).split("/", -1));
+    }
+
+    private static String clientRouterPath(String path) {
+        if (path.indexOf('%') < 0) {
+            return path;
+        }
+        return String.join(
+                "/",
+                Arrays.stream(path.split("/", -1))
+                        .map(RoutePatternMatcher::decodeClientRouterSegment)
+                        .toList());
+    }
+
+    private static String decodeClientRouterSegment(String segment) {
+        try {
+            return URLDecoder.decode(segment.replace("+", "%2B"), StandardCharsets.UTF_8)
+                    .replace("/", "%2F");
+        } catch (IllegalArgumentException exception) {
+            return segment;
+        }
+    }
+
+    record CompiledRoute<T>(String path, List<SegmentPattern> segments, boolean index, T target) {}
+
+    private enum SegmentType {
+        STATIC,
+        DYNAMIC,
+        WILDCARD
+    }
+
+    private record SegmentPattern(SegmentType type, String value, boolean optional) {
+
+        boolean canBeOmitted() {
+            return type == SegmentType.STATIC || value.isEmpty();
+        }
+
+        boolean matchesDynamic(String pathSegment) {
+            if (!endsWithIgnoreCase(pathSegment, value)) {
+                return false;
+            }
+            int parameterLength = pathSegment.length() - value.length();
+            return optional ? parameterLength >= 0 : parameterLength > 0;
+        }
+
+        private static boolean endsWithIgnoreCase(String value, String suffix) {
+            return value.regionMatches(true, value.length() - suffix.length(), suffix, 0, suffix.length());
+        }
+    }
+}

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RoutePatternMatcher.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RoutePatternMatcher.java
@@ -26,16 +26,25 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/** Matches server request paths against Hilla file-router route patterns. */
+/**
+ * Matches server request paths against Hilla file-router route patterns using React Router 8 branch-ranking
+ * semantics.
+ *
+ * <p>This is a versioned compatibility boundary, not a generic URL matcher. React Router 7, used by the 25.1 and
+ * 25.2 branches, ranks partial parameter segments differently. Revalidate the scoring constants and conformance
+ * tests whenever the managed React Router version changes. Unlike React Router, which resolves an equal-ranking
+ * sibling tie by declaration order, this matcher returns all tied routes so authorization remains conservative and
+ * independent of generated route order.
+ */
 final class RoutePatternMatcher {
 
     private static final Pattern DYNAMIC_SEGMENT = Pattern.compile("^:([\\w-]+)(\\?)?(.*)$");
     private static final Pattern OPTIONAL_STATIC_SEGMENT = Pattern.compile("^[\\w-]+\\?$");
 
     /*
-     * Scores are React Router's branch-ranking weights multiplied by two to
-     * represent its 3.5 partial-parameter value as an integer. Each consumed
-     * segment includes the branch base score. Higher scores win.
+     * React Router 8 branch-ranking weights, multiplied by two to represent its
+     * 3.5 partial-parameter value as an integer. Each consumed segment includes
+     * the branch base score. Higher scores win.
      */
     private static final int NO_MATCH_SCORE = Integer.MIN_VALUE;
     private static final int WILDCARD_SCORE = -2;

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RoutePatternMatcher.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RoutePatternMatcher.java
@@ -39,7 +39,6 @@ import java.util.regex.Pattern;
 final class RoutePatternMatcher {
 
     private static final Pattern DYNAMIC_SEGMENT = Pattern.compile("^:([\\w-]+)(\\?)?(.*)$");
-    private static final Pattern OPTIONAL_STATIC_SEGMENT = Pattern.compile("^[\\w-]+\\?$");
 
     /*
      * React Router 8 branch-ranking weights, multiplied by two to represent its
@@ -130,7 +129,7 @@ final class RoutePatternMatcher {
             return matched;
         }
 
-        int skipped = segmentPattern.optional() && segmentPattern.canBeOmitted()
+        int skipped = segmentPattern.optional()
                 ? matchScore(routeSegments, pathSegments, routeIndex + 1, pathIndex)
                 : NO_MATCH_SCORE;
         if (pathIndex == pathSegments.size()) {
@@ -159,7 +158,7 @@ final class RoutePatternMatcher {
     private static boolean remainingSegmentsCanBeOmitted(List<SegmentPattern> routeSegments, int routeIndex) {
         for (int index = routeIndex; index < routeSegments.size(); index++) {
             SegmentPattern remaining = routeSegments.get(index);
-            if (!remaining.optional() || !remaining.canBeOmitted()) {
+            if (!remaining.optional()) {
                 return false;
             }
         }
@@ -186,16 +185,15 @@ final class RoutePatternMatcher {
 
     private static SegmentPattern segmentPattern(String routeSegment) {
         if ("*".equals(routeSegment)) {
-            return new SegmentPattern(SegmentType.WILDCARD, "", false);
+            return new SegmentPattern(SegmentType.WILDCARD, "", false, false);
         }
-        Matcher dynamic = DYNAMIC_SEGMENT.matcher(routeSegment);
+        boolean optionalSegment = routeSegment.endsWith("?");
+        String segment = optionalSegment ? routeSegment.substring(0, routeSegment.length() - 1) : routeSegment;
+        Matcher dynamic = DYNAMIC_SEGMENT.matcher(segment);
         if (dynamic.matches()) {
-            return new SegmentPattern(SegmentType.DYNAMIC, dynamic.group(3), dynamic.group(2) != null);
+            return new SegmentPattern(SegmentType.DYNAMIC, dynamic.group(3), optionalSegment, dynamic.group(2) != null);
         }
-        if (OPTIONAL_STATIC_SEGMENT.matcher(routeSegment).matches()) {
-            return new SegmentPattern(SegmentType.STATIC, routeSegment.substring(0, routeSegment.length() - 1), true);
-        }
-        return new SegmentPattern(SegmentType.STATIC, routeSegment, false);
+        return new SegmentPattern(SegmentType.STATIC, segment, optionalSegment, false);
     }
 
     private static List<String> segments(String path) {
@@ -243,18 +241,14 @@ final class RoutePatternMatcher {
         WILDCARD
     }
 
-    private record SegmentPattern(SegmentType type, String value, boolean optional) {
-
-        boolean canBeOmitted() {
-            return type == SegmentType.STATIC || value.isEmpty();
-        }
+    private record SegmentPattern(SegmentType type, String value, boolean optional, boolean parameterOptional) {
 
         boolean matchesDynamic(String pathSegment) {
             if (!endsWithIgnoreCase(pathSegment, value)) {
                 return false;
             }
             int parameterLength = pathSegment.length() - value.length();
-            return optional ? parameterLength >= 0 : parameterLength > 0;
+            return parameterOptional ? parameterLength >= 0 : parameterLength > 0;
         }
 
         private static boolean endsWithIgnoreCase(String value, String suffix) {

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.internal.menu.MenuRegistry;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.menu.AvailableViewInfo;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
 import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,20 +135,56 @@ public class RouteUtil {
     }
 
     AuthorizationDecision checkRouteAccess(RoutingContext context, SecurityIdentity identity) {
+        if (identity == null) {
+            return AuthorizationDecision.DENY;
+        }
+        String routerPath;
+        String normalizedPath;
+        try {
+            routerPath = context.normalizedPath();
+            normalizedPath = HttpSecurityUtils.normalizePath(routerPath);
+        } catch (RuntimeException exception) {
+            LOGGER.debug("Cannot normalize Hilla client route path; denying access", exception);
+            return AuthorizationDecision.DENY;
+        }
+        return checkRouteAccess(normalizedPath, routerPath, identity);
+    }
+
+    AuthorizationDecision checkRouteAccess(String normalizedPath, SecurityIdentity identity) {
+        return checkRouteAccess(normalizedPath, normalizedPath, identity);
+    }
+
+    AuthorizationDecision checkRouteAccess(String normalizedPath, String routerPath, SecurityIdentity identity) {
         ensureRoutesDiscovered();
         RouteSnapshot snapshot = routeSnapshot;
         if (snapshot == null || !snapshot.hierarchyComplete() || identity == null) {
             return AuthorizationDecision.DENY;
         }
 
-        List<RoutePatternMatcher.CompiledRoute<List<List<AvailableViewInfo>>>> matchedRoutes;
         try {
-            matchedRoutes = RoutePatternMatcher.bestMatches(snapshot.routes(), context.normalizedPath());
+            AuthorizationDecision normalizedDecision = checkRouteMatches(snapshot.routes(), normalizedPath, identity);
+            if (normalizedPath.equals(routerPath)) {
+                return normalizedDecision;
+            }
+            AuthorizationDecision routerDecision = checkRouteMatches(snapshot.routes(), routerPath, identity);
+            if (normalizedDecision == AuthorizationDecision.DENY || routerDecision == AuthorizationDecision.DENY) {
+                return AuthorizationDecision.DENY;
+            }
+            return normalizedDecision == AuthorizationDecision.ALLOW || routerDecision == AuthorizationDecision.ALLOW
+                    ? AuthorizationDecision.ALLOW
+                    : AuthorizationDecision.NO_MATCH;
         } catch (RuntimeException exception) {
-            LOGGER.debug("Cannot normalize Hilla client route path; denying access", exception);
+            LOGGER.debug("Cannot match Hilla client route path; denying access", exception);
             return AuthorizationDecision.DENY;
         }
+    }
 
+    private static AuthorizationDecision checkRouteMatches(
+            List<RoutePatternMatcher.CompiledRoute<List<List<AvailableViewInfo>>>> routes,
+            String path,
+            SecurityIdentity identity) {
+        List<RoutePatternMatcher.CompiledRoute<List<List<AvailableViewInfo>>>> matchedRoutes =
+                RoutePatternMatcher.bestMatches(routes, path);
         if (matchedRoutes.isEmpty()) {
             return AuthorizationDecision.NO_MATCH;
         }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
@@ -32,7 +32,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.vaadin.flow.internal.CurrentInstance;
-import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.menu.MenuRegistry;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.menu.AvailableViewInfo;
@@ -42,16 +41,20 @@ import io.vertx.ext.web.RoutingContext;
 import org.jboss.logging.Logger;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.DeserializationFeature;
-import tools.jackson.databind.ObjectReader;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class RouteUtil {
 
     private static final Logger LOGGER = Logger.getLogger(RouteUtil.class);
-    private static final ObjectReader ROUTE_READER = JacksonUtils.getMapper()
-            .readerFor(new TypeReference<List<AvailableViewInfo>>() {})
-            .without(
+
+    // Keep internal route metadata parsing independent from application-level
+    // Jackson customization, consistent with Vaadin's MenuRegistry.
+    private static final ObjectMapper ROUTE_MAPPER = JsonMapper.builder()
+            .disable(
                     DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
-                    DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+                    DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .build();
     private static final Pattern DYNAMIC_SEGMENT = Pattern.compile("^:([\\w-]+)(\\?)?(.*)$");
     private static final Pattern OPTIONAL_STATIC_SEGMENT = Pattern.compile("^[\\w-]+\\?$");
     private static final long DISCOVERY_RETRY_NANOS = Duration.ofSeconds(1).toNanos();
@@ -218,7 +221,7 @@ public class RouteUtil {
     }
 
     static List<AvailableViewInfo> readRouteTree(InputStream input) throws IOException {
-        return ROUTE_READER.readValue(input);
+        return ROUTE_MAPPER.readValue(input, new TypeReference<List<AvailableViewInfo>>() {});
     }
 
     private void publishRouteTree(List<AvailableViewInfo> routeTree) {

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
@@ -116,6 +116,23 @@ public class RouteUtil {
         return checkRouteAccess(context, identity) == AuthorizationDecision.ALLOW;
     }
 
+    /**
+     * Loads and validates the fixed production route snapshot before this evaluator is published.
+     *
+     * @throws IllegalStateException
+     *             if expected production route metadata cannot be loaded completely
+     */
+    void initializeProductionSnapshot() {
+        if (developmentMode) {
+            return;
+        }
+        ensureRoutesDiscovered();
+        if (discoveryState != DiscoveryState.COMPLETE) {
+            throw new IllegalStateException(
+                    "Cannot initialize Hilla route security because the production file-routes.json manifest is missing, unreadable, invalid, or incomplete");
+        }
+    }
+
     AuthorizationDecision checkRouteAccess(RoutingContext context, SecurityIdentity identity) {
         ensureRoutesDiscovered();
         RouteSnapshot snapshot = routeSnapshot;
@@ -228,9 +245,13 @@ public class RouteUtil {
         }
     }
 
+    /** Must be called while holding the discovery monitor that guards the resource fingerprint. */
     DiscoveryResult discoverFromResource(URL routesResource) throws IOException {
         if (routesResource != null) {
             return readRouteResource(routesResource, developmentMode ? publishedResourceFingerprint : null);
+        }
+        if (!developmentMode && !fileRoutesManifestExpected) {
+            LOGGER.debug("No Hilla file-route manifest expected; route evaluator owns no client routes");
         }
         return missingManifest(developmentMode, fileRoutesManifestExpected);
     }
@@ -288,7 +309,7 @@ public class RouteUtil {
         } else {
             discoveryState = DiscoveryState.FAILED;
             LOGGER.error(
-                    "Hilla route discovery failed in production because META-INF/VAADIN/file-routes.json is missing, unreadable, or invalid; access to all generated Hilla routes remains denied until restart. Enable DEBUG logging for the underlying cause");
+                    "Hilla route discovery failed in production because META-INF/VAADIN/file-routes.json is missing, unreadable, invalid, or incomplete; production initialization cannot continue. Enable DEBUG logging for the underlying cause");
         }
     }
 
@@ -357,13 +378,7 @@ public class RouteUtil {
             AvailableViewInfo view,
             Map<String, AvailableViewInfo> routes,
             Map<String, List<List<AvailableViewInfo>>> chains) {
-        String routePath;
-        try {
-            routePath = appendRoute(parentPath, view.route());
-        } catch (IllegalArgumentException exception) {
-            LOGGER.error("Ignoring invalid Hilla client route '{}' below '{}'", view.route(), parentPath, exception);
-            return;
-        }
+        String routePath = appendRoute(parentPath, view.route());
         List<AvailableViewInfo> securityChain = new ArrayList<>(ancestors);
         securityChain.add(view);
         routes.putIfAbsent(routePath, view);

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
@@ -203,6 +203,10 @@ public class RouteUtil {
                 if (routesResource != null) {
                     return readRouteResource(routesResource, developmentMode ? publishedResourceFingerprint : null);
                 }
+                // A manifest is optional for applications using a custom
+                // client router. In that case this evaluator does not own any
+                // route, which is different from failing to read a manifest.
+                return DiscoveryResult.complete(List.of());
             } catch (IOException | RuntimeException exception) {
                 LOGGER.warn(
                         "Cannot load complete Hilla client route tree; route access cannot be evaluated", exception);

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
@@ -18,18 +18,14 @@ package com.github.mcollovati.quarkus.hilla.security;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
+import java.net.URLConnection;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.internal.menu.MenuRegistry;
@@ -37,15 +33,25 @@ import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.menu.AvailableViewInfo;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.vertx.ext.web.RoutingContext;
-import org.jboss.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
+/**
+ * Evaluates routes generated in Hilla's {@code file-routes.json} manifest.
+ *
+ * <p>Routes declared only in a custom {@code routes.tsx}, including security
+ * metadata on custom parent layouts, are not present in that manifest and are
+ * therefore outside this evaluator. Callers must apply another authorization
+ * source to those routes. Incomplete manifest data never produces an allow or
+ * no-match decision.
+ */
 public class RouteUtil {
 
-    private static final Logger LOGGER = Logger.getLogger(RouteUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RouteUtil.class);
 
     // Keep internal route metadata parsing independent from application-level
     // Jackson customization, consistent with Vaadin's MenuRegistry.
@@ -54,20 +60,7 @@ public class RouteUtil {
                     DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
                     DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
             .build();
-    private static final Pattern DYNAMIC_SEGMENT = Pattern.compile("^:([\\w-]+)(\\?)?(.*)$");
-    private static final Pattern OPTIONAL_STATIC_SEGMENT = Pattern.compile("^[\\w-]+\\?$");
     private static final long DISCOVERY_REFRESH_NANOS = Duration.ofSeconds(1).toNanos();
-
-    /*
-     * Relative scores follow React Router route ranking. Static and suffixed
-     * parameter segments rank above plain parameters, empty segments rank below
-     * them, and wildcards rank last. Only ordering matters.
-     */
-    private static final int NO_MATCH_SCORE = Integer.MIN_VALUE;
-    private static final int WILDCARD_SCORE = -1;
-    private static final int EMPTY_SEGMENT_SCORE = 2;
-    private static final int DYNAMIC_SEGMENT_SCORE = 4;
-    private static final int STATIC_SEGMENT_SCORE = 11;
 
     private final VaadinService vaadinService;
     private final boolean developmentMode;
@@ -77,6 +70,7 @@ public class RouteUtil {
     private volatile RouteSnapshot routeSnapshot;
     private volatile DiscoveryState discoveryState = DiscoveryState.UNINITIALIZED;
     private volatile long refreshAfterNanos;
+    private ResourceFingerprint publishedResourceFingerprint;
 
     public RouteUtil(VaadinService vaadinService) {
         this.vaadinService = vaadinService;
@@ -101,46 +95,36 @@ public class RouteUtil {
     }
 
     public boolean isRouteAllowed(RoutingContext context, SecurityIdentity identity) {
-        return checkRouteAccess(context, identity) == RouteAccess.ALLOW;
+        return checkRouteAccess(context, identity) == AuthorizationDecision.ALLOW;
     }
 
-    RouteAccess checkRouteAccess(RoutingContext context, SecurityIdentity identity) {
+    AuthorizationDecision checkRouteAccess(RoutingContext context, SecurityIdentity identity) {
         ensureRoutesDiscovered();
         RouteSnapshot snapshot = routeSnapshot;
         if (snapshot == null) {
-            return RouteAccess.NO_MATCH;
+            return AuthorizationDecision.DENY;
         }
 
-        List<CompiledRoute> matchedRoutes;
+        List<RoutePatternMatcher.CompiledRoute<List<List<AvailableViewInfo>>>> matchedRoutes;
         try {
-            String requestPath = context.normalizedPath();
-            String normalizedCandidate = requestPath;
-            String clientCandidate = clientRouterPath(requestPath);
-            matchedRoutes = new ArrayList<>(getRoutesByPath(snapshot.routes(), normalizedCandidate));
-            if (!normalizedCandidate.equals(clientCandidate)) {
-                for (CompiledRoute route : getRoutesByPath(snapshot.routes(), clientCandidate)) {
-                    if (!matchedRoutes.contains(route)) {
-                        matchedRoutes.add(route);
-                    }
-                }
-            }
+            matchedRoutes = RoutePatternMatcher.bestMatches(snapshot.routes(), context.normalizedPath());
         } catch (RuntimeException exception) {
             LOGGER.debug("Cannot normalize Hilla client route path; denying access", exception);
-            return RouteAccess.DENY;
+            return AuthorizationDecision.DENY;
         }
 
-        if (matchedRoutes.isEmpty()) {
-            return RouteAccess.NO_MATCH;
-        }
         if (!snapshot.hierarchyComplete() || identity == null) {
-            return RouteAccess.DENY;
+            return AuthorizationDecision.DENY;
         }
-        for (CompiledRoute route : matchedRoutes) {
+        if (matchedRoutes.isEmpty()) {
+            return AuthorizationDecision.NO_MATCH;
+        }
+        for (RoutePatternMatcher.CompiledRoute<List<List<AvailableViewInfo>>> route : matchedRoutes) {
             if (!isRouteAccessible(route, identity)) {
-                return RouteAccess.DENY;
+                return AuthorizationDecision.DENY;
             }
         }
-        return RouteAccess.ALLOW;
+        return AuthorizationDecision.ALLOW;
     }
 
     private void ensureRoutesDiscovered() {
@@ -166,24 +150,35 @@ public class RouteUtil {
             result = routeDiscovery.get();
         } catch (RuntimeException exception) {
             LOGGER.warn("Cannot discover Hilla client routes; route access cannot be evaluated", exception);
-            handleDiscoveryFailure(Map.of(), now);
+            handleDiscoveryFailure(now);
             return;
         }
         if (result == null) {
             LOGGER.warn("Hilla client route discovery returned no result; route access cannot be evaluated");
-            handleDiscoveryFailure(Map.of(), now);
+            handleDiscoveryFailure(now);
+            return;
+        }
+
+        if (result.unchanged()) {
+            RouteSnapshot currentSnapshot = routeSnapshot;
+            if (currentSnapshot != null && currentSnapshot.hierarchyComplete()) {
+                completeDiscovery(now);
+            } else {
+                handleDiscoveryFailure(now);
+            }
             return;
         }
 
         if (result.routeTree() != null) {
             try {
                 publishRouteTree(result.routeTree(), now);
+                publishedResourceFingerprint = result.resourceFingerprint();
                 return;
             } catch (RuntimeException exception) {
                 LOGGER.warn("Cannot compile Hilla client route tree; route access cannot be evaluated", exception);
             }
         }
-        handleDiscoveryFailure(result.fallbackRoutes(), now);
+        handleDiscoveryFailure(now);
     }
 
     private boolean requiresDiscovery(DiscoveryState state, long now) {
@@ -192,7 +187,7 @@ public class RouteUtil {
     }
 
     private static boolean isTerminal(DiscoveryState state) {
-        return state == DiscoveryState.COMPLETE || state == DiscoveryState.FALLBACK;
+        return state == DiscoveryState.COMPLETE || state == DiscoveryState.FAILED;
     }
 
     private DiscoveryResult discoverClientRoutes() {
@@ -206,40 +201,44 @@ public class RouteUtil {
             try {
                 URL routesResource = MenuRegistry.getViewsJsonAsResource(config);
                 if (routesResource != null) {
-                    try (InputStream input = routesResource.openStream()) {
-                        return DiscoveryResult.complete(readRouteTree(input));
-                    }
+                    return readRouteResource(routesResource, developmentMode ? publishedResourceFingerprint : null);
                 }
             } catch (IOException | RuntimeException exception) {
                 LOGGER.warn(
                         "Cannot load complete Hilla client route tree; route access cannot be evaluated", exception);
             }
-            Map<String, AvailableViewInfo> fallbackRoutes;
-            try {
-                fallbackRoutes = MenuRegistry.collectClientMenuItems(false, config, null);
-            } catch (RuntimeException exception) {
-                LOGGER.warn("Cannot collect fallback Hilla client routes; route access cannot be evaluated", exception);
-                fallbackRoutes = Map.of();
-            }
-            return DiscoveryResult.fallback(fallbackRoutes);
+            return DiscoveryResult.failure();
         } finally {
             CurrentInstance.clearAll();
             CurrentInstance.restoreInstances(oldInstances);
         }
     }
 
-    void setRoutes(Map<String, AvailableViewInfo> registeredRoutes) {
-        publishRoutes(registeredRoutes, true);
+    void setCompleteRoutesForTesting(Map<String, AvailableViewInfo> registeredRoutes) {
+        publishCompleteRoutes(registeredRoutes);
         discoveryState = DiscoveryState.COMPLETE;
     }
 
-    void setRouteTree(List<AvailableViewInfo> routeTree) {
+    void setCompleteRouteTreeForTesting(List<AvailableViewInfo> routeTree) {
         publishRouteTreeSnapshot(routeTree);
         discoveryState = DiscoveryState.COMPLETE;
     }
 
     static List<AvailableViewInfo> readRouteTree(InputStream input) throws IOException {
         return ROUTE_MAPPER.readValue(input, new TypeReference<List<AvailableViewInfo>>() {});
+    }
+
+    static DiscoveryResult readRouteResource(URL resource, ResourceFingerprint publishedFingerprint)
+            throws IOException {
+        URLConnection connection = resource.openConnection();
+        connection.setUseCaches(false);
+        ResourceFingerprint fingerprint = ResourceFingerprint.from(resource, connection);
+        if (fingerprint.reliable() && fingerprint.equals(publishedFingerprint)) {
+            return DiscoveryResult.unchangedResult();
+        }
+        try (InputStream input = connection.getInputStream()) {
+            return DiscoveryResult.complete(readRouteTree(input), fingerprint);
+        }
     }
 
     private void publishRouteTree(List<AvailableViewInfo> routeTree, long now) {
@@ -256,17 +255,17 @@ public class RouteUtil {
         routeSnapshot = createSnapshot(routes, chains, true);
     }
 
-    private void handleDiscoveryFailure(Map<String, AvailableViewInfo> fallbackRoutes, long now) {
+    private void handleDiscoveryFailure(long now) {
         RouteSnapshot currentSnapshot = routeSnapshot;
         if (currentSnapshot != null && currentSnapshot.hierarchyComplete()) {
             completeDiscovery(now);
             return;
         }
-        publishRoutes(fallbackRoutes, false);
+        routeSnapshot = new RouteSnapshot(List.of(), false);
         if (developmentMode) {
             scheduleRefresh(now);
         } else {
-            discoveryState = DiscoveryState.FALLBACK;
+            discoveryState = DiscoveryState.FAILED;
         }
     }
 
@@ -283,23 +282,25 @@ public class RouteUtil {
         discoveryState = DiscoveryState.REFRESH_PENDING;
     }
 
-    private void publishRoutes(Map<String, AvailableViewInfo> registeredRoutes, boolean hierarchyComplete) {
+    private void publishCompleteRoutes(Map<String, AvailableViewInfo> registeredRoutes) {
         Map<String, AvailableViewInfo> routes =
-                registeredRoutes == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(registeredRoutes));
+                registeredRoutes == null ? Map.of() : new LinkedHashMap<>(registeredRoutes);
         Map<String, List<List<AvailableViewInfo>>> chains = new LinkedHashMap<>();
         routes.forEach((route, view) -> chains.put(route, List.of(List.of(view))));
-        routeSnapshot = createSnapshot(routes, chains, hierarchyComplete);
+        routeSnapshot = createSnapshot(routes, chains, true);
     }
 
     private static RouteSnapshot createSnapshot(
             Map<String, AvailableViewInfo> routes,
             Map<String, List<List<AvailableViewInfo>>> securityChains,
             boolean hierarchyComplete) {
-        List<CompiledRoute> compiledRoutes = new ArrayList<>(routes.size());
+        List<RoutePatternMatcher.CompiledRoute<List<List<AvailableViewInfo>>>> compiledRoutes =
+                new ArrayList<>(routes.size());
         for (String route : routes.keySet()) {
             List<List<AvailableViewInfo>> chains = securityChains.get(route);
+            List<List<AvailableViewInfo>> immutableChains = chains == null ? List.of() : List.copyOf(chains);
             compiledRoutes.add(
-                    new CompiledRoute(route, routeSegments(route), chains == null ? List.of() : List.copyOf(chains)));
+                    RoutePatternMatcher.compile(route, containsIndexRoute(immutableChains), immutableChains));
         }
         return new RouteSnapshot(List.copyOf(compiledRoutes), hierarchyComplete);
     }
@@ -314,7 +315,7 @@ public class RouteUtil {
         try {
             routePath = appendRoute(parentPath, view.route());
         } catch (IllegalArgumentException exception) {
-            LOGGER.errorf(exception, "Ignoring invalid Hilla client route '%s' below '%s'", view.route(), parentPath);
+            LOGGER.error("Ignoring invalid Hilla client route '{}' below '{}'", view.route(), parentPath, exception);
             return;
         }
         List<AvailableViewInfo> securityChain = new ArrayList<>(ancestors);
@@ -347,9 +348,23 @@ public class RouteUtil {
         return route.replaceAll("/+", "/");
     }
 
-    private static boolean isRouteAccessible(CompiledRoute route, SecurityIdentity identity) {
-        List<List<AvailableViewInfo>> chains = route.securityChains();
+    private static boolean isRouteAccessible(
+            RoutePatternMatcher.CompiledRoute<List<List<AvailableViewInfo>>> route, SecurityIdentity identity) {
+        List<List<AvailableViewInfo>> chains = route.target();
         return chains != null && !chains.isEmpty() && allChainsAccessible(chains, identity);
+    }
+
+    private static boolean containsIndexRoute(List<List<AvailableViewInfo>> chains) {
+        for (List<AvailableViewInfo> chain : chains) {
+            if (!chain.isEmpty()) {
+                AvailableViewInfo target = chain.getLast();
+                if ((target.route() == null || target.route().isEmpty())
+                        && (target.children() == null || target.children().isEmpty())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private static boolean allChainsAccessible(List<List<AvailableViewInfo>> chains, SecurityIdentity identity) {
@@ -379,193 +394,45 @@ public class RouteUtil {
         return false;
     }
 
-    private static List<CompiledRoute> getRoutesByPath(List<CompiledRoute> availableRoutes, String path) {
-        List<CompiledRoute> bestMatches = new ArrayList<>();
-        List<String> pathSegments = segments(path);
-        int bestScore = NO_MATCH_SCORE;
-        for (CompiledRoute route : availableRoutes) {
-            int score = matchScore(route.segments(), pathSegments, 0, 0);
-            if (score == NO_MATCH_SCORE) {
-                continue;
-            }
-            if (score > bestScore) {
-                bestMatches.clear();
-                bestScore = score;
-            }
-            if (score == bestScore) {
-                bestMatches.add(route);
-            }
-        }
-        return List.copyOf(bestMatches);
-    }
-
-    private static int matchScore(
-            List<SegmentPattern> routeSegments, List<String> pathSegments, int routeIndex, int pathIndex) {
-        if (routeIndex == routeSegments.size()) {
-            return pathIndex == pathSegments.size() ? 0 : NO_MATCH_SCORE;
-        }
-
-        SegmentPattern segmentPattern = routeSegments.get(routeIndex);
-        if (segmentPattern.type() == SegmentType.WILDCARD) {
-            if (routeIndex == routeSegments.size() - 1) {
-                return WILDCARD_SCORE;
-            }
-            int matched =
-                    remainingSegmentsCanBeOmitted(routeSegments, routeIndex + 1) ? WILDCARD_SCORE : NO_MATCH_SCORE;
-            if (pathIndex < pathSegments.size() && "*".equals(pathSegments.get(pathIndex))) {
-                int remaining = matchScore(routeSegments, pathSegments, routeIndex + 1, pathIndex + 1);
-                if (remaining != NO_MATCH_SCORE) {
-                    matched = Math.max(matched, remaining + WILDCARD_SCORE);
-                }
-            }
-            return matched;
-        }
-        int skipped = segmentPattern.optional() && segmentPattern.canBeOmitted()
-                ? matchScore(routeSegments, pathSegments, routeIndex + 1, pathIndex)
-                : NO_MATCH_SCORE;
-        if (pathIndex == pathSegments.size()) {
-            return skipped;
-        }
-        int remaining = matchScore(routeSegments, pathSegments, routeIndex + 1, pathIndex + 1);
-        if (remaining == NO_MATCH_SCORE) {
-            return skipped;
-        }
-        String pathSegment = pathSegments.get(pathIndex);
-        int consumed = NO_MATCH_SCORE;
-        if (segmentPattern.type() == SegmentType.DYNAMIC && segmentPattern.matchesDynamic(pathSegment)) {
-            consumed = remaining + (segmentPattern.value().isEmpty() ? DYNAMIC_SEGMENT_SCORE : STATIC_SEGMENT_SCORE);
-        } else if (segmentPattern.type() == SegmentType.STATIC
-                && segmentPattern.value().equalsIgnoreCase(pathSegment)) {
-            consumed = remaining + (segmentPattern.value().isEmpty() ? EMPTY_SEGMENT_SCORE : STATIC_SEGMENT_SCORE);
-        }
-        return Math.max(skipped, consumed);
-    }
-
-    private static boolean remainingSegmentsCanBeOmitted(List<SegmentPattern> routeSegments, int routeIndex) {
-        for (int index = routeIndex; index < routeSegments.size(); index++) {
-            SegmentPattern remaining = routeSegments.get(index);
-            if (!remaining.optional() || !remaining.canBeOmitted()) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static SegmentPattern segmentPattern(String routeSegment) {
-        if ("*".equals(routeSegment)) {
-            return new SegmentPattern(SegmentType.WILDCARD, "", false);
-        }
-        Matcher dynamic = DYNAMIC_SEGMENT.matcher(routeSegment);
-        if (dynamic.matches()) {
-            return new SegmentPattern(SegmentType.DYNAMIC, dynamic.group(3), dynamic.group(2) != null);
-        }
-        if (OPTIONAL_STATIC_SEGMENT.matcher(routeSegment).matches()) {
-            return new SegmentPattern(SegmentType.STATIC, routeSegment.substring(0, routeSegment.length() - 1), true);
-        }
-        return new SegmentPattern(SegmentType.STATIC, routeSegment, false);
-    }
-
-    private static List<String> segments(String path) {
-        if (path == null || path.isBlank() || "/".equals(path)) {
-            return List.of();
-        }
-        int start = 0;
-        int end = path.length();
-        while (start < end && path.charAt(start) == '/') {
-            start++;
-        }
-        while (end > start && path.charAt(end - 1) == '/') {
-            end--;
-        }
-        return start == end
-                ? List.of()
-                : Arrays.asList(path.substring(start, end).split("/", -1));
-    }
-
-    private static List<SegmentPattern> routeSegments(String route) {
-        if (route != null && route.endsWith("*") && !"*".equals(route) && !route.endsWith("/*")) {
-            route = route.substring(0, route.length() - 1) + "/*";
-        }
-        List<String> segments = segments(route);
-        List<SegmentPattern> patterns = new ArrayList<>(segments.size());
-        for (String segment : segments) {
-            patterns.add(segmentPattern(segment));
-        }
-        return List.copyOf(patterns);
-    }
-
-    private static String clientRouterPath(String path) {
-        if (path.indexOf('%') < 0) {
-            return path;
-        }
-        return String.join(
-                "/",
-                Arrays.stream(path.split("/", -1))
-                        .map(RouteUtil::decodeClientRouterSegment)
-                        .toList());
-    }
-
-    private static String decodeClientRouterSegment(String segment) {
-        try {
-            return URLDecoder.decode(segment.replace("+", "%2B"), StandardCharsets.UTF_8)
-                    .replace("/", "%2F");
-        } catch (IllegalArgumentException exception) {
-            return segment;
-        }
-    }
-
-    enum RouteAccess {
-        NO_MATCH,
-        ALLOW,
-        DENY
-    }
-
     private enum DiscoveryState {
         UNINITIALIZED,
         REFRESH_PENDING,
         COMPLETE,
-        FALLBACK
+        FAILED
     }
 
-    record DiscoveryResult(List<AvailableViewInfo> routeTree, Map<String, AvailableViewInfo> fallbackRoutes) {
+    record DiscoveryResult(
+            List<AvailableViewInfo> routeTree, ResourceFingerprint resourceFingerprint, boolean unchanged) {
 
         static DiscoveryResult complete(List<AvailableViewInfo> routeTree) {
-            return new DiscoveryResult(List.copyOf(routeTree), Map.of());
+            return complete(routeTree, null);
         }
 
-        static DiscoveryResult fallback(Map<String, AvailableViewInfo> fallbackRoutes) {
-            return new DiscoveryResult(
-                    null, fallbackRoutes == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(fallbackRoutes)));
-        }
-    }
-
-    private enum SegmentType {
-        STATIC,
-        DYNAMIC,
-        WILDCARD
-    }
-
-    private record SegmentPattern(SegmentType type, String value, boolean optional) {
-
-        boolean canBeOmitted() {
-            return type == SegmentType.STATIC || value.isEmpty();
+        static DiscoveryResult complete(List<AvailableViewInfo> routeTree, ResourceFingerprint fingerprint) {
+            return new DiscoveryResult(List.copyOf(routeTree), fingerprint, false);
         }
 
-        boolean matchesDynamic(String pathSegment) {
-            if (!endsWithIgnoreCase(pathSegment, value)) {
-                return false;
-            }
-            int parameterLength = pathSegment.length() - value.length();
-            return optional ? parameterLength >= 0 : parameterLength > 0;
+        static DiscoveryResult failure() {
+            return new DiscoveryResult(null, null, false);
         }
 
-        private static boolean endsWithIgnoreCase(String value, String suffix) {
-            return value.regionMatches(true, value.length() - suffix.length(), suffix, 0, suffix.length());
+        static DiscoveryResult unchangedResult() {
+            return new DiscoveryResult(null, null, true);
         }
     }
 
-    private record CompiledRoute(
-            String path, List<SegmentPattern> segments, List<List<AvailableViewInfo>> securityChains) {}
+    record ResourceFingerprint(String resource, long lastModified, long contentLength) {
 
-    private record RouteSnapshot(List<CompiledRoute> routes, boolean hierarchyComplete) {}
+        static ResourceFingerprint from(URL resource, URLConnection connection) {
+            return new ResourceFingerprint(
+                    resource.toExternalForm(), connection.getLastModified(), connection.getContentLengthLong());
+        }
+
+        boolean reliable() {
+            return lastModified > 0;
+        }
+    }
+
+    private record RouteSnapshot(
+            List<RoutePatternMatcher.CompiledRoute<List<List<AvailableViewInfo>>>> routes, boolean hierarchyComplete) {}
 }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
@@ -216,10 +216,7 @@ public class RouteUtil {
             var config = vaadinService.getDeploymentConfiguration();
             try {
                 URL routesResource = MenuRegistry.getViewsJsonAsResource(config);
-                if (routesResource != null) {
-                    return readRouteResource(routesResource, developmentMode ? publishedResourceFingerprint : null);
-                }
-                return missingManifest(developmentMode, fileRoutesManifestExpected);
+                return discoverFromResource(routesResource);
             } catch (IOException | RuntimeException exception) {
                 logDiscoveryIssue(
                         "Cannot load complete Hilla client route tree; route access cannot be evaluated", exception);
@@ -229,6 +226,13 @@ public class RouteUtil {
             CurrentInstance.clearAll();
             CurrentInstance.restoreInstances(oldInstances);
         }
+    }
+
+    DiscoveryResult discoverFromResource(URL routesResource) throws IOException {
+        if (routesResource != null) {
+            return readRouteResource(routesResource, developmentMode ? publishedResourceFingerprint : null);
+        }
+        return missingManifest(developmentMode, fileRoutesManifestExpected);
     }
 
     void setCompleteRoutesForTesting(Map<String, AvailableViewInfo> registeredRoutes) {

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
@@ -15,13 +15,21 @@
  */
 package com.github.mcollovati.quarkus.hilla.security;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Predicate;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.internal.menu.MenuRegistry;
@@ -29,95 +37,492 @@ import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.menu.AvailableViewInfo;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import io.quarkus.security.identity.SecurityIdentity;
-import io.quarkus.vertx.http.runtime.security.ImmutablePathMatcher;
 import io.vertx.ext.web.RoutingContext;
+import org.jboss.logging.Logger;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class RouteUtil {
 
-    private Map<String, AvailableViewInfo> registeredRoutes = null;
+    private static final Logger LOGGER = Logger.getLogger(RouteUtil.class);
+    private static final ObjectMapper ROUTE_MAPPER = JsonMapper.builder()
+            .disable(
+                    DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+                    DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .build();
+    private static final Pattern DYNAMIC_SEGMENT = Pattern.compile("^:([\\w-]+)(\\?)?(.*)$");
+    private static final Pattern OPTIONAL_STATIC_SEGMENT = Pattern.compile("^[\\w-]+\\?$");
+    private static final long DISCOVERY_RETRY_NANOS = Duration.ofSeconds(1).toNanos();
+    private static final int NO_MATCH_SCORE = Integer.MIN_VALUE;
+    private static final int WILDCARD_SCORE = -1;
+    private static final int EMPTY_SEGMENT_SCORE = 2;
+    private static final int DYNAMIC_SEGMENT_SCORE = 4;
+    private static final int STATIC_SEGMENT_SCORE = 11;
+
     private final VaadinService vaadinService;
+    private final Supplier<DiscoveryResult> routeDiscovery;
+    private final LongSupplier nanoTime;
+
+    private volatile RouteSnapshot routeSnapshot;
+    private volatile DiscoveryState discoveryState = DiscoveryState.UNINITIALIZED;
+    private volatile long retryAfterNanos;
 
     public RouteUtil(VaadinService vaadinService) {
         this.vaadinService = vaadinService;
+        this.routeDiscovery = this::discoverClientRoutes;
+        this.nanoTime = System::nanoTime;
+    }
+
+    RouteUtil(VaadinService vaadinService, Supplier<DiscoveryResult> routeDiscovery, LongSupplier nanoTime) {
+        this.vaadinService = vaadinService;
+        this.routeDiscovery = routeDiscovery;
+        this.nanoTime = nanoTime;
     }
 
     public boolean isRouteAllowed(RoutingContext context, SecurityIdentity identity) {
-        // Ensure that the VaadinService is set for the current thread, so that collectClientRoutes can access it.
-        // The current instances should always be null, but for safety, we restore them after the operation.
+        return checkRouteAccess(context, identity) == RouteAccess.ALLOW;
+    }
+
+    RouteAccess checkRouteAccess(RoutingContext context, SecurityIdentity identity) {
+        ensureRoutesDiscovered();
+        RouteSnapshot snapshot = routeSnapshot;
+        if (snapshot == null) {
+            return RouteAccess.NO_MATCH;
+        }
+
+        List<CompiledRoute> matchedRoutes;
+        try {
+            String requestPath = context.normalizedPath();
+            String normalizedCandidate = requestPath;
+            String clientCandidate = clientRouterPath(requestPath);
+            matchedRoutes = new ArrayList<>(getRoutesByPath(snapshot.routes(), normalizedCandidate));
+            if (!normalizedCandidate.equals(clientCandidate)) {
+                for (CompiledRoute route : getRoutesByPath(snapshot.routes(), clientCandidate)) {
+                    if (!matchedRoutes.contains(route)) {
+                        matchedRoutes.add(route);
+                    }
+                }
+            }
+        } catch (RuntimeException exception) {
+            LOGGER.debug("Cannot normalize Hilla client route path; denying access", exception);
+            return RouteAccess.DENY;
+        }
+
+        if (matchedRoutes.isEmpty()) {
+            return RouteAccess.NO_MATCH;
+        }
+        if (!snapshot.hierarchyComplete() || identity == null) {
+            return RouteAccess.DENY;
+        }
+        for (CompiledRoute route : matchedRoutes) {
+            if (!isRouteAccessible(route, identity)) {
+                return RouteAccess.DENY;
+            }
+        }
+        return RouteAccess.ALLOW;
+    }
+
+    private void ensureRoutesDiscovered() {
+        DiscoveryState state = discoveryState;
+        long now = nanoTime.getAsLong();
+        if (state == DiscoveryState.COMPLETE
+                || state == DiscoveryState.FALLBACK
+                || (state == DiscoveryState.RETRY_PENDING && now - retryAfterNanos < 0)) {
+            return;
+        }
+        discoverRoutes(now);
+    }
+
+    private synchronized void discoverRoutes(long now) {
+        DiscoveryState state = discoveryState;
+        if (state == DiscoveryState.COMPLETE
+                || state == DiscoveryState.FALLBACK
+                || (state == DiscoveryState.RETRY_PENDING && now - retryAfterNanos < 0)) {
+            return;
+        }
+
+        DiscoveryResult result;
+        try {
+            result = routeDiscovery.get();
+        } catch (RuntimeException exception) {
+            LOGGER.warn("Cannot discover Hilla client routes; route access cannot be evaluated", exception);
+            publishFallback(Map.of(), true, now);
+            return;
+        }
+        if (result == null) {
+            LOGGER.warn("Hilla client route discovery returned no result; route access cannot be evaluated");
+            publishFallback(Map.of(), true, now);
+            return;
+        }
+
+        if (result.routeTree() != null) {
+            try {
+                publishRouteTree(result.routeTree());
+                return;
+            } catch (RuntimeException exception) {
+                LOGGER.warn("Cannot compile Hilla client route tree; route access cannot be evaluated", exception);
+            }
+        }
+        publishFallback(result.fallbackRoutes(), result.retryable(), now);
+    }
+
+    private DiscoveryResult discoverClientRoutes() {
+        // Route discovery needs a current VaadinService. Matching an already
+        // published snapshot does not, so keep thread-local manipulation out of
+        // the per-request hot path.
         final var oldInstances = CurrentInstance.getInstances();
         VaadinService.setCurrent(vaadinService);
         try {
-            return isRouteAllowedSafe(context, identity);
+            ApplicationConfiguration config = ApplicationConfiguration.get(vaadinService.getContext());
+            boolean retryable = !config.isProductionMode();
+            try {
+                URL routesResource = MenuRegistry.getViewsJsonAsResource(config);
+                if (routesResource != null) {
+                    try (InputStream input = routesResource.openStream()) {
+                        return DiscoveryResult.complete(readRouteTree(input));
+                    }
+                }
+            } catch (IOException | RuntimeException exception) {
+                LOGGER.warn(
+                        "Cannot load complete Hilla client route tree; route access cannot be evaluated", exception);
+            }
+            Map<String, AvailableViewInfo> fallbackRoutes;
+            try {
+                fallbackRoutes = MenuRegistry.collectClientMenuItems(false, config, null);
+            } catch (RuntimeException exception) {
+                LOGGER.warn("Cannot collect fallback Hilla client routes; route access cannot be evaluated", exception);
+                fallbackRoutes = Map.of();
+            }
+            return DiscoveryResult.fallback(fallbackRoutes, retryable);
         } finally {
             CurrentInstance.clearAll();
             CurrentInstance.restoreInstances(oldInstances);
         }
     }
 
-    private boolean isRouteAllowedSafe(RoutingContext context, SecurityIdentity identity) {
-        if (registeredRoutes == null) {
-            collectClientRoutes();
+    void setRoutes(Map<String, AvailableViewInfo> registeredRoutes) {
+        publishRoutes(registeredRoutes, true);
+        discoveryState = DiscoveryState.COMPLETE;
+    }
+
+    void setRouteTree(List<AvailableViewInfo> routeTree) {
+        publishRouteTree(routeTree);
+    }
+
+    static List<AvailableViewInfo> readRouteTree(InputStream input) throws IOException {
+        return ROUTE_MAPPER.readValue(input, new TypeReference<List<AvailableViewInfo>>() {});
+    }
+
+    private void publishRouteTree(List<AvailableViewInfo> routeTree) {
+        Map<String, AvailableViewInfo> routes = new LinkedHashMap<>();
+        Map<String, List<List<AvailableViewInfo>>> chains = new LinkedHashMap<>();
+        for (AvailableViewInfo route : routeTree) {
+            collectRouteTree("", List.of(), route, routes, chains);
         }
-        var viewConfig = getRouteData(context.normalizedPath(), identity);
-        return viewConfig.isPresent();
+        routeSnapshot = createSnapshot(routes, chains, true);
+        discoveryState = DiscoveryState.COMPLETE;
     }
 
-    private void collectClientRoutes() {
-        ApplicationConfiguration config = ApplicationConfiguration.get(vaadinService.getContext());
-        setRoutes(MenuRegistry.collectClientMenuItems(false, config, null));
-    }
-
-    private void setRoutes(final Map<String, AvailableViewInfo> registeredRoutes) {
-        if (registeredRoutes == null) {
-            this.registeredRoutes = null;
+    private void publishFallback(Map<String, AvailableViewInfo> fallbackRoutes, boolean retryable, long now) {
+        publishRoutes(fallbackRoutes, false);
+        if (retryable) {
+            retryAfterNanos = now + DISCOVERY_RETRY_NANOS;
+            discoveryState = DiscoveryState.RETRY_PENDING;
         } else {
-            this.registeredRoutes = new HashMap<>(registeredRoutes);
+            discoveryState = DiscoveryState.FALLBACK;
         }
     }
 
-    private Optional<AvailableViewInfo> getRouteData(String path, SecurityIdentity identity) {
-        Map<String, AvailableViewInfo> availableRoutes = new HashMap<>(registeredRoutes);
-        filterClientViews(availableRoutes, identity);
-        return Optional.ofNullable(getRouteByPath(availableRoutes, path));
+    private void publishRoutes(Map<String, AvailableViewInfo> registeredRoutes, boolean hierarchyComplete) {
+        Map<String, AvailableViewInfo> routes =
+                registeredRoutes == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(registeredRoutes));
+        Map<String, List<List<AvailableViewInfo>>> chains = new LinkedHashMap<>();
+        routes.forEach((route, view) -> chains.put(route, List.of(List.of(view))));
+        routeSnapshot = createSnapshot(routes, chains, hierarchyComplete);
     }
 
-    private static void filterClientViews(Map<String, AvailableViewInfo> configurations, SecurityIdentity identity) {
-        final boolean isUserAuthenticated = !identity.isAnonymous();
-        Set<String> clientEntries = new HashSet<>(configurations.keySet());
-        // configurations::containsKey is used to avoid ConcurrentModificationException
-        clientEntries.stream().filter(configurations::containsKey).forEach(path -> {
-            final AvailableViewInfo viewInfo = configurations.get(path);
-            final boolean routeValid = validateViewAccessible(viewInfo, isUserAuthenticated, identity::hasRole);
-            if (!routeValid) {
-                removePathRecursive(configurations, viewInfo, path);
+    private static RouteSnapshot createSnapshot(
+            Map<String, AvailableViewInfo> routes,
+            Map<String, List<List<AvailableViewInfo>>> securityChains,
+            boolean hierarchyComplete) {
+        List<CompiledRoute> compiledRoutes = new ArrayList<>(routes.size());
+        for (String route : routes.keySet()) {
+            List<List<AvailableViewInfo>> chains = securityChains.get(route);
+            compiledRoutes.add(
+                    new CompiledRoute(route, routeSegments(route), chains == null ? List.of() : List.copyOf(chains)));
+        }
+        return new RouteSnapshot(List.copyOf(compiledRoutes), hierarchyComplete);
+    }
+
+    private static void collectRouteTree(
+            String parentPath,
+            List<AvailableViewInfo> ancestors,
+            AvailableViewInfo view,
+            Map<String, AvailableViewInfo> routes,
+            Map<String, List<List<AvailableViewInfo>>> chains) {
+        String routePath;
+        try {
+            routePath = appendRoute(parentPath, view.route());
+        } catch (IllegalArgumentException exception) {
+            LOGGER.errorf(exception, "Ignoring invalid Hilla client route '%s' below '%s'", view.route(), parentPath);
+            return;
+        }
+        List<AvailableViewInfo> securityChain = new ArrayList<>(ancestors);
+        securityChain.add(view);
+        routes.putIfAbsent(routePath, view);
+        chains.computeIfAbsent(routePath, ignored -> new ArrayList<>()).add(List.copyOf(securityChain));
+        if (view.children() != null) {
+            for (AvailableViewInfo child : view.children()) {
+                collectRouteTree(routePath, securityChain, child, routes, chains);
             }
-        });
+        }
     }
 
-    private static boolean validateViewAccessible(
-            AvailableViewInfo viewInfo, boolean isUserAuthenticated, Predicate<? super String> roleAuthentication) {
-        if (viewInfo.loginRequired() && !isUserAuthenticated) {
+    private static String appendRoute(String parentPath, String route) {
+        if (route == null || route.isEmpty()) {
+            return parentPath;
+        }
+        if (route.startsWith("/")) {
+            String absoluteRoute = normalizeRoutePath(route);
+            if (!parentPath.isEmpty() && !absoluteRoute.startsWith(parentPath)) {
+                throw new IllegalArgumentException(
+                        "Absolute child route '" + route + "' must start with parent path '" + parentPath + "'");
+            }
+            return normalizeRoutePath(parentPath + "/" + absoluteRoute.substring(parentPath.length()));
+        }
+        return normalizeRoutePath(parentPath + "/" + route);
+    }
+
+    private static String normalizeRoutePath(String route) {
+        return route.replaceAll("/+", "/");
+    }
+
+    private static boolean isRouteAccessible(CompiledRoute route, SecurityIdentity identity) {
+        List<List<AvailableViewInfo>> chains = route.securityChains();
+        return chains != null && !chains.isEmpty() && allChainsAccessible(chains, identity);
+    }
+
+    private static boolean allChainsAccessible(List<List<AvailableViewInfo>> chains, SecurityIdentity identity) {
+        for (List<AvailableViewInfo> chain : chains) {
+            for (AvailableViewInfo view : chain) {
+                if (!validateViewAccessible(view, identity)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static boolean validateViewAccessible(AvailableViewInfo viewInfo, SecurityIdentity identity) {
+        if (viewInfo.loginRequired() && identity.isAnonymous()) {
             return false;
         }
         String[] roles = viewInfo.rolesAllowed();
-        return roles == null || roles.length == 0 || Arrays.stream(roles).anyMatch(roleAuthentication);
+        if (roles == null || roles.length == 0) {
+            return true;
+        }
+        for (String role : roles) {
+            if (identity.hasRole(role)) {
+                return true;
+            }
+        }
+        return false;
     }
 
-    private static void removePathRecursive(
-            Map<String, AvailableViewInfo> configurations, AvailableViewInfo viewInfo, String parentPath) {
-        configurations.remove(parentPath);
-        if (viewInfo.children() == null) return;
-        for (AvailableViewInfo child : viewInfo.children()) {
-            String childRoute = (parentPath + "/" + child.route()).replace("//", "/");
-            removePathRecursive(configurations, child, childRoute);
+    private static List<CompiledRoute> getRoutesByPath(List<CompiledRoute> availableRoutes, String path) {
+        List<CompiledRoute> bestMatches = new ArrayList<>();
+        List<String> pathSegments = segments(path);
+        int bestScore = NO_MATCH_SCORE;
+        for (CompiledRoute route : availableRoutes) {
+            int score = matchScore(route.segments(), pathSegments, 0, 0);
+            if (score == NO_MATCH_SCORE) {
+                continue;
+            }
+            if (score > bestScore) {
+                bestMatches.clear();
+                bestScore = score;
+            }
+            if (score == bestScore) {
+                bestMatches.add(route);
+            }
+        }
+        return List.copyOf(bestMatches);
+    }
+
+    private static int matchScore(
+            List<SegmentPattern> routeSegments, List<String> pathSegments, int routeIndex, int pathIndex) {
+        if (routeIndex == routeSegments.size()) {
+            return pathIndex == pathSegments.size() ? 0 : NO_MATCH_SCORE;
+        }
+
+        // Relative weights follow React Router branch ranking: literal and
+        // suffixed segments outrank plain parameters, while wildcards rank last.
+        SegmentPattern segmentPattern = routeSegments.get(routeIndex);
+        if (segmentPattern.type() == SegmentType.WILDCARD) {
+            if (routeIndex == routeSegments.size() - 1) {
+                return WILDCARD_SCORE;
+            }
+            int matched =
+                    remainingSegmentsCanBeOmitted(routeSegments, routeIndex + 1) ? WILDCARD_SCORE : NO_MATCH_SCORE;
+            if (pathIndex < pathSegments.size() && "*".equals(pathSegments.get(pathIndex))) {
+                int remaining = matchScore(routeSegments, pathSegments, routeIndex + 1, pathIndex + 1);
+                if (remaining != NO_MATCH_SCORE) {
+                    matched = Math.max(matched, remaining + WILDCARD_SCORE);
+                }
+            }
+            return matched;
+        }
+        int skipped = segmentPattern.optional() && segmentPattern.canBeOmitted()
+                ? matchScore(routeSegments, pathSegments, routeIndex + 1, pathIndex)
+                : NO_MATCH_SCORE;
+        if (pathIndex == pathSegments.size()) {
+            return skipped;
+        }
+        int remaining = matchScore(routeSegments, pathSegments, routeIndex + 1, pathIndex + 1);
+        if (remaining == NO_MATCH_SCORE) {
+            return skipped;
+        }
+        String pathSegment = pathSegments.get(pathIndex);
+        int consumed = NO_MATCH_SCORE;
+        if (segmentPattern.type() == SegmentType.DYNAMIC && segmentPattern.matchesDynamic(pathSegment)) {
+            consumed = remaining + (segmentPattern.value().isEmpty() ? DYNAMIC_SEGMENT_SCORE : STATIC_SEGMENT_SCORE);
+        } else if (segmentPattern.type() == SegmentType.STATIC
+                && segmentPattern.value().equalsIgnoreCase(pathSegment)) {
+            consumed = remaining + (segmentPattern.value().isEmpty() ? EMPTY_SEGMENT_SCORE : STATIC_SEGMENT_SCORE);
+        }
+        return Math.max(skipped, consumed);
+    }
+
+    private static boolean remainingSegmentsCanBeOmitted(List<SegmentPattern> routeSegments, int routeIndex) {
+        for (int index = routeIndex; index < routeSegments.size(); index++) {
+            SegmentPattern remaining = routeSegments.get(index);
+            if (!remaining.optional() || !remaining.canBeOmitted()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static SegmentPattern segmentPattern(String routeSegment) {
+        if ("*".equals(routeSegment)) {
+            return new SegmentPattern(SegmentType.WILDCARD, "", false);
+        }
+        Matcher dynamic = DYNAMIC_SEGMENT.matcher(routeSegment);
+        if (dynamic.matches()) {
+            return new SegmentPattern(SegmentType.DYNAMIC, dynamic.group(3), dynamic.group(2) != null);
+        }
+        if (OPTIONAL_STATIC_SEGMENT.matcher(routeSegment).matches()) {
+            return new SegmentPattern(SegmentType.STATIC, routeSegment.substring(0, routeSegment.length() - 1), true);
+        }
+        return new SegmentPattern(SegmentType.STATIC, routeSegment, false);
+    }
+
+    private static List<String> segments(String path) {
+        if (path == null || path.isBlank() || "/".equals(path)) {
+            return List.of();
+        }
+        int start = 0;
+        int end = path.length();
+        while (start < end && path.charAt(start) == '/') {
+            start++;
+        }
+        while (end > start && path.charAt(end - 1) == '/') {
+            end--;
+        }
+        return start == end
+                ? List.of()
+                : Arrays.asList(path.substring(start, end).split("/", -1));
+    }
+
+    private static List<SegmentPattern> routeSegments(String route) {
+        if (route != null && route.endsWith("*") && !"*".equals(route) && !route.endsWith("/*")) {
+            route = route.substring(0, route.length() - 1) + "/*";
+        }
+        List<String> segments = segments(route);
+        List<SegmentPattern> patterns = new ArrayList<>(segments.size());
+        for (String segment : segments) {
+            patterns.add(segmentPattern(segment));
+        }
+        return List.copyOf(patterns);
+    }
+
+    private static String clientRouterPath(String path) {
+        if (path.indexOf('%') < 0) {
+            return path;
+        }
+        return String.join(
+                "/",
+                Arrays.stream(path.split("/", -1))
+                        .map(RouteUtil::decodeClientRouterSegment)
+                        .toList());
+    }
+
+    private static String decodeClientRouterSegment(String segment) {
+        try {
+            return URLDecoder.decode(segment.replace("+", "%2B"), StandardCharsets.UTF_8)
+                    .replace("/", "%2F");
+        } catch (IllegalArgumentException exception) {
+            return segment;
         }
     }
 
-    private AvailableViewInfo getRouteByPath(Map<String, AvailableViewInfo> availableRoutes, String path) {
-        final var matcherBuilder = ImmutablePathMatcher.<AvailableViewInfo>builder();
-        availableRoutes.forEach((route, info) -> {
-            matcherBuilder.addPath(PathUtil.ensureSlashBegin(route), info);
-        });
-        return matcherBuilder.build().match(path).getValue();
+    enum RouteAccess {
+        NO_MATCH,
+        ALLOW,
+        DENY
     }
+
+    private enum DiscoveryState {
+        UNINITIALIZED,
+        RETRY_PENDING,
+        COMPLETE,
+        FALLBACK
+    }
+
+    record DiscoveryResult(
+            List<AvailableViewInfo> routeTree, Map<String, AvailableViewInfo> fallbackRoutes, boolean retryable) {
+
+        static DiscoveryResult complete(List<AvailableViewInfo> routeTree) {
+            return new DiscoveryResult(List.copyOf(routeTree), Map.of(), false);
+        }
+
+        static DiscoveryResult fallback(Map<String, AvailableViewInfo> fallbackRoutes, boolean retryable) {
+            return new DiscoveryResult(
+                    null,
+                    fallbackRoutes == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(fallbackRoutes)),
+                    retryable);
+        }
+    }
+
+    private enum SegmentType {
+        STATIC,
+        DYNAMIC,
+        WILDCARD
+    }
+
+    private record SegmentPattern(SegmentType type, String value, boolean optional) {
+
+        boolean canBeOmitted() {
+            return type == SegmentType.STATIC || value.isEmpty();
+        }
+
+        boolean matchesDynamic(String pathSegment) {
+            if (!endsWithIgnoreCase(pathSegment, value)) {
+                return false;
+            }
+            int parameterLength = pathSegment.length() - value.length();
+            return optional ? parameterLength >= 0 : parameterLength > 0;
+        }
+
+        private static boolean endsWithIgnoreCase(String value, String suffix) {
+            return value.regionMatches(true, value.length() - suffix.length(), suffix, 0, suffix.length());
+        }
+    }
+
+    private record CompiledRoute(
+            String path, List<SegmentPattern> segments, List<List<AvailableViewInfo>> securityChains) {}
+
+    private record RouteSnapshot(List<CompiledRoute> routes, boolean hierarchyComplete) {}
 }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
@@ -35,7 +35,6 @@ import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.internal.menu.MenuRegistry;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.menu.AvailableViewInfo;
-import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.vertx.ext.web.RoutingContext;
 import org.jboss.logging.Logger;
@@ -57,7 +56,7 @@ public class RouteUtil {
             .build();
     private static final Pattern DYNAMIC_SEGMENT = Pattern.compile("^:([\\w-]+)(\\?)?(.*)$");
     private static final Pattern OPTIONAL_STATIC_SEGMENT = Pattern.compile("^[\\w-]+\\?$");
-    private static final long DISCOVERY_RETRY_NANOS = Duration.ofSeconds(1).toNanos();
+    private static final long DISCOVERY_REFRESH_NANOS = Duration.ofSeconds(1).toNanos();
 
     /*
      * Relative scores follow React Router route ranking. Static and suffixed
@@ -71,21 +70,32 @@ public class RouteUtil {
     private static final int STATIC_SEGMENT_SCORE = 11;
 
     private final VaadinService vaadinService;
+    private final boolean developmentMode;
     private final Supplier<DiscoveryResult> routeDiscovery;
     private final LongSupplier nanoTime;
 
     private volatile RouteSnapshot routeSnapshot;
     private volatile DiscoveryState discoveryState = DiscoveryState.UNINITIALIZED;
-    private volatile long retryAfterNanos;
+    private volatile long refreshAfterNanos;
 
     public RouteUtil(VaadinService vaadinService) {
         this.vaadinService = vaadinService;
+        this.developmentMode = !vaadinService.getDeploymentConfiguration().isProductionMode();
         this.routeDiscovery = this::discoverClientRoutes;
         this.nanoTime = System::nanoTime;
     }
 
     RouteUtil(VaadinService vaadinService, Supplier<DiscoveryResult> routeDiscovery, LongSupplier nanoTime) {
+        this(vaadinService, true, routeDiscovery, nanoTime);
+    }
+
+    RouteUtil(
+            VaadinService vaadinService,
+            boolean developmentMode,
+            Supplier<DiscoveryResult> routeDiscovery,
+            LongSupplier nanoTime) {
         this.vaadinService = vaadinService;
+        this.developmentMode = developmentMode;
         this.routeDiscovery = routeDiscovery;
         this.nanoTime = nanoTime;
     }
@@ -135,10 +145,11 @@ public class RouteUtil {
 
     private void ensureRoutesDiscovered() {
         DiscoveryState state = discoveryState;
+        if (isTerminal(state)) {
+            return;
+        }
         long now = nanoTime.getAsLong();
-        if (state == DiscoveryState.COMPLETE
-                || state == DiscoveryState.FALLBACK
-                || (state == DiscoveryState.RETRY_PENDING && now - retryAfterNanos < 0)) {
+        if (!requiresDiscovery(state, now)) {
             return;
         }
         discoverRoutes(now);
@@ -146,9 +157,7 @@ public class RouteUtil {
 
     private synchronized void discoverRoutes(long now) {
         DiscoveryState state = discoveryState;
-        if (state == DiscoveryState.COMPLETE
-                || state == DiscoveryState.FALLBACK
-                || (state == DiscoveryState.RETRY_PENDING && now - retryAfterNanos < 0)) {
+        if (isTerminal(state) || !requiresDiscovery(state, now)) {
             return;
         }
 
@@ -157,24 +166,33 @@ public class RouteUtil {
             result = routeDiscovery.get();
         } catch (RuntimeException exception) {
             LOGGER.warn("Cannot discover Hilla client routes; route access cannot be evaluated", exception);
-            publishFallback(Map.of(), true, now);
+            handleDiscoveryFailure(Map.of(), now);
             return;
         }
         if (result == null) {
             LOGGER.warn("Hilla client route discovery returned no result; route access cannot be evaluated");
-            publishFallback(Map.of(), true, now);
+            handleDiscoveryFailure(Map.of(), now);
             return;
         }
 
         if (result.routeTree() != null) {
             try {
-                publishRouteTree(result.routeTree());
+                publishRouteTree(result.routeTree(), now);
                 return;
             } catch (RuntimeException exception) {
                 LOGGER.warn("Cannot compile Hilla client route tree; route access cannot be evaluated", exception);
             }
         }
-        publishFallback(result.fallbackRoutes(), result.retryable(), now);
+        handleDiscoveryFailure(result.fallbackRoutes(), now);
+    }
+
+    private boolean requiresDiscovery(DiscoveryState state, long now) {
+        return state == DiscoveryState.UNINITIALIZED
+                || (state == DiscoveryState.REFRESH_PENDING && now - refreshAfterNanos >= 0);
+    }
+
+    private static boolean isTerminal(DiscoveryState state) {
+        return state == DiscoveryState.COMPLETE || state == DiscoveryState.FALLBACK;
     }
 
     private DiscoveryResult discoverClientRoutes() {
@@ -184,8 +202,7 @@ public class RouteUtil {
         final var oldInstances = CurrentInstance.getInstances();
         VaadinService.setCurrent(vaadinService);
         try {
-            ApplicationConfiguration config = ApplicationConfiguration.get(vaadinService.getContext());
-            boolean retryable = !config.isProductionMode();
+            var config = vaadinService.getDeploymentConfiguration();
             try {
                 URL routesResource = MenuRegistry.getViewsJsonAsResource(config);
                 if (routesResource != null) {
@@ -204,7 +221,7 @@ public class RouteUtil {
                 LOGGER.warn("Cannot collect fallback Hilla client routes; route access cannot be evaluated", exception);
                 fallbackRoutes = Map.of();
             }
-            return DiscoveryResult.fallback(fallbackRoutes, retryable);
+            return DiscoveryResult.fallback(fallbackRoutes);
         } finally {
             CurrentInstance.clearAll();
             CurrentInstance.restoreInstances(oldInstances);
@@ -217,31 +234,53 @@ public class RouteUtil {
     }
 
     void setRouteTree(List<AvailableViewInfo> routeTree) {
-        publishRouteTree(routeTree);
+        publishRouteTreeSnapshot(routeTree);
+        discoveryState = DiscoveryState.COMPLETE;
     }
 
     static List<AvailableViewInfo> readRouteTree(InputStream input) throws IOException {
         return ROUTE_MAPPER.readValue(input, new TypeReference<List<AvailableViewInfo>>() {});
     }
 
-    private void publishRouteTree(List<AvailableViewInfo> routeTree) {
+    private void publishRouteTree(List<AvailableViewInfo> routeTree, long now) {
+        publishRouteTreeSnapshot(routeTree);
+        completeDiscovery(now);
+    }
+
+    private void publishRouteTreeSnapshot(List<AvailableViewInfo> routeTree) {
         Map<String, AvailableViewInfo> routes = new LinkedHashMap<>();
         Map<String, List<List<AvailableViewInfo>>> chains = new LinkedHashMap<>();
         for (AvailableViewInfo route : routeTree) {
             collectRouteTree("", List.of(), route, routes, chains);
         }
         routeSnapshot = createSnapshot(routes, chains, true);
-        discoveryState = DiscoveryState.COMPLETE;
     }
 
-    private void publishFallback(Map<String, AvailableViewInfo> fallbackRoutes, boolean retryable, long now) {
+    private void handleDiscoveryFailure(Map<String, AvailableViewInfo> fallbackRoutes, long now) {
+        RouteSnapshot currentSnapshot = routeSnapshot;
+        if (currentSnapshot != null && currentSnapshot.hierarchyComplete()) {
+            completeDiscovery(now);
+            return;
+        }
         publishRoutes(fallbackRoutes, false);
-        if (retryable) {
-            retryAfterNanos = now + DISCOVERY_RETRY_NANOS;
-            discoveryState = DiscoveryState.RETRY_PENDING;
+        if (developmentMode) {
+            scheduleRefresh(now);
         } else {
             discoveryState = DiscoveryState.FALLBACK;
         }
+    }
+
+    private void completeDiscovery(long now) {
+        if (developmentMode) {
+            scheduleRefresh(now);
+        } else {
+            discoveryState = DiscoveryState.COMPLETE;
+        }
+    }
+
+    private void scheduleRefresh(long now) {
+        refreshAfterNanos = now + DISCOVERY_REFRESH_NANOS;
+        discoveryState = DiscoveryState.REFRESH_PENDING;
     }
 
     private void publishRoutes(Map<String, AvailableViewInfo> registeredRoutes, boolean hierarchyComplete) {
@@ -483,23 +522,20 @@ public class RouteUtil {
 
     private enum DiscoveryState {
         UNINITIALIZED,
-        RETRY_PENDING,
+        REFRESH_PENDING,
         COMPLETE,
         FALLBACK
     }
 
-    record DiscoveryResult(
-            List<AvailableViewInfo> routeTree, Map<String, AvailableViewInfo> fallbackRoutes, boolean retryable) {
+    record DiscoveryResult(List<AvailableViewInfo> routeTree, Map<String, AvailableViewInfo> fallbackRoutes) {
 
         static DiscoveryResult complete(List<AvailableViewInfo> routeTree) {
-            return new DiscoveryResult(List.copyOf(routeTree), Map.of(), false);
+            return new DiscoveryResult(List.copyOf(routeTree), Map.of());
         }
 
-        static DiscoveryResult fallback(Map<String, AvailableViewInfo> fallbackRoutes, boolean retryable) {
+        static DiscoveryResult fallback(Map<String, AvailableViewInfo> fallbackRoutes) {
             return new DiscoveryResult(
-                    null,
-                    fallbackRoutes == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(fallbackRoutes)),
-                    retryable);
+                    null, fallbackRoutes == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(fallbackRoutes)));
         }
     }
 

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
@@ -245,7 +245,9 @@ public class RouteUtil {
         }
     }
 
-    /** Must be called while holding the discovery monitor that guards the resource fingerprint. */
+    /**
+     * Must be called while holding the discovery monitor that guards the resource fingerprint.
+     */
     DiscoveryResult discoverFromResource(URL routesResource) throws IOException {
         if (routesResource != null) {
             return readRouteResource(routesResource, developmentMode ? publishedResourceFingerprint : null);

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Marco Collovati, Dario Götze
+ * Copyright 2025-2026 Marco Collovati, Dario Götze
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -178,7 +179,7 @@ public class RouteUtil {
                 LOGGER.warn("Cannot compile Hilla client route tree; route access cannot be evaluated", exception);
             }
         }
-        handleDiscoveryFailure(now);
+        handleDiscoveryFailure(now, result.retryImmediately());
     }
 
     private boolean requiresDiscovery(DiscoveryState state, long now) {
@@ -203,10 +204,14 @@ public class RouteUtil {
                 if (routesResource != null) {
                     return readRouteResource(routesResource, developmentMode ? publishedResourceFingerprint : null);
                 }
-                // A manifest is optional for applications using a custom
-                // client router. In that case this evaluator does not own any
-                // route, which is different from failing to read a manifest.
-                return DiscoveryResult.complete(List.of());
+                boolean reactEnabled = config.isReactEnabled();
+                boolean customRouter = false;
+                if (developmentMode && reactEnabled) {
+                    var frontendFolder = config.getFrontendFolder().toPath();
+                    customRouter = Files.isRegularFile(frontendFolder.resolve("routes.tsx"))
+                            || Files.isRegularFile(frontendFolder.resolve("routes.ts"));
+                }
+                return missingManifest(developmentMode, reactEnabled, customRouter);
             } catch (IOException | RuntimeException exception) {
                 LOGGER.warn(
                         "Cannot load complete Hilla client route tree; route access cannot be evaluated", exception);
@@ -260,6 +265,10 @@ public class RouteUtil {
     }
 
     private void handleDiscoveryFailure(long now) {
+        handleDiscoveryFailure(now, false);
+    }
+
+    private void handleDiscoveryFailure(long now, boolean retryImmediately) {
         RouteSnapshot currentSnapshot = routeSnapshot;
         if (currentSnapshot != null && currentSnapshot.hierarchyComplete()) {
             completeDiscovery(now);
@@ -267,7 +276,7 @@ public class RouteUtil {
         }
         routeSnapshot = new RouteSnapshot(List.of(), false);
         if (developmentMode) {
-            scheduleRefresh(now);
+            scheduleRefresh(now, retryImmediately ? 0 : DISCOVERY_REFRESH_NANOS);
         } else {
             discoveryState = DiscoveryState.FAILED;
         }
@@ -275,15 +284,26 @@ public class RouteUtil {
 
     private void completeDiscovery(long now) {
         if (developmentMode) {
-            scheduleRefresh(now);
+            scheduleRefresh(now, DISCOVERY_REFRESH_NANOS);
         } else {
             discoveryState = DiscoveryState.COMPLETE;
         }
     }
 
-    private void scheduleRefresh(long now) {
-        refreshAfterNanos = now + DISCOVERY_REFRESH_NANOS;
+    private void scheduleRefresh(long now, long delayNanos) {
+        refreshAfterNanos = now + delayNanos;
         discoveryState = DiscoveryState.REFRESH_PENDING;
+    }
+
+    static DiscoveryResult missingManifest(boolean developmentMode, boolean reactEnabled, boolean customRouter) {
+        // React/Hilla normally produces file-routes.json. During a development
+        // startup it can briefly be unavailable while frontend generation is
+        // still running, so deny and retry instead of publishing an empty tree.
+        // Applications with a custom client router can legitimately have no
+        // manifest, in which case this evaluator owns no routes.
+        return developmentMode && reactEnabled && !customRouter
+                ? DiscoveryResult.retryableFailure()
+                : DiscoveryResult.complete(List.of());
     }
 
     private void publishCompleteRoutes(Map<String, AvailableViewInfo> registeredRoutes) {
@@ -406,22 +426,29 @@ public class RouteUtil {
     }
 
     record DiscoveryResult(
-            List<AvailableViewInfo> routeTree, ResourceFingerprint resourceFingerprint, boolean unchanged) {
+            List<AvailableViewInfo> routeTree,
+            ResourceFingerprint resourceFingerprint,
+            boolean unchanged,
+            boolean retryImmediately) {
 
         static DiscoveryResult complete(List<AvailableViewInfo> routeTree) {
             return complete(routeTree, null);
         }
 
         static DiscoveryResult complete(List<AvailableViewInfo> routeTree, ResourceFingerprint fingerprint) {
-            return new DiscoveryResult(List.copyOf(routeTree), fingerprint, false);
+            return new DiscoveryResult(List.copyOf(routeTree), fingerprint, false, false);
         }
 
         static DiscoveryResult failure() {
-            return new DiscoveryResult(null, null, false);
+            return new DiscoveryResult(null, null, false, false);
+        }
+
+        static DiscoveryResult retryableFailure() {
+            return new DiscoveryResult(null, null, false, true);
         }
 
         static DiscoveryResult unchangedResult() {
-            return new DiscoveryResult(null, null, true);
+            return new DiscoveryResult(null, null, true, false);
         }
     }
 

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -47,8 +46,9 @@ import tools.jackson.databind.json.JsonMapper;
  * <p>Routes declared only in a custom {@code routes.tsx}, including security
  * metadata on custom parent layouts, are not present in that manifest and are
  * therefore outside this evaluator. Callers must apply another authorization
- * source to those routes. Incomplete manifest data never produces an allow or
- * no-match decision.
+ * source to those routes. An expected manifest that is incomplete or cannot be
+ * read never produces an allow or no-match decision: access remains denied. An
+ * absent manifest can instead mean that this evaluator owns no file routes.
  */
 public class RouteUtil {
 
@@ -65,23 +65,30 @@ public class RouteUtil {
 
     private final VaadinService vaadinService;
     private final boolean developmentMode;
+    private final boolean fileRoutesManifestExpected;
     private final Supplier<DiscoveryResult> routeDiscovery;
     private final LongSupplier nanoTime;
 
     private volatile RouteSnapshot routeSnapshot;
     private volatile DiscoveryState discoveryState = DiscoveryState.UNINITIALIZED;
     private volatile long refreshAfterNanos;
+    // Access is guarded by the synchronized discovery monitor.
     private ResourceFingerprint publishedResourceFingerprint;
 
     public RouteUtil(VaadinService vaadinService) {
+        this(vaadinService, true);
+    }
+
+    public RouteUtil(VaadinService vaadinService, boolean fileRoutesManifestExpected) {
         this.vaadinService = vaadinService;
         this.developmentMode = !vaadinService.getDeploymentConfiguration().isProductionMode();
+        this.fileRoutesManifestExpected = fileRoutesManifestExpected;
         this.routeDiscovery = this::discoverClientRoutes;
         this.nanoTime = System::nanoTime;
     }
 
     RouteUtil(VaadinService vaadinService, Supplier<DiscoveryResult> routeDiscovery, LongSupplier nanoTime) {
-        this(vaadinService, true, routeDiscovery, nanoTime);
+        this(vaadinService, true, true, routeDiscovery, nanoTime);
     }
 
     RouteUtil(
@@ -89,8 +96,18 @@ public class RouteUtil {
             boolean developmentMode,
             Supplier<DiscoveryResult> routeDiscovery,
             LongSupplier nanoTime) {
+        this(vaadinService, developmentMode, true, routeDiscovery, nanoTime);
+    }
+
+    RouteUtil(
+            VaadinService vaadinService,
+            boolean developmentMode,
+            boolean fileRoutesManifestExpected,
+            Supplier<DiscoveryResult> routeDiscovery,
+            LongSupplier nanoTime) {
         this.vaadinService = vaadinService;
         this.developmentMode = developmentMode;
+        this.fileRoutesManifestExpected = fileRoutesManifestExpected;
         this.routeDiscovery = routeDiscovery;
         this.nanoTime = nanoTime;
     }
@@ -102,7 +119,7 @@ public class RouteUtil {
     AuthorizationDecision checkRouteAccess(RoutingContext context, SecurityIdentity identity) {
         ensureRoutesDiscovered();
         RouteSnapshot snapshot = routeSnapshot;
-        if (snapshot == null) {
+        if (snapshot == null || !snapshot.hierarchyComplete() || identity == null) {
             return AuthorizationDecision.DENY;
         }
 
@@ -114,9 +131,6 @@ public class RouteUtil {
             return AuthorizationDecision.DENY;
         }
 
-        if (!snapshot.hierarchyComplete() || identity == null) {
-            return AuthorizationDecision.DENY;
-        }
         if (matchedRoutes.isEmpty()) {
             return AuthorizationDecision.NO_MATCH;
         }
@@ -150,12 +164,12 @@ public class RouteUtil {
         try {
             result = routeDiscovery.get();
         } catch (RuntimeException exception) {
-            LOGGER.warn("Cannot discover Hilla client routes; route access cannot be evaluated", exception);
+            logDiscoveryIssue("Cannot discover Hilla client routes; route access cannot be evaluated", exception);
             handleDiscoveryFailure(now);
             return;
         }
         if (result == null) {
-            LOGGER.warn("Hilla client route discovery returned no result; route access cannot be evaluated");
+            logDiscoveryIssue("Hilla client route discovery returned no result; route access cannot be evaluated");
             handleDiscoveryFailure(now);
             return;
         }
@@ -176,7 +190,8 @@ public class RouteUtil {
                 publishedResourceFingerprint = result.resourceFingerprint();
                 return;
             } catch (RuntimeException exception) {
-                LOGGER.warn("Cannot compile Hilla client route tree; route access cannot be evaluated", exception);
+                logDiscoveryIssue(
+                        "Cannot compile Hilla client route tree; route access cannot be evaluated", exception);
             }
         }
         handleDiscoveryFailure(now, result.retryImmediately());
@@ -204,16 +219,9 @@ public class RouteUtil {
                 if (routesResource != null) {
                     return readRouteResource(routesResource, developmentMode ? publishedResourceFingerprint : null);
                 }
-                boolean reactEnabled = config.isReactEnabled();
-                boolean customRouter = false;
-                if (developmentMode && reactEnabled) {
-                    var frontendFolder = config.getFrontendFolder().toPath();
-                    customRouter = Files.isRegularFile(frontendFolder.resolve("routes.tsx"))
-                            || Files.isRegularFile(frontendFolder.resolve("routes.ts"));
-                }
-                return missingManifest(developmentMode, reactEnabled, customRouter);
+                return missingManifest(developmentMode, fileRoutesManifestExpected);
             } catch (IOException | RuntimeException exception) {
-                LOGGER.warn(
+                logDiscoveryIssue(
                         "Cannot load complete Hilla client route tree; route access cannot be evaluated", exception);
             }
             return DiscoveryResult.failure();
@@ -269,16 +277,30 @@ public class RouteUtil {
     }
 
     private void handleDiscoveryFailure(long now, boolean retryImmediately) {
-        RouteSnapshot currentSnapshot = routeSnapshot;
-        if (currentSnapshot != null && currentSnapshot.hierarchyComplete()) {
-            completeDiscovery(now);
-            return;
-        }
         routeSnapshot = new RouteSnapshot(List.of(), false);
+        publishedResourceFingerprint = null;
         if (developmentMode) {
             scheduleRefresh(now, retryImmediately ? 0 : DISCOVERY_REFRESH_NANOS);
         } else {
             discoveryState = DiscoveryState.FAILED;
+            LOGGER.error(
+                    "Hilla route discovery failed in production because META-INF/VAADIN/file-routes.json is missing, unreadable, or invalid; access to all generated Hilla routes remains denied until restart. Enable DEBUG logging for the underlying cause");
+        }
+    }
+
+    private void logDiscoveryIssue(String message) {
+        if (developmentMode) {
+            LOGGER.warn(message);
+        } else {
+            LOGGER.debug(message);
+        }
+    }
+
+    private void logDiscoveryIssue(String message, Throwable exception) {
+        if (developmentMode) {
+            LOGGER.warn(message, exception);
+        } else {
+            LOGGER.debug(message, exception);
         }
     }
 
@@ -295,15 +317,11 @@ public class RouteUtil {
         discoveryState = DiscoveryState.REFRESH_PENDING;
     }
 
-    static DiscoveryResult missingManifest(boolean developmentMode, boolean reactEnabled, boolean customRouter) {
-        // React/Hilla normally produces file-routes.json. During a development
-        // startup it can briefly be unavailable while frontend generation is
-        // still running, so deny and retry instead of publishing an empty tree.
-        // Applications with a custom client router can legitimately have no
-        // manifest, in which case this evaluator owns no routes.
-        return developmentMode && reactEnabled && !customRouter
-                ? DiscoveryResult.retryableFailure()
-                : DiscoveryResult.complete(List.of());
+    static DiscoveryResult missingManifest(boolean developmentMode, boolean fileRoutesManifestExpected) {
+        if (!fileRoutesManifestExpected) {
+            return DiscoveryResult.complete(List.of());
+        }
+        return developmentMode ? DiscoveryResult.retryableFailure() : DiscoveryResult.failure();
     }
 
     private void publishCompleteRoutes(Map<String, AvailableViewInfo> registeredRoutes) {

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/RouteUtil.java
@@ -32,6 +32,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.menu.MenuRegistry;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.menu.AvailableViewInfo;
@@ -41,20 +42,25 @@ import io.vertx.ext.web.RoutingContext;
 import org.jboss.logging.Logger;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.DeserializationFeature;
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.ObjectReader;
 
 public class RouteUtil {
 
     private static final Logger LOGGER = Logger.getLogger(RouteUtil.class);
-    private static final ObjectMapper ROUTE_MAPPER = JsonMapper.builder()
-            .disable(
+    private static final ObjectReader ROUTE_READER = JacksonUtils.getMapper()
+            .readerFor(new TypeReference<List<AvailableViewInfo>>() {})
+            .without(
                     DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
-                    DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
-            .build();
+                    DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
     private static final Pattern DYNAMIC_SEGMENT = Pattern.compile("^:([\\w-]+)(\\?)?(.*)$");
     private static final Pattern OPTIONAL_STATIC_SEGMENT = Pattern.compile("^[\\w-]+\\?$");
     private static final long DISCOVERY_RETRY_NANOS = Duration.ofSeconds(1).toNanos();
+
+    /*
+     * Relative scores follow React Router route ranking. Static and suffixed
+     * parameter segments rank above plain parameters, empty segments rank below
+     * them, and wildcards rank last. Only ordering matters.
+     */
     private static final int NO_MATCH_SCORE = Integer.MIN_VALUE;
     private static final int WILDCARD_SCORE = -1;
     private static final int EMPTY_SEGMENT_SCORE = 2;
@@ -212,7 +218,7 @@ public class RouteUtil {
     }
 
     static List<AvailableViewInfo> readRouteTree(InputStream input) throws IOException {
-        return ROUTE_MAPPER.readValue(input, new TypeReference<List<AvailableViewInfo>>() {});
+        return ROUTE_READER.readValue(input);
     }
 
     private void publishRouteTree(List<AvailableViewInfo> routeTree) {
@@ -357,8 +363,6 @@ public class RouteUtil {
             return pathIndex == pathSegments.size() ? 0 : NO_MATCH_SCORE;
         }
 
-        // Relative weights follow React Router branch ranking: literal and
-        // suffixed segments outrank plain parameters, while wildcards rank last.
         SegmentPattern segmentPattern = routeSegments.get(routeIndex);
         if (segmentPattern.type() == SegmentType.WILDCARD) {
             if (routeIndex == routeSegments.size() - 1) {

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicyTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicyTest.java
@@ -62,6 +62,45 @@ class HillaSecurityPolicyTest {
     }
 
     @Test
+    void checkPermission_matchesPermitAllPathsAgainstNormalizedPath() {
+        HillaSecurityPolicy policy = policy();
+
+        assertFalse(check(policy, context("/VAADIN/../hilla-admin", "/hilla-admin"), mock(SecurityIdentity.class))
+                .isPermitted());
+        assertTrue(check(policy, context("/VAADIN/client.js"), mock(SecurityIdentity.class))
+                .isPermitted());
+    }
+
+    @Test
+    void checkPermission_matchesWebIconsAgainstNormalizedPath() {
+        TestPolicy policy = policy();
+        policy.setFileRoutesManifestExpected(true);
+        policy.onVaadinServiceInit(new ServiceInitEvent(service()));
+        RoutingContext context = context("/icons/../hilla-admin", "/hilla-admin");
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        when(policy.webIconsRequestMatcher.isWebIconRequest("/icons/../hilla-admin"))
+                .thenReturn(true);
+        when(policy.routeUtil.checkRouteAccess(context, identity)).thenReturn(AuthorizationDecision.DENY);
+
+        assertFalse(check(policy, context, identity).isPermitted());
+        verify(policy.webIconsRequestMatcher).isWebIconRequest("/hilla-admin");
+    }
+
+    @Test
+    void checkPermission_keepsNormalizedWebIconRequestsPermitted() {
+        TestPolicy policy = policy();
+        policy.onVaadinServiceInit(new ServiceInitEvent(service()));
+        when(policy.webIconsRequestMatcher.isWebIconRequest("/icons/favicon.svg"))
+                .thenReturn(true);
+
+        assertTrue(check(
+                        policy,
+                        context("/icons/../icons/favicon.svg", "/icons/favicon.svg"),
+                        mock(SecurityIdentity.class))
+                .isPermitted());
+    }
+
+    @Test
     void routeUtilInitialization_waitsForServiceAndClassificationInEitherOrder() {
         TestPolicy classificationFirst = policy();
         classificationFirst.setFileRoutesManifestExpected(false);
@@ -140,11 +179,15 @@ class HillaSecurityPolicyTest {
     }
 
     private static RoutingContext context(String path) {
+        return context(path, path);
+    }
+
+    private static RoutingContext context(String rawPath, String normalizedPath) {
         RoutingContext context = mock(RoutingContext.class);
         HttpServerRequest request = mock(HttpServerRequest.class);
         when(context.request()).thenReturn(request);
-        when(request.path()).thenReturn(path);
-        when(context.normalizedPath()).thenReturn(path);
+        when(request.path()).thenReturn(rawPath);
+        when(context.normalizedPath()).thenReturn(normalizedPath);
         return context;
     }
 

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicyTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicyTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.security;
+
+import com.vaadin.flow.router.Router;
+import com.vaadin.flow.server.RouteRegistry;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinService;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy.CheckResult;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.hilla.QuarkusEndpointConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HillaSecurityPolicyTest {
+
+    @Test
+    void checkPermission_beforeServiceInitializationDeniesWithoutFailure() {
+        QuarkusEndpointConfiguration endpointConfiguration = mock(QuarkusEndpointConfiguration.class);
+        when(endpointConfiguration.getNormalizedEndpointPrefix()).thenReturn("/connect");
+        EndpointUtil endpointUtil = mock(EndpointUtil.class);
+        RoutingContext context = context("/first-request");
+        HillaSecurityPolicy policy = new HillaSecurityPolicy(
+                mock(com.vaadin.flow.server.auth.NavigationAccessControl.class), endpointConfiguration, endpointUtil);
+
+        CheckResult result = policy.checkPermission(
+                        context,
+                        Uni.createFrom().item(mock(SecurityIdentity.class)),
+                        mock(
+                                io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy.AuthorizationRequestContext
+                                        .class))
+                .await()
+                .indefinitely();
+
+        assertFalse(result.isPermitted());
+    }
+
+    @Test
+    void routeUtilInitialization_waitsForServiceAndClassificationInEitherOrder() {
+        TestPolicy classificationFirst = policy();
+        classificationFirst.setFileRoutesManifestExpected(false);
+        assertEquals(0, classificationFirst.createdRouteUtils);
+        classificationFirst.onVaadinServiceInit(new ServiceInitEvent(service()));
+        assertEquals(1, classificationFirst.createdRouteUtils);
+        verify(classificationFirst.routeUtil).initializeProductionSnapshot();
+
+        TestPolicy serviceFirst = policy();
+        serviceFirst.onVaadinServiceInit(new ServiceInitEvent(service()));
+        assertEquals(0, serviceFirst.createdRouteUtils);
+        serviceFirst.setFileRoutesManifestExpected(false);
+        assertEquals(1, serviceFirst.createdRouteUtils);
+        verify(serviceFirst.routeUtil).initializeProductionSnapshot();
+    }
+
+    @Test
+    void routeUtilInitialization_propagatesFailureWithoutPublishingEvaluator() {
+        TestPolicy policy = policy();
+        policy.onVaadinServiceInit(new ServiceInitEvent(service()));
+        doThrow(new IllegalStateException("invalid manifest"))
+                .when(policy.routeUtil)
+                .initializeProductionSnapshot();
+
+        assertThrows(IllegalStateException.class, () -> policy.setFileRoutesManifestExpected(true));
+        assertFalse(check(policy, context("/client-route"), mock(SecurityIdentity.class))
+                .isPermitted());
+    }
+
+    @Test
+    void checkPermission_mapsHillaAuthorizationDecisions() {
+        TestPolicy policy = policy();
+        policy.setFileRoutesManifestExpected(true);
+        policy.onVaadinServiceInit(new ServiceInitEvent(service()));
+        RoutingContext context = context("/client-route");
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+
+        when(policy.routeUtil.checkRouteAccess(context, identity)).thenReturn(AuthorizationDecision.ALLOW);
+        assertTrue(check(policy, context, identity).isPermitted());
+
+        when(policy.routeUtil.checkRouteAccess(context, identity)).thenReturn(AuthorizationDecision.DENY);
+        assertFalse(check(policy, context, identity).isPermitted());
+
+        when(policy.routeUtil.checkRouteAccess(context, identity)).thenReturn(AuthorizationDecision.NO_MATCH);
+        assertTrue(check(policy, context, identity).isPermitted());
+    }
+
+    private static CheckResult check(HillaSecurityPolicy policy, RoutingContext context, SecurityIdentity identity) {
+        return policy.checkPermission(
+                        context,
+                        Uni.createFrom().item(identity),
+                        mock(
+                                io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy.AuthorizationRequestContext
+                                        .class))
+                .await()
+                .indefinitely();
+    }
+
+    private static TestPolicy policy() {
+        QuarkusEndpointConfiguration endpointConfiguration = mock(QuarkusEndpointConfiguration.class);
+        when(endpointConfiguration.getNormalizedEndpointPrefix()).thenReturn("/connect");
+        return new TestPolicy(
+                mock(com.vaadin.flow.server.auth.NavigationAccessControl.class),
+                endpointConfiguration,
+                mock(EndpointUtil.class));
+    }
+
+    private static VaadinService service() {
+        VaadinService service = mock(VaadinService.class);
+        Router router = mock(Router.class);
+        RouteRegistry registry = mock(RouteRegistry.class);
+        when(service.getRouter()).thenReturn(router);
+        when(router.getRegistry()).thenReturn(registry);
+        when(registry.getNavigationRouteTarget(any())).thenReturn(null);
+        return service;
+    }
+
+    private static RoutingContext context(String path) {
+        RoutingContext context = mock(RoutingContext.class);
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        when(context.request()).thenReturn(request);
+        when(request.path()).thenReturn(path);
+        when(context.normalizedPath()).thenReturn(path);
+        return context;
+    }
+
+    private static final class TestPolicy extends HillaSecurityPolicy {
+
+        private final RouteUtil routeUtil = mock(RouteUtil.class);
+        private final WebIconsRequestMatcher webIconsRequestMatcher = mock(WebIconsRequestMatcher.class);
+        private int createdRouteUtils;
+
+        private TestPolicy(
+                com.vaadin.flow.server.auth.NavigationAccessControl accessControl,
+                QuarkusEndpointConfiguration endpointConfiguration,
+                EndpointUtil endpointUtil) {
+            super(accessControl, endpointConfiguration, endpointUtil);
+        }
+
+        @Override
+        RouteUtil createRouteUtil(VaadinService service, boolean manifestExpected) {
+            createdRouteUtils++;
+            return routeUtil;
+        }
+
+        @Override
+        WebIconsRequestMatcher createWebIconsRequestMatcher(VaadinService service) {
+            return webIconsRequestMatcher;
+        }
+    }
+}

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicyTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityPolicyTest.java
@@ -15,10 +15,17 @@
  */
 package com.github.mcollovati.quarkus.hilla.security;
 
+import java.util.Map;
+
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Router;
+import com.vaadin.flow.router.internal.NavigationRouteTarget;
+import com.vaadin.flow.router.internal.RouteTarget;
 import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.auth.AccessCheckResult;
+import com.vaadin.flow.server.auth.NavigationAccessControl;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy.CheckResult;
 import io.smallrye.mutiny.Uni;
@@ -33,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -67,8 +75,51 @@ class HillaSecurityPolicyTest {
 
         assertFalse(check(policy, context("/VAADIN/../hilla-admin", "/hilla-admin"), mock(SecurityIdentity.class))
                 .isPermitted());
+        assertFalse(check(policy, context("/VAADIN%2F..%2Fhilla-admin"), mock(SecurityIdentity.class))
+                .isPermitted());
         assertTrue(check(policy, context("/VAADIN/client.js"), mock(SecurityIdentity.class))
                 .isPermitted());
+    }
+
+    @Test
+    void checkPermission_usesQuarkusCanonicalPathForPermitAndRouteMatching() {
+        TestPolicy policy = policy();
+        policy.setFileRoutesManifestExpected(true);
+        policy.onVaadinServiceInit(new ServiceInitEvent(service()));
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        RoutingContext matrixPath = context("/hilla-admin;a=b");
+        RoutingContext encodedMatrixPath = context("/hilla-admin%3Ba=b");
+        when(policy.routeUtil.checkRouteAccess("/hilla-admin", "/hilla-admin;a=b", identity))
+                .thenReturn(AuthorizationDecision.DENY);
+        when(policy.routeUtil.checkRouteAccess("/hilla-admin", "/hilla-admin%3Ba=b", identity))
+                .thenReturn(AuthorizationDecision.DENY);
+
+        assertFalse(check(policy, matrixPath, identity).isPermitted());
+        assertFalse(check(policy, encodedMatrixPath, identity).isPermitted());
+        verify(policy.routeUtil).checkRouteAccess("/hilla-admin", "/hilla-admin;a=b", identity);
+        verify(policy.routeUtil).checkRouteAccess("/hilla-admin", "/hilla-admin%3Ba=b", identity);
+    }
+
+    @Test
+    void checkPermission_preservesEncodedSlashWhenResolvingFlowRoutes() {
+        NavigationAccessControl accessControl = mock(NavigationAccessControl.class);
+        when(accessControl.isEnabled()).thenReturn(true);
+        when(accessControl.checkAccess(any(), anyBoolean())).thenReturn(AccessCheckResult.deny("admin only"));
+        QuarkusEndpointConfiguration endpointConfiguration = mock(QuarkusEndpointConfiguration.class);
+        when(endpointConfiguration.getNormalizedEndpointPrefix()).thenReturn("/connect");
+        TestPolicy policy = new TestPolicy(accessControl, endpointConfiguration, mock(EndpointUtil.class));
+        policy.setFileRoutesManifestExpected(true);
+
+        RouteRegistry registry = mock(RouteRegistry.class);
+        NavigationRouteTarget target =
+                new NavigationRouteTarget("items/:id", new RouteTarget(ProtectedFlowView.class), Map.of("id", "a/b"));
+        when(registry.getNavigationRouteTarget("items/a%2Fb")).thenReturn(target);
+        policy.onVaadinServiceInit(new ServiceInitEvent(service(registry)));
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        when(identity.isAnonymous()).thenReturn(true);
+
+        assertFalse(check(policy, context("/items/a%2Fb"), identity).isPermitted());
+        verify(accessControl).checkAccess(any(), anyBoolean());
     }
 
     @Test
@@ -80,7 +131,8 @@ class HillaSecurityPolicyTest {
         SecurityIdentity identity = mock(SecurityIdentity.class);
         when(policy.webIconsRequestMatcher.isWebIconRequest("/icons/../hilla-admin"))
                 .thenReturn(true);
-        when(policy.routeUtil.checkRouteAccess(context, identity)).thenReturn(AuthorizationDecision.DENY);
+        when(policy.routeUtil.checkRouteAccess("/hilla-admin", "/hilla-admin", identity))
+                .thenReturn(AuthorizationDecision.DENY);
 
         assertFalse(check(policy, context, identity).isPermitted());
         verify(policy.webIconsRequestMatcher).isWebIconRequest("/hilla-admin");
@@ -138,13 +190,16 @@ class HillaSecurityPolicyTest {
         RoutingContext context = context("/client-route");
         SecurityIdentity identity = mock(SecurityIdentity.class);
 
-        when(policy.routeUtil.checkRouteAccess(context, identity)).thenReturn(AuthorizationDecision.ALLOW);
+        when(policy.routeUtil.checkRouteAccess("/client-route", "/client-route", identity))
+                .thenReturn(AuthorizationDecision.ALLOW);
         assertTrue(check(policy, context, identity).isPermitted());
 
-        when(policy.routeUtil.checkRouteAccess(context, identity)).thenReturn(AuthorizationDecision.DENY);
+        when(policy.routeUtil.checkRouteAccess("/client-route", "/client-route", identity))
+                .thenReturn(AuthorizationDecision.DENY);
         assertFalse(check(policy, context, identity).isPermitted());
 
-        when(policy.routeUtil.checkRouteAccess(context, identity)).thenReturn(AuthorizationDecision.NO_MATCH);
+        when(policy.routeUtil.checkRouteAccess("/client-route", "/client-route", identity))
+                .thenReturn(AuthorizationDecision.NO_MATCH);
         assertTrue(check(policy, context, identity).isPermitted());
     }
 
@@ -169,12 +224,18 @@ class HillaSecurityPolicyTest {
     }
 
     private static VaadinService service() {
+        RouteRegistry registry = mock(RouteRegistry.class);
+        when(registry.getNavigationRouteTarget(any())).thenReturn(null);
+        return service(registry);
+    }
+
+    private static VaadinService service(RouteRegistry registry) {
         VaadinService service = mock(VaadinService.class);
         Router router = mock(Router.class);
-        RouteRegistry registry = mock(RouteRegistry.class);
         when(service.getRouter()).thenReturn(router);
         when(router.getRegistry()).thenReturn(registry);
-        when(registry.getNavigationRouteTarget(any())).thenReturn(null);
+        when(service.getDeploymentConfiguration())
+                .thenReturn(mock(com.vaadin.flow.function.DeploymentConfiguration.class));
         return service;
     }
 
@@ -187,6 +248,7 @@ class HillaSecurityPolicyTest {
         HttpServerRequest request = mock(HttpServerRequest.class);
         when(context.request()).thenReturn(request);
         when(request.path()).thenReturn(rawPath);
+        when(request.params()).thenReturn(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
         when(context.normalizedPath()).thenReturn(normalizedPath);
         return context;
     }
@@ -215,4 +277,6 @@ class HillaSecurityPolicyTest {
             return webIconsRequestMatcher;
         }
     }
+
+    private static final class ProtectedFlowView extends Div {}
 }

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RoutePatternMatcherTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RoutePatternMatcherTest.java
@@ -23,13 +23,55 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class RoutePatternMatcherTest {
 
+    /*
+     * Golden winners captured from the public React Router 8.3 matchRoutes API.
+     * ReactRouterCompatibilityTest forces review of these cases when Vaadin's
+     * managed React Router version changes.
+     */
+
     @Test
-    void bestMatches_staticRouteOutranksPartialParameter() {
+    void reactRouter8_staticRouteOutranksPartialParameter() {
         List<RoutePatternMatcher.CompiledRoute<String>> routes = List.of(
                 RoutePatternMatcher.compile("files/:id.json", "parameter"),
                 RoutePatternMatcher.compile("files/public.json", "static"));
 
         assertEquals(List.of("static"), targets(RoutePatternMatcher.bestMatches(routes, "/files/public.json")));
+    }
+
+    @Test
+    void reactRouter8_partialParameterOutranksDynamicParameter() {
+        List<RoutePatternMatcher.CompiledRoute<String>> routes = List.of(
+                RoutePatternMatcher.compile("files/:id", "dynamic"),
+                RoutePatternMatcher.compile("files/:id.json", "partial"));
+
+        assertEquals(List.of("partial"), targets(RoutePatternMatcher.bestMatches(routes, "/files/report.json")));
+    }
+
+    @Test
+    void reactRouter8_dynamicParameterOutranksWildcard() {
+        List<RoutePatternMatcher.CompiledRoute<String>> routes = List.of(
+                RoutePatternMatcher.compile("files/*", "wildcard"),
+                RoutePatternMatcher.compile("files/:id", "dynamic"));
+
+        assertEquals(List.of("dynamic"), targets(RoutePatternMatcher.bestMatches(routes, "/files/report")));
+    }
+
+    @Test
+    void reactRouter8_optionalStaticOutranksDynamicParameter() {
+        List<RoutePatternMatcher.CompiledRoute<String>> routes = List.of(
+                RoutePatternMatcher.compile("docs/:id", "dynamic"),
+                RoutePatternMatcher.compile("docs/edit?", "optional-static"));
+
+        assertEquals(List.of("optional-static"), targets(RoutePatternMatcher.bestMatches(routes, "/docs/edit")));
+    }
+
+    @Test
+    void equalRankReturnsAllRoutesForConservativeAuthorization() {
+        List<RoutePatternMatcher.CompiledRoute<String>> routes = List.of(
+                RoutePatternMatcher.compile("projects", "short"),
+                RoutePatternMatcher.compile("projects/:id?", "optional-tail"));
+
+        assertEquals(List.of("short", "optional-tail"), targets(RoutePatternMatcher.bestMatches(routes, "/projects")));
     }
 
     @Test

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RoutePatternMatcherTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RoutePatternMatcherTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.security;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RoutePatternMatcherTest {
+
+    @Test
+    void bestMatches_staticRouteOutranksPartialParameter() {
+        List<RoutePatternMatcher.CompiledRoute<String>> routes = List.of(
+                RoutePatternMatcher.compile("files/:id.json", "parameter"),
+                RoutePatternMatcher.compile("files/public.json", "static"));
+
+        assertEquals(List.of("static"), targets(RoutePatternMatcher.bestMatches(routes, "/files/public.json")));
+    }
+
+    @Test
+    void bestMatches_indexRouteOutranksOmittedOptionalStaticRoute() {
+        List<RoutePatternMatcher.CompiledRoute<String>> routes = List.of(
+                RoutePatternMatcher.compile("", true, "index"), RoutePatternMatcher.compile("projects?", "optional"));
+
+        assertEquals(List.of("index"), targets(RoutePatternMatcher.bestMatches(routes, "/")));
+    }
+
+    @Test
+    void bestMatches_trailingSplatWithoutSlashUsesReactRouterNormalization() {
+        List<RoutePatternMatcher.CompiledRoute<String>> routes =
+                List.of(RoutePatternMatcher.compile("files/:id*", "splat"));
+
+        assertEquals(List.of("splat"), targets(RoutePatternMatcher.bestMatches(routes, "/files/42/details")));
+    }
+
+    @Test
+    void bestMatches_decodesUtf8ClientRouteSegment() {
+        List<RoutePatternMatcher.CompiledRoute<String>> routes =
+                List.of(RoutePatternMatcher.compile("café", "unicode"));
+
+        assertEquals(List.of("unicode"), targets(RoutePatternMatcher.bestMatches(routes, "/caf%C3%A9")));
+    }
+
+    @Test
+    void bestMatches_decodesBackslashClientRouteSegment() {
+        List<RoutePatternMatcher.CompiledRoute<String>> routes =
+                List.of(RoutePatternMatcher.compile("files/a\\b", "backslash"));
+
+        assertEquals(List.of("backslash"), targets(RoutePatternMatcher.bestMatches(routes, "/files/a%5Cb")));
+    }
+
+    @Test
+    void bestMatches_deduplicatesRouteMatchingEncodedAndDecodedCandidates() {
+        List<RoutePatternMatcher.CompiledRoute<String>> routes =
+                List.of(RoutePatternMatcher.compile("items/:id", "parameter"));
+
+        assertEquals(List.of("parameter"), targets(RoutePatternMatcher.bestMatches(routes, "/items/caf%C3%A9")));
+    }
+
+    private static List<String> targets(List<RoutePatternMatcher.CompiledRoute<String>> routes) {
+        return routes.stream().map(RoutePatternMatcher.CompiledRoute::target).toList();
+    }
+}

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RoutePatternMatcherTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RoutePatternMatcherTest.java
@@ -83,6 +83,15 @@ class RoutePatternMatcherTest {
     }
 
     @Test
+    void bestMatches_trailingQuestionMarksAnySegmentOptional() {
+        List<RoutePatternMatcher.CompiledRoute<String>> routes =
+                List.of(RoutePatternMatcher.compile("orders/:id.v2?", "optional-suffix"));
+
+        assertEquals(List.of("optional-suffix"), targets(RoutePatternMatcher.bestMatches(routes, "/orders")));
+        assertEquals(List.of("optional-suffix"), targets(RoutePatternMatcher.bestMatches(routes, "/orders/x.v2")));
+    }
+
+    @Test
     void bestMatches_trailingSplatWithoutSlashUsesReactRouterNormalization() {
         List<RoutePatternMatcher.CompiledRoute<String>> routes =
                 List.of(RoutePatternMatcher.compile("files/:id*", "splat"));

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
@@ -282,14 +282,14 @@ class RouteUtilTest {
     }
 
     @Test
-    void discovery_retryableFallbackUsesBackoffThenPublishesCompleteTree() {
+    void discovery_developmentFallbackUsesBackoffThenPublishesCompleteTree() {
         AtomicInteger discoveries = new AtomicInteger();
         AtomicLong nanoTime = new AtomicLong();
         AvailableViewInfo admin = view("admin", new String[] {"ADMIN"}, Map.of());
         RouteUtil routeUtil = new RouteUtil(
                 mock(VaadinService.class),
                 () -> discoveries.incrementAndGet() == 1
-                        ? RouteUtil.DiscoveryResult.fallback(Map.of("admin", admin), true)
+                        ? RouteUtil.DiscoveryResult.fallback(Map.of("admin", admin))
                         : RouteUtil.DiscoveryResult.complete(List.of(admin)),
                 nanoTime::get);
 
@@ -303,14 +303,15 @@ class RouteUtilTest {
     }
 
     @Test
-    void discovery_terminalFallbackIsNotRepeatedAndDeniesKnownRoutes() {
+    void discovery_productionFallbackIsNotRepeatedAndDeniesKnownRoutes() {
         AtomicInteger discoveries = new AtomicInteger();
         AvailableViewInfo publicView = view("public", new String[0], Map.of());
         RouteUtil routeUtil = new RouteUtil(
                 mock(VaadinService.class),
+                false,
                 () -> {
                     discoveries.incrementAndGet();
-                    return RouteUtil.DiscoveryResult.fallback(Map.of("public", publicView), false);
+                    return RouteUtil.DiscoveryResult.fallback(Map.of("public", publicView));
                 },
                 System::nanoTime);
 
@@ -345,6 +346,72 @@ class RouteUtilTest {
     }
 
     @Test
+    void discovery_developmentCompleteTreeIsRefreshedAfterBackoff() {
+        AtomicInteger discoveries = new AtomicInteger();
+        AtomicLong nanoTime = new AtomicLong();
+        AvailableViewInfo admin = view("admin", new String[] {"ADMIN"}, Map.of());
+        AvailableViewInfo user = view("admin", new String[] {"USER"}, Map.of());
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                () -> RouteUtil.DiscoveryResult.complete(List.of(discoveries.incrementAndGet() == 1 ? admin : user)),
+                nanoTime::get);
+
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(1, discoveries.get());
+
+        nanoTime.set(Duration.ofSeconds(1).toNanos());
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("USER")));
+        assertEquals(2, discoveries.get());
+    }
+
+    @Test
+    void discovery_productionCompleteTreeIsNotRefreshed() {
+        AtomicInteger discoveries = new AtomicInteger();
+        AtomicLong nanoTime = new AtomicLong();
+        AvailableViewInfo admin = view("admin", new String[] {"ADMIN"}, Map.of());
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                false,
+                () -> {
+                    discoveries.incrementAndGet();
+                    return RouteUtil.DiscoveryResult.complete(List.of(admin));
+                },
+                nanoTime::get);
+
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        nanoTime.set(Duration.ofDays(1).toNanos());
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(1, discoveries.get());
+    }
+
+    @Test
+    void discovery_developmentFailureKeepsLastCompleteTreeUntilSuccessfulRefresh() {
+        AtomicInteger discoveries = new AtomicInteger();
+        AtomicLong nanoTime = new AtomicLong();
+        AvailableViewInfo admin = view("admin", new String[] {"ADMIN"}, Map.of());
+        AvailableViewInfo user = view("admin", new String[] {"USER"}, Map.of());
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                () -> switch (discoveries.incrementAndGet()) {
+                    case 1 -> RouteUtil.DiscoveryResult.complete(List.of(admin));
+                    case 2 -> RouteUtil.DiscoveryResult.fallback(Map.of());
+                    default -> RouteUtil.DiscoveryResult.complete(List.of(user));
+                },
+                nanoTime::get);
+
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        nanoTime.set(Duration.ofSeconds(1).toNanos());
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(2, discoveries.get());
+
+        nanoTime.set(Duration.ofSeconds(2).toNanos());
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(3, discoveries.get());
+    }
+
+    @Test
     void checkRouteAccess_anonymousIdentityDeniedForLoginRequiredRoute() {
         RouteUtil routeUtil = routeUtil(Map.of("profile", view("profile", new String[0], Map.of())));
 
@@ -352,13 +419,13 @@ class RouteUtilTest {
     }
 
     private static RouteUtil routeUtil(Map<String, AvailableViewInfo> routes) {
-        RouteUtil routeUtil = new RouteUtil(mock(VaadinService.class));
+        RouteUtil routeUtil = new RouteUtil(mock(VaadinService.class), false, () -> null, System::nanoTime);
         routeUtil.setRoutes(new LinkedHashMap<>(routes));
         return routeUtil;
     }
 
     private static RouteUtil routeUtil(List<AvailableViewInfo> routeTree) {
-        RouteUtil routeUtil = new RouteUtil(mock(VaadinService.class));
+        RouteUtil routeUtil = new RouteUtil(mock(VaadinService.class), false, () -> null, System::nanoTime);
         routeUtil.setRouteTree(routeTree);
         return routeUtil;
     }

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.security;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.menu.AvailableViewInfo;
+import com.vaadin.flow.server.menu.RouteParamType;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RouteUtilTest {
+
+    @Test
+    void readRouteTree_deserializesGeneratedFileRouteFormat() throws Exception {
+        String json = """
+                [{
+                  "title": "Admin layout",
+                  "rolesAllowed": ["ADMIN"],
+                  "loginRequired": true,
+                  "route": "admin",
+                  "children": [{
+                    "title": "User",
+                    "rolesAllowed": [],
+                    "loginRequired": true,
+                    "route": ":id",
+                    "params": {":id": "req"}
+                  }]
+                }]
+                """;
+
+        List<AvailableViewInfo> routes =
+                RouteUtil.readRouteTree(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+        RouteUtil routeUtil = routeUtil(routes);
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/admin/42"), identity("USER")));
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin/42"), identity("ADMIN")));
+        assertEquals(
+                RouteParamType.REQUIRED,
+                routes.getFirst().children().getFirst().routeParameters().get(":id"));
+    }
+
+    @Test
+    void checkRouteAccess_requiredParameterEnforcesRouteRoles() {
+        RouteUtil routeUtil = routeUtil(
+                Map.of("users/:id", view("users/:id", new String[] {"ADMIN"}, Map.of(":id", RouteParamType.REQUIRED))));
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/users/42"), identity("USER")));
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/users/42"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_optionalParameterMatchesWithAndWithoutValue() {
+        RouteUtil routeUtil = routeUtil(Map.of(
+                "reports/:filter?",
+                view("reports/:filter?", new String[] {"ADMIN"}, Map.of(":filter?", RouteParamType.OPTIONAL))));
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/reports"), identity("USER")));
+        assertEquals(
+                RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/reports/open"), identity("USER")));
+        assertEquals(
+                RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/reports/open"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_optionalStaticSegmentMatchesWithAndWithoutSegment() {
+        RouteUtil routeUtil = routeUtil(Map.of("projects?", view("projects?", new String[] {"ADMIN"}, Map.of())));
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/"), identity("USER")));
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/projects"), identity("USER")));
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/"), identity("ADMIN")));
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/projects"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_preservesEncodedSlashInsideParameter() {
+        RouteUtil routeUtil = routeUtil(
+                Map.of("items/:id", view("items/:id", new String[] {"ADMIN"}, Map.of(":id", RouteParamType.REQUIRED))));
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/items/a%2Fb"), identity("USER")));
+        assertEquals(
+                RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/items/a%2Fb"), identity("ADMIN")));
+        assertEquals(
+                RouteUtil.RouteAccess.NO_MATCH, routeUtil.checkRouteAccess(context("/items/a/b"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_staticRouteWinsOverParameterRoute() {
+        Map<String, AvailableViewInfo> routes = new LinkedHashMap<>();
+        routes.put("users/:id", view("users/:id", new String[] {"ADMIN"}, Map.of(":id", RouteParamType.REQUIRED)));
+        routes.put("users/new", view("users/new", new String[] {"USER"}, Map.of()));
+        RouteUtil routeUtil = routeUtil(routes);
+
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/users/new"), identity("USER")));
+    }
+
+    @Test
+    void checkRouteAccess_deniedSpecificRouteDoesNotFallBackToPublicParameterRoute() {
+        Map<String, AvailableViewInfo> routes = new LinkedHashMap<>();
+        routes.put("users/:id", view("users/:id", new String[0], Map.of(":id", RouteParamType.REQUIRED)));
+        routes.put("users/new", view("users/new", new String[] {"ADMIN"}, Map.of()));
+        RouteUtil routeUtil = routeUtil(routes);
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/users/new"), identity("USER")));
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/users/new"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_equalScoreMatchesMustAllPermit() {
+        Map<String, AvailableViewInfo> routes = new LinkedHashMap<>();
+        routes.put("items/:id", view("items/:id", new String[0], Map.of(":id", RouteParamType.REQUIRED)));
+        routes.put(
+                "items/:slug", view("items/:slug", new String[] {"ADMIN"}, Map.of(":slug", RouteParamType.REQUIRED)));
+        RouteUtil routeUtil = routeUtil(routes);
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/items/42"), identity("USER")));
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/items/42"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_parameterSuffixMustMatchBeforeOutrankingWildcard() {
+        Map<String, AvailableViewInfo> routes = new LinkedHashMap<>();
+        routes.put("files/:id.json", view("files/:id.json", new String[0], Map.of()));
+        routes.put("files/*", view("files/*", new String[] {"ADMIN"}, Map.of("*", RouteParamType.WILDCARD)));
+        RouteUtil routeUtil = routeUtil(routes);
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/files/foo"), identity("USER")));
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/files/foo"), identity("ADMIN")));
+        assertEquals(
+                RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/files/foo.json"), identity("USER")));
+    }
+
+    @Test
+    void checkRouteAccess_parameterSuffixKeepsEqualStaticMatchRestrictive() {
+        Map<String, AvailableViewInfo> routes = new LinkedHashMap<>();
+        routes.put("files/:id.json", view("files/:id.json", new String[] {"ADMIN"}, Map.of()));
+        routes.put("files/public.json", view("files/public.json", new String[0], Map.of()));
+        RouteUtil routeUtil = routeUtil(routes);
+
+        assertEquals(
+                RouteUtil.RouteAccess.DENY,
+                routeUtil.checkRouteAccess(context("/files/public.json"), identity("USER")));
+        assertEquals(
+                RouteUtil.RouteAccess.ALLOW,
+                routeUtil.checkRouteAccess(context("/files/public.json"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_optionalParameterWithSuffixKeepsSegmentRequired() {
+        RouteUtil routeUtil =
+                routeUtil(Map.of("files/:id?.json", view("files/:id?.json", new String[] {"ADMIN"}, Map.of())));
+
+        assertEquals(RouteUtil.RouteAccess.NO_MATCH, routeUtil.checkRouteAccess(context("/files"), identity("ADMIN")));
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/files/.json"), identity("USER")));
+        assertEquals(
+                RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/files/foo.json"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_layoutSecurityAppliesToIndexAtSamePath() {
+        AvailableViewInfo index = view("", new String[0], Map.of());
+        AvailableViewInfo layout = view("", new String[] {"ADMIN"}, Map.of(), List.of(index));
+        RouteUtil routeUtil = routeUtil(List.of(layout));
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/"), identity("USER")));
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_layoutSecurityAppliesToParameterizedChild() {
+        AvailableViewInfo child = view(":id", new String[0], Map.of(":id", RouteParamType.REQUIRED));
+        AvailableViewInfo layout = view("admin", new String[] {"ADMIN"}, Map.of(), List.of(child));
+        RouteUtil routeUtil = routeUtil(List.of(layout));
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/admin/42"), identity("USER")));
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin/42"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_layoutSecurityAppliesToNestedAbsoluteChild() {
+        AvailableViewInfo child = view("/admin/users", new String[0], Map.of());
+        AvailableViewInfo layout = view("admin", new String[] {"ADMIN"}, Map.of(), List.of(child));
+        RouteUtil routeUtil = routeUtil(List.of(layout));
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/admin/users"), identity("USER")));
+        assertEquals(
+                RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin/users"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_nestedAbsoluteChildUsesReactPrefixSlicing() {
+        AvailableViewInfo child = view("/administrator/users", new String[0], Map.of());
+        AvailableViewInfo layout = view("admin", new String[] {"ADMIN"}, Map.of(), List.of(child));
+        RouteUtil routeUtil = routeUtil(List.of(layout));
+
+        assertEquals(
+                RouteUtil.RouteAccess.DENY,
+                routeUtil.checkRouteAccess(context("/admin/istrator/users"), identity("USER")));
+        assertEquals(
+                RouteUtil.RouteAccess.ALLOW,
+                routeUtil.checkRouteAccess(context("/admin/istrator/users"), identity("ADMIN")));
+        assertEquals(
+                RouteUtil.RouteAccess.NO_MATCH,
+                routeUtil.checkRouteAccess(context("/administrator/users"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_invalidAbsoluteChildDoesNotDiscardOtherRoutes() {
+        AvailableViewInfo invalidChild = view("/users", new String[0], Map.of());
+        AvailableViewInfo layout = view("admin", new String[] {"ADMIN"}, Map.of(), List.of(invalidChild));
+        AvailableViewInfo publicView = view("public", new String[0], Map.of());
+        RouteUtil routeUtil = routeUtil(List.of(layout, publicView));
+
+        assertEquals(RouteUtil.RouteAccess.NO_MATCH, routeUtil.checkRouteAccess(context("/users"), identity("ADMIN")));
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/public"), identity("USER")));
+    }
+
+    @Test
+    void checkRouteAccess_wildcardEnforcesRouteRoles() {
+        RouteUtil routeUtil = routeUtil(
+                Map.of("files/*", view("files/*", new String[] {"ADMIN"}, Map.of("*", RouteParamType.WILDCARD))));
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/files/a/b"), identity("USER")));
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/files/a/b"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_wildcardBeforeOptionalParameterMatchesOptionalExpansion() {
+        RouteUtil routeUtil = routeUtil(Map.of(
+                "files/*/:id?",
+                view(
+                        "files/*/:id?",
+                        new String[] {"ADMIN"},
+                        Map.of("*", RouteParamType.WILDCARD, ":id?", RouteParamType.OPTIONAL))));
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/files/a/b"), identity("USER")));
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/files/a/b"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_nonTerminalWildcardUsesLiteralBranch() {
+        RouteUtil routeUtil = routeUtil(Map.of(
+                "files/*/:id",
+                view(
+                        "files/*/:id",
+                        new String[] {"ADMIN"},
+                        Map.of("*", RouteParamType.WILDCARD, ":id", RouteParamType.REQUIRED))));
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/files/*/42"), identity("USER")));
+        assertEquals(
+                RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/files/*/42"), identity("ADMIN")));
+        assertEquals(
+                RouteUtil.RouteAccess.NO_MATCH, routeUtil.checkRouteAccess(context("/files/a/42"), identity("ADMIN")));
+    }
+
+    @Test
+    void discovery_retryableFallbackUsesBackoffThenPublishesCompleteTree() {
+        AtomicInteger discoveries = new AtomicInteger();
+        AtomicLong nanoTime = new AtomicLong();
+        AvailableViewInfo admin = view("admin", new String[] {"ADMIN"}, Map.of());
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                () -> discoveries.incrementAndGet() == 1
+                        ? RouteUtil.DiscoveryResult.fallback(Map.of("admin", admin), true)
+                        : RouteUtil.DiscoveryResult.complete(List.of(admin)),
+                nanoTime::get);
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(1, discoveries.get());
+
+        nanoTime.set(Duration.ofSeconds(1).toNanos());
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(2, discoveries.get());
+    }
+
+    @Test
+    void discovery_terminalFallbackIsNotRepeatedAndDeniesKnownRoutes() {
+        AtomicInteger discoveries = new AtomicInteger();
+        AvailableViewInfo publicView = view("public", new String[0], Map.of());
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                () -> {
+                    discoveries.incrementAndGet();
+                    return RouteUtil.DiscoveryResult.fallback(Map.of("public", publicView), false);
+                },
+                System::nanoTime);
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/public"), identity("USER")));
+        assertEquals(RouteUtil.RouteAccess.NO_MATCH, routeUtil.checkRouteAccess(context("/unknown"), identity("USER")));
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/public"), identity("USER")));
+        assertEquals(1, discoveries.get());
+    }
+
+    @Test
+    void discovery_failureIsRetriedAfterBackoff() {
+        AtomicInteger discoveries = new AtomicInteger();
+        AtomicLong nanoTime = new AtomicLong();
+        AvailableViewInfo admin = view("admin", new String[] {"ADMIN"}, Map.of());
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                () -> {
+                    if (discoveries.incrementAndGet() == 1) {
+                        throw new IllegalStateException("routes unavailable");
+                    }
+                    return RouteUtil.DiscoveryResult.complete(List.of(admin));
+                },
+                nanoTime::get);
+
+        assertEquals(RouteUtil.RouteAccess.NO_MATCH, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(RouteUtil.RouteAccess.NO_MATCH, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(1, discoveries.get());
+
+        nanoTime.set(Duration.ofSeconds(1).toNanos());
+        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(2, discoveries.get());
+    }
+
+    @Test
+    void checkRouteAccess_anonymousIdentityDeniedForLoginRequiredRoute() {
+        RouteUtil routeUtil = routeUtil(Map.of("profile", view("profile", new String[0], Map.of())));
+
+        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/profile"), anonymousIdentity()));
+    }
+
+    private static RouteUtil routeUtil(Map<String, AvailableViewInfo> routes) {
+        RouteUtil routeUtil = new RouteUtil(mock(VaadinService.class));
+        routeUtil.setRoutes(new LinkedHashMap<>(routes));
+        return routeUtil;
+    }
+
+    private static RouteUtil routeUtil(List<AvailableViewInfo> routeTree) {
+        RouteUtil routeUtil = new RouteUtil(mock(VaadinService.class));
+        routeUtil.setRouteTree(routeTree);
+        return routeUtil;
+    }
+
+    private static RoutingContext context(String path) {
+        RoutingContext context = mock(RoutingContext.class);
+        when(context.normalizedPath()).thenReturn(path);
+        return context;
+    }
+
+    private static SecurityIdentity identity(String... roles) {
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        Set<String> roleSet = Set.of(roles);
+        when(identity.isAnonymous()).thenReturn(false);
+        when(identity.hasRole(anyString())).thenAnswer(invocation -> roleSet.contains(invocation.getArgument(0)));
+        return identity;
+    }
+
+    private static SecurityIdentity anonymousIdentity() {
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        when(identity.isAnonymous()).thenReturn(true);
+        return identity;
+    }
+
+    private static AvailableViewInfo view(
+            String route, String[] rolesAllowed, Map<String, RouteParamType> routeParameters) {
+        return view(route, rolesAllowed, routeParameters, List.of());
+    }
+
+    private static AvailableViewInfo view(
+            String route,
+            String[] rolesAllowed,
+            Map<String, RouteParamType> routeParameters,
+            List<AvailableViewInfo> children) {
+        return new AvailableViewInfo(
+                route, rolesAllowed, true, route, false, true, null, children, routeParameters, false, null);
+    }
+}

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
@@ -348,6 +348,59 @@ class RouteUtilTest {
     }
 
     @Test
+    void discovery_developmentMissingReactManifestIsRetriedImmediatelyAndDeniesUntilComplete() {
+        AtomicInteger discoveries = new AtomicInteger();
+        AtomicLong nanoTime = new AtomicLong();
+        AvailableViewInfo admin = view("admin", new String[] {"ADMIN"}, Map.of());
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                () -> discoveries.incrementAndGet() == 1
+                        ? RouteUtil.missingManifest(true, true, false)
+                        : RouteUtil.DiscoveryResult.complete(List.of(admin)),
+                nanoTime::get);
+
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(2, discoveries.get());
+    }
+
+    @Test
+    void discovery_productionMissingReactManifestIsNoMatch() {
+        AtomicInteger discoveries = new AtomicInteger();
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                false,
+                () -> {
+                    discoveries.incrementAndGet();
+                    return RouteUtil.missingManifest(false, true, false);
+                },
+                System::nanoTime);
+
+        assertEquals(AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/custom"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/custom"), identity("ADMIN")));
+        assertEquals(1, discoveries.get());
+    }
+
+    @Test
+    void discovery_missingNonReactManifestIsNoMatch() {
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                false,
+                () -> RouteUtil.missingManifest(true, false, false),
+                System::nanoTime);
+
+        assertEquals(AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/custom"), identity("USER")));
+    }
+
+    @Test
+    void discovery_developmentMissingManifestWithCustomReactRouterIsNoMatch() {
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class), false, () -> RouteUtil.missingManifest(true, true, true), System::nanoTime);
+
+        assertEquals(AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/custom"), identity("USER")));
+    }
+
+    @Test
     void discovery_productionFailureResultIsNotRepeatedAndDeniesEveryRoute() {
         AtomicInteger discoveries = new AtomicInteger();
         RouteUtil routeUtil = new RouteUtil(

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
@@ -248,6 +248,34 @@ class RouteUtilTest {
     }
 
     @Test
+    void checkRouteAccess_optionalSuffixRouteDoesNotFallThroughToNoMatch() {
+        RouteUtil routeUtil =
+                routeUtil(Map.of("orders/:id.v2?", view("orders/:id.v2?", new String[] {"ADMIN"}, Map.of())));
+
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/orders/x.v2"), identity("USER")));
+        assertEquals(
+                AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/orders/x.v2"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_canonicalizesMatrixParametersBeforeMatching() {
+        RouteUtil routeUtil = routeUtil(Map.of("admin", view("admin", new String[] {"ADMIN"}, Map.of())));
+
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin;a=b"), identity("USER")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin%3Ba=b"), identity("USER")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin;a=b"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_preservesEncodedSlashInsideReactRouterParameter() {
+        RouteUtil routeUtil = routeUtil(Map.of("items/:id", view("items/:id", new String[] {"ADMIN"}, Map.of())));
+
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/items/a%2Fb"), identity("USER")));
+        assertEquals(
+                AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/items/a%2Fb"), identity("ADMIN")));
+    }
+
+    @Test
     void checkRouteAccess_equalScoreMatchesMustAllPermit() {
         Map<String, AvailableViewInfo> routes = new LinkedHashMap<>();
         routes.put("items/:id", view("items/:id", new String[0], Map.of(":id", RouteParamType.REQUIRED)));

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
@@ -46,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class RouteUtilTest {
@@ -355,7 +356,7 @@ class RouteUtilTest {
         RouteUtil routeUtil = new RouteUtil(
                 mock(VaadinService.class),
                 () -> discoveries.incrementAndGet() == 1
-                        ? RouteUtil.missingManifest(true, true, false)
+                        ? RouteUtil.missingManifest(true, true)
                         : RouteUtil.DiscoveryResult.complete(List.of(admin)),
                 nanoTime::get);
 
@@ -365,29 +366,26 @@ class RouteUtilTest {
     }
 
     @Test
-    void discovery_productionMissingReactManifestIsNoMatch() {
+    void discovery_productionMissingExpectedManifestIsTerminalFailure() {
         AtomicInteger discoveries = new AtomicInteger();
         RouteUtil routeUtil = new RouteUtil(
                 mock(VaadinService.class),
                 false,
                 () -> {
                     discoveries.incrementAndGet();
-                    return RouteUtil.missingManifest(false, true, false);
+                    return RouteUtil.missingManifest(false, true);
                 },
                 System::nanoTime);
 
-        assertEquals(AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/custom"), identity("ADMIN")));
-        assertEquals(AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/custom"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/custom"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/custom"), identity("ADMIN")));
         assertEquals(1, discoveries.get());
     }
 
     @Test
     void discovery_missingNonReactManifestIsNoMatch() {
         RouteUtil routeUtil = new RouteUtil(
-                mock(VaadinService.class),
-                false,
-                () -> RouteUtil.missingManifest(true, false, false),
-                System::nanoTime);
+                mock(VaadinService.class), false, () -> RouteUtil.missingManifest(true, false), System::nanoTime);
 
         assertEquals(AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/custom"), identity("USER")));
     }
@@ -395,7 +393,7 @@ class RouteUtilTest {
     @Test
     void discovery_developmentMissingManifestWithCustomReactRouterIsNoMatch() {
         RouteUtil routeUtil = new RouteUtil(
-                mock(VaadinService.class), false, () -> RouteUtil.missingManifest(true, true, true), System::nanoTime);
+                mock(VaadinService.class), false, () -> RouteUtil.missingManifest(true, false), System::nanoTime);
 
         assertEquals(AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/custom"), identity("USER")));
     }
@@ -536,7 +534,7 @@ class RouteUtilTest {
     }
 
     @Test
-    void discovery_developmentFailureKeepsLastCompleteTreeUntilSuccessfulRefresh() {
+    void discovery_developmentRefreshFailureDeniesAllRoutesUntilSuccessfulRefresh() {
         AtomicInteger discoveries = new AtomicInteger();
         AtomicLong nanoTime = new AtomicLong();
         AvailableViewInfo admin = view("admin", new String[] {"ADMIN"}, Map.of());
@@ -552,11 +550,13 @@ class RouteUtilTest {
 
         assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
         nanoTime.set(Duration.ofSeconds(1).toNanos());
-        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/unknown"), identity("ADMIN")));
         assertEquals(2, discoveries.get());
 
         nanoTime.set(Duration.ofSeconds(2).toNanos());
         assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("USER")));
         assertEquals(3, discoveries.get());
     }
 
@@ -629,6 +629,15 @@ class RouteUtilTest {
         when(context.normalizedPath()).thenThrow(new IllegalStateException("normalization failed"));
 
         assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context, identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_nullIdentityIsDeniedBeforeRouteMatching() {
+        RouteUtil routeUtil = routeUtil(Map.of("admin", view("admin", new String[] {"ADMIN"}, Map.of())));
+        RoutingContext context = mock(RoutingContext.class);
+
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context, null));
+        verifyNoInteractions(context);
     }
 
     private static RouteUtil routeUtil(Map<String, AvailableViewInfo> routes) {

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
@@ -17,11 +17,19 @@ package com.github.mcollovati.quarkus.hilla.security;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -31,13 +39,19 @@ import com.vaadin.flow.server.menu.RouteParamType;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.vertx.ext.web.RoutingContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class RouteUtilTest {
+
+    @TempDir
+    Path temporaryDirectory;
 
     @Test
     void readRouteTree_deserializesGeneratedFileRouteFormat() throws Exception {
@@ -61,11 +75,31 @@ class RouteUtilTest {
                 RouteUtil.readRouteTree(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
         RouteUtil routeUtil = routeUtil(routes);
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/admin/42"), identity("USER")));
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin/42"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin/42"), identity("USER")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin/42"), identity("ADMIN")));
         assertEquals(
                 RouteParamType.REQUIRED,
                 routes.getFirst().children().getFirst().routeParameters().get(":id"));
+    }
+
+    @Test
+    void readRouteResource_unchangedReliableFingerprintSkipsParsing() throws Exception {
+        Path manifest = temporaryDirectory.resolve("file-routes.json");
+        Files.writeString(manifest, "[]");
+        Files.setLastModifiedTime(manifest, FileTime.fromMillis(System.currentTimeMillis() - 5_000));
+
+        RouteUtil.DiscoveryResult first =
+                RouteUtil.readRouteResource(manifest.toUri().toURL(), null);
+        RouteUtil.DiscoveryResult unchanged =
+                RouteUtil.readRouteResource(manifest.toUri().toURL(), first.resourceFingerprint());
+        Files.writeString(manifest, "[\n]");
+        Files.setLastModifiedTime(manifest, FileTime.fromMillis(System.currentTimeMillis()));
+        RouteUtil.DiscoveryResult changed =
+                RouteUtil.readRouteResource(manifest.toUri().toURL(), first.resourceFingerprint());
+
+        assertFalse(first.unchanged());
+        assertTrue(unchanged.unchanged());
+        assertFalse(changed.unchanged());
     }
 
     @Test
@@ -73,8 +107,8 @@ class RouteUtilTest {
         RouteUtil routeUtil = routeUtil(
                 Map.of("users/:id", view("users/:id", new String[] {"ADMIN"}, Map.of(":id", RouteParamType.REQUIRED))));
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/users/42"), identity("USER")));
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/users/42"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/users/42"), identity("USER")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/users/42"), identity("ADMIN")));
     }
 
     @Test
@@ -83,21 +117,32 @@ class RouteUtilTest {
                 "reports/:filter?",
                 view("reports/:filter?", new String[] {"ADMIN"}, Map.of(":filter?", RouteParamType.OPTIONAL))));
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/reports"), identity("USER")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/reports"), identity("USER")));
         assertEquals(
-                RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/reports/open"), identity("USER")));
+                AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/reports/open"), identity("USER")));
         assertEquals(
-                RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/reports/open"), identity("ADMIN")));
+                AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/reports/open"), identity("ADMIN")));
     }
 
     @Test
     void checkRouteAccess_optionalStaticSegmentMatchesWithAndWithoutSegment() {
         RouteUtil routeUtil = routeUtil(Map.of("projects?", view("projects?", new String[] {"ADMIN"}, Map.of())));
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/"), identity("USER")));
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/projects"), identity("USER")));
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/"), identity("ADMIN")));
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/projects"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/"), identity("USER")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/projects"), identity("USER")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/projects"), identity("ADMIN")));
+    }
+
+    @Test
+    void checkRouteAccess_indexRouteOutranksRestrictedOmittedOptionalStaticRoute() {
+        Map<String, AvailableViewInfo> routes = new LinkedHashMap<>();
+        routes.put("", view("", new String[0], Map.of()));
+        routes.put("projects?", view("projects?", new String[] {"ADMIN"}, Map.of()));
+        RouteUtil routeUtil = routeUtil(routes);
+
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/"), identity("USER")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/projects"), identity("USER")));
     }
 
     @Test
@@ -105,11 +150,11 @@ class RouteUtilTest {
         RouteUtil routeUtil = routeUtil(
                 Map.of("items/:id", view("items/:id", new String[] {"ADMIN"}, Map.of(":id", RouteParamType.REQUIRED))));
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/items/a%2Fb"), identity("USER")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/items/a%2Fb"), identity("USER")));
         assertEquals(
-                RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/items/a%2Fb"), identity("ADMIN")));
+                AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/items/a%2Fb"), identity("ADMIN")));
         assertEquals(
-                RouteUtil.RouteAccess.NO_MATCH, routeUtil.checkRouteAccess(context("/items/a/b"), identity("ADMIN")));
+                AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/items/a/b"), identity("ADMIN")));
     }
 
     @Test
@@ -119,7 +164,7 @@ class RouteUtilTest {
         routes.put("users/new", view("users/new", new String[] {"USER"}, Map.of()));
         RouteUtil routeUtil = routeUtil(routes);
 
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/users/new"), identity("USER")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/users/new"), identity("USER")));
     }
 
     @Test
@@ -129,8 +174,8 @@ class RouteUtilTest {
         routes.put("users/new", view("users/new", new String[] {"ADMIN"}, Map.of()));
         RouteUtil routeUtil = routeUtil(routes);
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/users/new"), identity("USER")));
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/users/new"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/users/new"), identity("USER")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/users/new"), identity("ADMIN")));
     }
 
     @Test
@@ -141,8 +186,8 @@ class RouteUtilTest {
                 "items/:slug", view("items/:slug", new String[] {"ADMIN"}, Map.of(":slug", RouteParamType.REQUIRED)));
         RouteUtil routeUtil = routeUtil(routes);
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/items/42"), identity("USER")));
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/items/42"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/items/42"), identity("USER")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/items/42"), identity("ADMIN")));
     }
 
     @Test
@@ -152,24 +197,24 @@ class RouteUtilTest {
         routes.put("files/*", view("files/*", new String[] {"ADMIN"}, Map.of("*", RouteParamType.WILDCARD)));
         RouteUtil routeUtil = routeUtil(routes);
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/files/foo"), identity("USER")));
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/files/foo"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/files/foo"), identity("USER")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/files/foo"), identity("ADMIN")));
         assertEquals(
-                RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/files/foo.json"), identity("USER")));
+                AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/files/foo.json"), identity("USER")));
     }
 
     @Test
-    void checkRouteAccess_parameterSuffixKeepsEqualStaticMatchRestrictive() {
+    void checkRouteAccess_staticRouteOutranksPartialParameterRoute() {
         Map<String, AvailableViewInfo> routes = new LinkedHashMap<>();
         routes.put("files/:id.json", view("files/:id.json", new String[] {"ADMIN"}, Map.of()));
         routes.put("files/public.json", view("files/public.json", new String[0], Map.of()));
         RouteUtil routeUtil = routeUtil(routes);
 
         assertEquals(
-                RouteUtil.RouteAccess.DENY,
+                AuthorizationDecision.ALLOW,
                 routeUtil.checkRouteAccess(context("/files/public.json"), identity("USER")));
         assertEquals(
-                RouteUtil.RouteAccess.ALLOW,
+                AuthorizationDecision.ALLOW,
                 routeUtil.checkRouteAccess(context("/files/public.json"), identity("ADMIN")));
     }
 
@@ -178,10 +223,10 @@ class RouteUtilTest {
         RouteUtil routeUtil =
                 routeUtil(Map.of("files/:id?.json", view("files/:id?.json", new String[] {"ADMIN"}, Map.of())));
 
-        assertEquals(RouteUtil.RouteAccess.NO_MATCH, routeUtil.checkRouteAccess(context("/files"), identity("ADMIN")));
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/files/.json"), identity("USER")));
+        assertEquals(AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/files"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/files/.json"), identity("USER")));
         assertEquals(
-                RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/files/foo.json"), identity("ADMIN")));
+                AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/files/foo.json"), identity("ADMIN")));
     }
 
     @Test
@@ -190,8 +235,8 @@ class RouteUtilTest {
         AvailableViewInfo layout = view("", new String[] {"ADMIN"}, Map.of(), List.of(index));
         RouteUtil routeUtil = routeUtil(List.of(layout));
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/"), identity("USER")));
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/"), identity("USER")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/"), identity("ADMIN")));
     }
 
     @Test
@@ -200,8 +245,8 @@ class RouteUtilTest {
         AvailableViewInfo layout = view("admin", new String[] {"ADMIN"}, Map.of(), List.of(child));
         RouteUtil routeUtil = routeUtil(List.of(layout));
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/admin/42"), identity("USER")));
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin/42"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin/42"), identity("USER")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin/42"), identity("ADMIN")));
     }
 
     @Test
@@ -210,9 +255,9 @@ class RouteUtilTest {
         AvailableViewInfo layout = view("admin", new String[] {"ADMIN"}, Map.of(), List.of(child));
         RouteUtil routeUtil = routeUtil(List.of(layout));
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/admin/users"), identity("USER")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin/users"), identity("USER")));
         assertEquals(
-                RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin/users"), identity("ADMIN")));
+                AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin/users"), identity("ADMIN")));
     }
 
     @Test
@@ -222,13 +267,13 @@ class RouteUtilTest {
         RouteUtil routeUtil = routeUtil(List.of(layout));
 
         assertEquals(
-                RouteUtil.RouteAccess.DENY,
+                AuthorizationDecision.DENY,
                 routeUtil.checkRouteAccess(context("/admin/istrator/users"), identity("USER")));
         assertEquals(
-                RouteUtil.RouteAccess.ALLOW,
+                AuthorizationDecision.ALLOW,
                 routeUtil.checkRouteAccess(context("/admin/istrator/users"), identity("ADMIN")));
         assertEquals(
-                RouteUtil.RouteAccess.NO_MATCH,
+                AuthorizationDecision.NO_MATCH,
                 routeUtil.checkRouteAccess(context("/administrator/users"), identity("ADMIN")));
     }
 
@@ -239,8 +284,8 @@ class RouteUtilTest {
         AvailableViewInfo publicView = view("public", new String[0], Map.of());
         RouteUtil routeUtil = routeUtil(List.of(layout, publicView));
 
-        assertEquals(RouteUtil.RouteAccess.NO_MATCH, routeUtil.checkRouteAccess(context("/users"), identity("ADMIN")));
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/public"), identity("USER")));
+        assertEquals(AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/users"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/public"), identity("USER")));
     }
 
     @Test
@@ -248,8 +293,8 @@ class RouteUtilTest {
         RouteUtil routeUtil = routeUtil(
                 Map.of("files/*", view("files/*", new String[] {"ADMIN"}, Map.of("*", RouteParamType.WILDCARD))));
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/files/a/b"), identity("USER")));
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/files/a/b"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/files/a/b"), identity("USER")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/files/a/b"), identity("ADMIN")));
     }
 
     @Test
@@ -261,8 +306,8 @@ class RouteUtilTest {
                         new String[] {"ADMIN"},
                         Map.of("*", RouteParamType.WILDCARD, ":id?", RouteParamType.OPTIONAL))));
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/files/a/b"), identity("USER")));
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/files/a/b"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/files/a/b"), identity("USER")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/files/a/b"), identity("ADMIN")));
     }
 
     @Test
@@ -274,55 +319,54 @@ class RouteUtilTest {
                         new String[] {"ADMIN"},
                         Map.of("*", RouteParamType.WILDCARD, ":id", RouteParamType.REQUIRED))));
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/files/*/42"), identity("USER")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/files/*/42"), identity("USER")));
         assertEquals(
-                RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/files/*/42"), identity("ADMIN")));
+                AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/files/*/42"), identity("ADMIN")));
         assertEquals(
-                RouteUtil.RouteAccess.NO_MATCH, routeUtil.checkRouteAccess(context("/files/a/42"), identity("ADMIN")));
+                AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/files/a/42"), identity("ADMIN")));
     }
 
     @Test
-    void discovery_developmentFallbackUsesBackoffThenPublishesCompleteTree() {
+    void discovery_developmentFailureResultUsesBackoffThenPublishesCompleteTree() {
         AtomicInteger discoveries = new AtomicInteger();
         AtomicLong nanoTime = new AtomicLong();
         AvailableViewInfo admin = view("admin", new String[] {"ADMIN"}, Map.of());
         RouteUtil routeUtil = new RouteUtil(
                 mock(VaadinService.class),
                 () -> discoveries.incrementAndGet() == 1
-                        ? RouteUtil.DiscoveryResult.fallback(Map.of("admin", admin))
+                        ? RouteUtil.DiscoveryResult.failure()
                         : RouteUtil.DiscoveryResult.complete(List.of(admin)),
                 nanoTime::get);
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
         assertEquals(1, discoveries.get());
 
         nanoTime.set(Duration.ofSeconds(1).toNanos());
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
         assertEquals(2, discoveries.get());
     }
 
     @Test
-    void discovery_productionFallbackIsNotRepeatedAndDeniesKnownRoutes() {
+    void discovery_productionFailureResultIsNotRepeatedAndDeniesEveryRoute() {
         AtomicInteger discoveries = new AtomicInteger();
-        AvailableViewInfo publicView = view("public", new String[0], Map.of());
         RouteUtil routeUtil = new RouteUtil(
                 mock(VaadinService.class),
                 false,
                 () -> {
                     discoveries.incrementAndGet();
-                    return RouteUtil.DiscoveryResult.fallback(Map.of("public", publicView));
+                    return RouteUtil.DiscoveryResult.failure();
                 },
                 System::nanoTime);
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/public"), identity("USER")));
-        assertEquals(RouteUtil.RouteAccess.NO_MATCH, routeUtil.checkRouteAccess(context("/unknown"), identity("USER")));
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/public"), identity("USER")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/public"), identity("USER")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/unknown"), identity("USER")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/public"), identity("USER")));
         assertEquals(1, discoveries.get());
     }
 
     @Test
-    void discovery_failureIsRetriedAfterBackoff() {
+    void discovery_developmentFailureIsRetriedAfterBackoffAndDeniesUntilComplete() {
         AtomicInteger discoveries = new AtomicInteger();
         AtomicLong nanoTime = new AtomicLong();
         AvailableViewInfo admin = view("admin", new String[] {"ADMIN"}, Map.of());
@@ -336,13 +380,30 @@ class RouteUtilTest {
                 },
                 nanoTime::get);
 
-        assertEquals(RouteUtil.RouteAccess.NO_MATCH, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
-        assertEquals(RouteUtil.RouteAccess.NO_MATCH, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
         assertEquals(1, discoveries.get());
 
         nanoTime.set(Duration.ofSeconds(1).toNanos());
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
         assertEquals(2, discoveries.get());
+    }
+
+    @Test
+    void discovery_productionFailureIsNotRetriedAndDeniesEveryRoute() {
+        AtomicInteger discoveries = new AtomicInteger();
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                false,
+                () -> {
+                    discoveries.incrementAndGet();
+                    throw new IllegalStateException("routes unavailable");
+                },
+                System::nanoTime);
+
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/unknown"), identity("ADMIN")));
+        assertEquals(1, discoveries.get());
     }
 
     @Test
@@ -356,13 +417,31 @@ class RouteUtilTest {
                 () -> RouteUtil.DiscoveryResult.complete(List.of(discoveries.incrementAndGet() == 1 ? admin : user)),
                 nanoTime::get);
 
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
         assertEquals(1, discoveries.get());
 
         nanoTime.set(Duration.ofSeconds(1).toNanos());
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("USER")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("USER")));
+        assertEquals(2, discoveries.get());
+    }
+
+    @Test
+    void discovery_developmentUnchangedResourceKeepsPublishedTree() {
+        AtomicInteger discoveries = new AtomicInteger();
+        AtomicLong nanoTime = new AtomicLong();
+        AvailableViewInfo admin = view("admin", new String[] {"ADMIN"}, Map.of());
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                () -> discoveries.incrementAndGet() == 1
+                        ? RouteUtil.DiscoveryResult.complete(List.of(admin))
+                        : RouteUtil.DiscoveryResult.unchangedResult(),
+                nanoTime::get);
+
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        nanoTime.set(Duration.ofSeconds(1).toNanos());
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
         assertEquals(2, discoveries.get());
     }
 
@@ -380,9 +459,9 @@ class RouteUtilTest {
                 },
                 nanoTime::get);
 
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
         nanoTime.set(Duration.ofDays(1).toNanos());
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
         assertEquals(1, discoveries.get());
     }
 
@@ -396,37 +475,101 @@ class RouteUtilTest {
                 mock(VaadinService.class),
                 () -> switch (discoveries.incrementAndGet()) {
                     case 1 -> RouteUtil.DiscoveryResult.complete(List.of(admin));
-                    case 2 -> RouteUtil.DiscoveryResult.fallback(Map.of());
+                    case 2 -> RouteUtil.DiscoveryResult.failure();
                     default -> RouteUtil.DiscoveryResult.complete(List.of(user));
                 },
                 nanoTime::get);
 
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
         nanoTime.set(Duration.ofSeconds(1).toNanos());
-        assertEquals(RouteUtil.RouteAccess.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
         assertEquals(2, discoveries.get());
 
         nanoTime.set(Duration.ofSeconds(2).toNanos());
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
         assertEquals(3, discoveries.get());
+    }
+
+    @Test
+    void discovery_productionRouteTreeCompilationFailureDeniesEveryRoute() {
+        AvailableViewInfo brokenParent =
+                view("admin", new String[] {"ADMIN"}, Map.of(), java.util.Arrays.asList((AvailableViewInfo) null));
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                false,
+                () -> RouteUtil.DiscoveryResult.complete(List.of(brokenParent)),
+                System::nanoTime);
+
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/unknown"), identity("ADMIN")));
+    }
+
+    @Test
+    void discovery_concurrentRequestsPublishSingleProductionSnapshot() throws Exception {
+        AtomicInteger discoveries = new AtomicInteger();
+        CountDownLatch discoveryStarted = new CountDownLatch(1);
+        CountDownLatch continueDiscovery = new CountDownLatch(1);
+        AvailableViewInfo admin = view("admin", new String[] {"ADMIN"}, Map.of());
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                false,
+                () -> {
+                    discoveries.incrementAndGet();
+                    discoveryStarted.countDown();
+                    try {
+                        if (!continueDiscovery.await(5, TimeUnit.SECONDS)) {
+                            throw new IllegalStateException("timed out waiting for concurrent request");
+                        }
+                    } catch (InterruptedException exception) {
+                        Thread.currentThread().interrupt();
+                        throw new IllegalStateException(exception);
+                    }
+                    return RouteUtil.DiscoveryResult.complete(List.of(admin));
+                },
+                System::nanoTime);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<AuthorizationDecision> first =
+                    executor.submit(() -> routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+            assertTrue(discoveryStarted.await(5, TimeUnit.SECONDS));
+            Future<AuthorizationDecision> second =
+                    executor.submit(() -> routeUtil.checkRouteAccess(context("/admin"), identity("ADMIN")));
+            continueDiscovery.countDown();
+
+            assertEquals(AuthorizationDecision.ALLOW, first.get(5, TimeUnit.SECONDS));
+            assertEquals(AuthorizationDecision.ALLOW, second.get(5, TimeUnit.SECONDS));
+            assertEquals(1, discoveries.get());
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     @Test
     void checkRouteAccess_anonymousIdentityDeniedForLoginRequiredRoute() {
         RouteUtil routeUtil = routeUtil(Map.of("profile", view("profile", new String[0], Map.of())));
 
-        assertEquals(RouteUtil.RouteAccess.DENY, routeUtil.checkRouteAccess(context("/profile"), anonymousIdentity()));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/profile"), anonymousIdentity()));
+    }
+
+    @Test
+    void checkRouteAccess_normalizedPathFailureIsDenied() {
+        RouteUtil routeUtil = routeUtil(Map.of("admin", view("admin", new String[] {"ADMIN"}, Map.of())));
+        RoutingContext context = mock(RoutingContext.class);
+        when(context.normalizedPath()).thenThrow(new IllegalStateException("normalization failed"));
+
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context, identity("ADMIN")));
     }
 
     private static RouteUtil routeUtil(Map<String, AvailableViewInfo> routes) {
         RouteUtil routeUtil = new RouteUtil(mock(VaadinService.class), false, () -> null, System::nanoTime);
-        routeUtil.setRoutes(new LinkedHashMap<>(routes));
+        routeUtil.setCompleteRoutesForTesting(new LinkedHashMap<>(routes));
         return routeUtil;
     }
 
     private static RouteUtil routeUtil(List<AvailableViewInfo> routeTree) {
         RouteUtil routeUtil = new RouteUtil(mock(VaadinService.class), false, () -> null, System::nanoTime);
-        routeUtil.setRouteTree(routeTree);
+        routeUtil.setCompleteRouteTreeForTesting(routeTree);
         return routeUtil;
     }
 

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -124,6 +125,50 @@ class RouteUtilTest {
 
         assertNull(result.routeTree());
         assertFalse(result.retryImmediately());
+    }
+
+    @Test
+    void initializeProductionSnapshot_completeTreeSucceeds() {
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                false,
+                () -> RouteUtil.DiscoveryResult.complete(List.of(view("public", new String[0], Map.of()))),
+                System::nanoTime);
+
+        routeUtil.initializeProductionSnapshot();
+
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/public"), identity("USER")));
+    }
+
+    @Test
+    void initializeProductionSnapshot_missingExpectedManifestFailsStartup() {
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class), false, () -> RouteUtil.missingManifest(false, true), System::nanoTime);
+
+        assertThrows(IllegalStateException.class, routeUtil::initializeProductionSnapshot);
+    }
+
+    @Test
+    void initializeProductionSnapshot_missingUnexpectedManifestSucceeds() {
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class), false, () -> RouteUtil.missingManifest(false, false), System::nanoTime);
+
+        routeUtil.initializeProductionSnapshot();
+
+        assertEquals(AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/custom"), identity("USER")));
+    }
+
+    @Test
+    void initializeProductionSnapshot_invalidRouteTreeFailsStartup() {
+        AvailableViewInfo invalidChild = view("/users", new String[0], Map.of());
+        AvailableViewInfo layout = view("admin", new String[] {"ADMIN"}, Map.of(), List.of(invalidChild));
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                false,
+                () -> RouteUtil.DiscoveryResult.complete(List.of(layout)),
+                System::nanoTime);
+
+        assertThrows(IllegalStateException.class, routeUtil::initializeProductionSnapshot);
     }
 
     @Test
@@ -302,14 +347,18 @@ class RouteUtilTest {
     }
 
     @Test
-    void checkRouteAccess_invalidAbsoluteChildDoesNotDiscardOtherRoutes() {
+    void checkRouteAccess_invalidAbsoluteChildInvalidatesEntireSnapshot() {
         AvailableViewInfo invalidChild = view("/users", new String[0], Map.of());
         AvailableViewInfo layout = view("admin", new String[] {"ADMIN"}, Map.of(), List.of(invalidChild));
         AvailableViewInfo publicView = view("public", new String[0], Map.of());
-        RouteUtil routeUtil = routeUtil(List.of(layout, publicView));
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                false,
+                () -> RouteUtil.DiscoveryResult.complete(List.of(layout, publicView)),
+                System::nanoTime);
 
-        assertEquals(AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/users"), identity("ADMIN")));
-        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/public"), identity("USER")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/users"), identity("ADMIN")));
+        assertEquals(AuthorizationDecision.DENY, routeUtil.checkRouteAccess(context("/public"), identity("USER")));
     }
 
     @Test
@@ -646,6 +695,13 @@ class RouteUtilTest {
     }
 
     @Test
+    void checkRouteAccess_anonymousIdentityAllowedForPublicRoute() {
+        RouteUtil routeUtil = routeUtil(Map.of("public", view("public", new String[0], false, Map.of(), List.of())));
+
+        assertEquals(AuthorizationDecision.ALLOW, routeUtil.checkRouteAccess(context("/public"), anonymousIdentity()));
+    }
+
+    @Test
     void checkRouteAccess_normalizedPathFailureIsDenied() {
         RouteUtil routeUtil = routeUtil(Map.of("admin", view("admin", new String[] {"ADMIN"}, Map.of())));
         RoutingContext context = mock(RoutingContext.class);
@@ -705,7 +761,16 @@ class RouteUtilTest {
             String[] rolesAllowed,
             Map<String, RouteParamType> routeParameters,
             List<AvailableViewInfo> children) {
+        return view(route, rolesAllowed, true, routeParameters, children);
+    }
+
+    private static AvailableViewInfo view(
+            String route,
+            String[] rolesAllowed,
+            boolean loginRequired,
+            Map<String, RouteParamType> routeParameters,
+            List<AvailableViewInfo> children) {
         return new AvailableViewInfo(
-                route, rolesAllowed, true, route, false, true, null, children, routeParameters, false, null);
+                route, rolesAllowed, loginRequired, route, false, true, null, children, routeParameters, false, null);
     }
 }

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -101,6 +102,28 @@ class RouteUtilTest {
         assertFalse(first.unchanged());
         assertTrue(unchanged.unchanged());
         assertFalse(changed.unchanged());
+    }
+
+    @Test
+    void discoverFromResource_productionMissingUnexpectedManifestReturnsEmptyCompleteTree() throws Exception {
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class), false, false, RouteUtil.DiscoveryResult::failure, System::nanoTime);
+
+        RouteUtil.DiscoveryResult result = routeUtil.discoverFromResource(null);
+
+        assertEquals(List.of(), result.routeTree());
+        assertFalse(result.retryImmediately());
+    }
+
+    @Test
+    void discoverFromResource_productionMissingExpectedManifestReturnsFailure() throws Exception {
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class), false, true, RouteUtil.DiscoveryResult::failure, System::nanoTime);
+
+        RouteUtil.DiscoveryResult result = routeUtil.discoverFromResource(null);
+
+        assertNull(result.routeTree());
+        assertFalse(result.retryImmediately());
     }
 
     @Test

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/RouteUtilTest.java
@@ -466,6 +466,23 @@ class RouteUtilTest {
     }
 
     @Test
+    void discovery_productionAbsentManifestIsNoMatchAndNotRepeated() {
+        AtomicInteger discoveries = new AtomicInteger();
+        RouteUtil routeUtil = new RouteUtil(
+                mock(VaadinService.class),
+                false,
+                () -> {
+                    discoveries.incrementAndGet();
+                    return RouteUtil.DiscoveryResult.complete(List.of());
+                },
+                System::nanoTime);
+
+        assertEquals(AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/custom"), identity("USER")));
+        assertEquals(AuthorizationDecision.NO_MATCH, routeUtil.checkRouteAccess(context("/custom"), identity("USER")));
+        assertEquals(1, discoveries.get());
+    }
+
+    @Test
     void discovery_developmentFailureKeepsLastCompleteTreeUntilSuccessfulRefresh() {
         AtomicInteger discoveries = new AtomicInteger();
         AtomicLong nanoTime = new AtomicLong();

--- a/integration-tests/security-form-tests/src/main/frontend/views/hierarchy/@layout.tsx
+++ b/integration-tests/security-form-tests/src/main/frontend/views/hierarchy/@layout.tsx
@@ -1,0 +1,11 @@
+import { ViewConfig } from '@vaadin/hilla-file-router/types.js';
+import { Outlet } from 'react-router';
+
+export const config: ViewConfig = {
+  menu: { exclude: true },
+  rolesAllowed: ['ADMIN'],
+};
+
+export default function AdminHierarchyLayout() {
+  return <Outlet />;
+}

--- a/integration-tests/security-form-tests/src/main/frontend/views/hierarchy/child.tsx
+++ b/integration-tests/security-form-tests/src/main/frontend/views/hierarchy/child.tsx
@@ -1,0 +1,10 @@
+import { ViewConfig } from '@vaadin/hilla-file-router/types.js';
+
+export const config: ViewConfig = {
+  menu: { exclude: true },
+  title: 'Hilla hierarchy child',
+};
+
+export default function HillaHierarchyChildView() {
+  return <h2>Hilla hierarchy child</h2>;
+}

--- a/integration-tests/security-form-tests/src/main/java/com/example/application/DynamicFlowRouteRegistration.java
+++ b/integration-tests/security-form-tests/src/main/java/com/example/application/DynamicFlowRouteRegistration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import com.example.application.views.DynamicFlowAdminView;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.server.ServiceInitEvent;
+
+@ApplicationScoped
+class DynamicFlowRouteRegistration {
+
+    void register(@Observes ServiceInitEvent event) {
+        RouteConfiguration.forApplicationScope().setAnnotatedRoute(DynamicFlowAdminView.class);
+    }
+}

--- a/integration-tests/security-form-tests/src/main/java/com/example/application/DynamicFlowRouteRegistration.java
+++ b/integration-tests/security-form-tests/src/main/java/com/example/application/DynamicFlowRouteRegistration.java
@@ -25,7 +25,10 @@ import com.vaadin.flow.server.ServiceInitEvent;
 @ApplicationScoped
 class DynamicFlowRouteRegistration {
 
-    void register(@Observes ServiceInitEvent event) {
-        RouteConfiguration.forApplicationScope().setAnnotatedRoute(DynamicFlowAdminView.class);
+    void register(@Observes ServiceInitEvent ignored) {
+        RouteConfiguration routes = RouteConfiguration.forApplicationScope();
+        if (!routes.isRouteRegistered(DynamicFlowAdminView.class)) {
+            routes.setAnnotatedRoute(DynamicFlowAdminView.class);
+        }
     }
 }

--- a/integration-tests/security-form-tests/src/main/java/com/example/application/views/DynamicFlowAdminView.java
+++ b/integration-tests/security-form-tests/src/main/java/com/example/application/views/DynamicFlowAdminView.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application.views;
+
+import jakarta.annotation.security.RolesAllowed;
+
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+@PageTitle(DynamicFlowAdminView.TITLE)
+@Route(value = "flow-dynamic-admin", registerAtStartup = false)
+@RolesAllowed("ADMIN")
+public class DynamicFlowAdminView extends AbstractFlowView {
+
+    public static final String TITLE = "Flow - Dynamic Admin";
+
+    public DynamicFlowAdminView() {
+        super(TITLE, "Only users with role ADMIN see this dynamically registered route");
+    }
+}

--- a/integration-tests/security-form-tests/src/main/java/com/example/application/views/FlowParameterAdminView.java
+++ b/integration-tests/security-form-tests/src/main/java/com/example/application/views/FlowParameterAdminView.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application.views;
+
+import jakarta.annotation.security.RolesAllowed;
+
+import com.vaadin.flow.router.Route;
+
+/**
+ * Admin-only Flow test route with a dynamic path parameter.
+ */
+@Route("flow-parameter-admin/:id")
+@RolesAllowed("ADMIN")
+public class FlowParameterAdminView extends AbstractFlowView {
+
+    public FlowParameterAdminView() {
+        super("Flow - Parameter Admin", "Only users with role ADMIN see this page");
+    }
+}

--- a/integration-tests/security-form-tests/src/test/java/com/example/application/FormAuthenticationProtocolTest.java
+++ b/integration-tests/security-form-tests/src/test/java/com/example/application/FormAuthenticationProtocolTest.java
@@ -96,6 +96,34 @@ class FormAuthenticationProtocolTest {
     }
 
     @Test
+    void authenticatedUser_roleProtectedHillaRouteWithMatrixParameter_returnsForbidden() throws Exception {
+        HttpClient client = newClient();
+        assertThat(login(client, "user", "user", true).statusCode()).isEqualTo(200);
+
+        HttpResponse<Void> response = get(client, "hilla-admin;a=b");
+
+        assertThat(response.statusCode()).isEqualTo(403);
+    }
+
+    @Test
+    void adminUser_roleProtectedHillaRouteWithMatrixParameter_returnsSuccess() throws Exception {
+        HttpClient client = newClient();
+        assertThat(login(client, "admin", "admin", true).statusCode()).isEqualTo(200);
+
+        HttpResponse<Void> response = get(client, "hilla-admin;a=b");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void anonymousUser_roleProtectedFlowParameterWithEncodedSlash_requiresLogin() throws Exception {
+        HttpResponse<Void> response = get(newClient(), "flow-parameter-admin/a%2Fb");
+
+        assertThat(response.statusCode()).isEqualTo(302);
+        assertRedirect(response, "/login", null);
+    }
+
+    @Test
     void adminUser_roleProtectedHillaRoute_returnsSuccess() throws Exception {
         HttpClient client = newClient();
         assertThat(login(client, "admin", "admin", true).statusCode()).isEqualTo(200);

--- a/integration-tests/security-form-tests/src/test/java/com/example/application/FormAuthenticationProtocolTest.java
+++ b/integration-tests/security-form-tests/src/test/java/com/example/application/FormAuthenticationProtocolTest.java
@@ -22,20 +22,37 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.concurrent.TimeUnit;
 
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 @QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FormAuthenticationProtocolTest {
 
     private static final String LOGIN_FORM = "username=%s&password=%s";
 
     @TestHTTPResource("/")
     URI baseUri;
+
+    @BeforeAll
+    void awaitClientRouteMetadata() {
+        // In development mode, file-routes.json is generated asynchronously
+        // after Quarkus starts. RouteUtil intentionally denies access until a
+        // complete manifest exists. Wait here so denial assertions exercise
+        // route roles instead of only that temporary fail-closed state.
+        await().pollInterval(500, TimeUnit.MILLISECONDS)
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () -> assertThat(get(newClient(), "").statusCode()).isEqualTo(200));
+    }
 
     @Test
     void typescriptLogin_invalidCredentials_returnsAuthenticationFailure() throws Exception {

--- a/integration-tests/security-form-tests/src/test/java/com/example/application/FormAuthenticationProtocolTest.java
+++ b/integration-tests/security-form-tests/src/test/java/com/example/application/FormAuthenticationProtocolTest.java
@@ -68,6 +68,54 @@ class FormAuthenticationProtocolTest {
     }
 
     @Test
+    void authenticatedUser_roleProtectedHillaRoute_returnsForbidden() throws Exception {
+        HttpClient client = newClient();
+        HttpResponse<Void> loginResponse = login(client, "user", "user", true);
+        assertThat(loginResponse.statusCode()).isEqualTo(200);
+
+        HttpResponse<Void> response = get(client, "hilla-admin");
+
+        assertThat(response.statusCode()).isEqualTo(403);
+    }
+
+    @Test
+    void adminUser_roleProtectedHillaRoute_returnsSuccess() throws Exception {
+        HttpClient client = newClient();
+        assertThat(login(client, "admin", "admin", true).statusCode()).isEqualTo(200);
+
+        HttpResponse<Void> response = get(client, "hilla-admin");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void anonymousUser_publicHillaRoute_returnsSuccess() throws Exception {
+        HttpResponse<Void> response = get(newClient(), "");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void authenticatedUser_publicChildOfAdminHillaLayout_returnsForbidden() throws Exception {
+        HttpClient client = newClient();
+        assertThat(login(client, "user", "user", true).statusCode()).isEqualTo(200);
+
+        HttpResponse<Void> response = get(client, "hierarchy/child");
+
+        assertThat(response.statusCode()).isEqualTo(403);
+    }
+
+    @Test
+    void adminUser_publicChildOfAdminHillaLayout_returnsSuccess() throws Exception {
+        HttpClient client = newClient();
+        assertThat(login(client, "admin", "admin", true).statusCode()).isEqualTo(200);
+
+        HttpResponse<Void> response = get(client, "hierarchy/child");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
     void formLogin_validCredentials_redirectsToConfiguredLandingPage() throws Exception {
         HttpResponse<Void> response = login(newClient(), "user", "user", false);
 
@@ -148,6 +196,12 @@ class FormAuthenticationProtocolTest {
             request.header("source", "typescript");
         }
         return client.send(request.build(), HttpResponse.BodyHandlers.discarding());
+    }
+
+    private HttpResponse<Void> get(HttpClient client, String path) throws IOException, InterruptedException {
+        HttpRequest request =
+                HttpRequest.newBuilder(baseUri.resolve(path)).GET().build();
+        return client.send(request, HttpResponse.BodyHandlers.discarding());
     }
 
     private void assertRedirect(HttpResponse<?> response, String expectedPath, String expectedQuery) {

--- a/integration-tests/security-form-tests/src/test/java/com/example/application/SecurityTest.java
+++ b/integration-tests/security-form-tests/src/test/java/com/example/application/SecurityTest.java
@@ -47,6 +47,7 @@ import static com.example.application.SecurityTest.MenuItem.HILLA_ADMIN;
 import static com.example.application.SecurityTest.MenuItem.HILLA_AUTHENTICATED;
 import static com.example.application.SecurityTest.MenuItem.HILLA_PUBLIC;
 import static com.example.application.SecurityTest.MenuItem.HILLA_USER;
+import static com.example.application.views.DynamicFlowAdminView.TITLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
@@ -179,6 +180,17 @@ class SecurityTest extends AbstractTest {
     }
 
     @Test
+    void authenticatedUser_dynamicallyRegisteredFlowView_viewNotDisplayed() {
+        openProtectedPage("flow-protected", true);
+        login("user", "user");
+        openProtectedPage("flow-dynamic-admin", false);
+        $$("div")
+                .filter(Condition.text("Could not navigate to 'flow-dynamic-admin'"))
+                .first()
+                .shouldBe(visible);
+    }
+
+    @Test
     void authenticatedUser_unannotatedFlowView_viewNotDisplayed() {
         openProtectedPage("flow-protected", true);
         login("user", "user");
@@ -207,6 +219,14 @@ class SecurityTest extends AbstractTest {
         assertThatMenuHasItems(ADMIN_VIEWS);
         openProtectedPage("flow-admin", false);
         appLayout.$("h2").shouldHave(text(FLOW_ADMIN.toString()));
+    }
+
+    @Test
+    void adminUser_dynamicallyRegisteredFlowView_viewDisplayed() {
+        openProtectedPage("flow-protected", true);
+        login("admin", "admin");
+        openProtectedPage("flow-dynamic-admin", false);
+        appLayout.$("h2").shouldHave(text(TITLE));
     }
 
     protected void openPublicPage(String path) {

--- a/integration-tests/security-form-tests/src/test/java/com/example/application/SecurityTest.java
+++ b/integration-tests/security-form-tests/src/test/java/com/example/application/SecurityTest.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.WebDriverRunner;
+import com.example.application.views.DynamicFlowAdminView;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,6 @@ import static com.example.application.SecurityTest.MenuItem.HILLA_ADMIN;
 import static com.example.application.SecurityTest.MenuItem.HILLA_AUTHENTICATED;
 import static com.example.application.SecurityTest.MenuItem.HILLA_PUBLIC;
 import static com.example.application.SecurityTest.MenuItem.HILLA_USER;
-import static com.example.application.views.DynamicFlowAdminView.TITLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
@@ -163,7 +163,8 @@ class SecurityTest extends AbstractTest {
         login("user", "user");
         appLayout.$("h2").shouldHave(text(FLOW_AUTHENTICATED.toString()));
         assertThatMenuHasItems(USER_VIEWS);
-        openProtectedPage("hilla-admin", true);
+        open(getTestUrl() + "hilla-admin");
+        $("body").shouldHave(text("HTTP ERROR 403"));
     }
 
     @Test
@@ -226,7 +227,7 @@ class SecurityTest extends AbstractTest {
         openProtectedPage("flow-protected", true);
         login("admin", "admin");
         openProtectedPage("flow-dynamic-admin", false);
-        appLayout.$("h2").shouldHave(text(TITLE));
+        appLayout.$("h2").shouldHave(text(DynamicFlowAdminView.TITLE));
     }
 
     protected void openPublicPage(String path) {


### PR DESCRIPTION
## Summary

With Quarkus form authentication enabled, generated Hilla file routes need server-side authorization that preserves parent layout rules and follows React Router path semantics.

This PR:

- reads generated `file-routes.json` as a tree and preserves every parent security chain
- adds internal `ALLOW`, `DENY`, and `NO_MATCH` decisions
- evaluates generated Hilla routes when no Flow route matches
- leaves unrelated `NO_MATCH` paths to other Quarkus HTTP authorization
- classifies whether generated file-route metadata is expected
- fails closed when expected metadata is unavailable, incomplete, or invalid
- validates the fixed production snapshot before publishing the evaluator
- refreshes development metadata with backoff and skips unchanged manifests
- compiles immutable React Router patterns once
- handles static, parameterized, partial, optional, index, wildcard, and encoded paths
- canonicalizes authorization paths with Quarkus HTTP security rules
- evaluates both canonical and router path interpretations when encoding changes route semantics
- requires the strictest matching Hilla or Flow decision

## Decision model

`ALLOW` and `DENY` are final results for a matched Hilla route. `NO_MATCH` means this evaluator does not own the path. It permits only this policy, allowing configured Quarkus HTTP policies to continue evaluating unrelated paths.

Flow routes remain resolved through the Flow route registry. Public Flow routes are permitted at the HTTP boundary. Other Flow routes require authentication there and remain subject to Flow navigation access control during navigation.

## Discovery behavior

Build-time classification distinguishes generated Hilla file routes from Lit and pure custom routers. Standard React file routes and custom React routers with a direct `withFileRoutes(...)` call expect `file-routes.json`. Lit, `withReactRoutes(...)`, and pure custom routers do not.

Production discovers and validates expected metadata during initialization. Missing, unreadable, invalid, or incomplete expected metadata prevents startup. If no generated manifest is expected, the evaluator owns no client routes and returns `NO_MATCH`.

Development retries incomplete metadata after a short backoff. A failed refresh invalidates the previous snapshot and denies until complete metadata is available again. Reliable resource fingerprints avoid reparsing unchanged manifests.

## Compatibility notes

- Public-resource, web-icon, Flow, and generated Hilla route checks use Quarkus-canonical paths. Encoded router paths are also evaluated where Quarkus and Vaadin/React Router semantics differ; the stricter result wins.
- React Router resolves equal-ranking siblings by declaration order. The security matcher intentionally evaluates every tied best match, preventing generated route order from weakening authorization.
- Route scoring targets React Router 8 on this branch. Backports to quarkus-hilla 25.1 and 25.2 use React Router 7 and must adapt partial-parameter ranking instead of cherry-picking the matcher unchanged.
- Tests pin the Vaadin-managed React Router version and golden ranking cases so version changes require explicit revalidation.
- Disabled or failing Vaadin navigation access control no longer makes Flow routes anonymous. Keep navigation access control enabled and mark public Flow routes with `@AnonymousAllowed`.
- During development startup or metadata regeneration, generated routes can temporarily be denied until `file-routes.json` is complete.

## Scope

Only generated Hilla file routes represented in `file-routes.json` are evaluated. Routes declared only in custom `routes.ts` or `routes.tsx`, including access metadata on custom parent layouts, remain frontend-owned and outside this evaluator.

The classifier recognizes direct `withFileRoutes(...)` calls, including whitespace before `(`. Import aliases are not detected and remain outside supported server-side route evaluation.

This PR does not add OIDC support, annotation/configuration mismatch diagnostics, security documentation, or ADRs. Responsibility separation follows in stacked PR #2275.