### PR TITLE
fix(deps): use resolved Vaadin version catalogs

### DIFF
--- a/commons/hilla-shaded-deps/pom.xml
+++ b/commons/hilla-shaded-deps/pom.xml
@@ -19,22 +19,6 @@
             <groupId>com.vaadin</groupId>
             <artifactId>hilla</artifactId>
         </dependency>
-        <!--
-            vaadin-core-versions.json and vaadin-versions.json have been removed frm Hilla artifacts in
-            unified platform. Since quarkus-hilla currently still focus on Hilla only, for the moment we repack
-            json files in shaded deps module.
-        -->
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-core</artifactId>
-            <version>${vaadin.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin</artifactId>
-            <version>${vaadin.version}</version>
-            <optional>true</optional>
-        </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring</artifactId>
@@ -159,18 +143,6 @@
                                         <include>com/vaadin/flow/spring/data/VaadinSpringDataHelpers.class</include>
                                     </includes>
                                 </filter>
-                                <filter>
-                                    <artifact>com.vaadin:vaadin-core-internal</artifact>
-                                    <includes>
-                                        <include>vaadin-core-versions.json</include>
-                                    </includes>
-                                </filter>
-                                <filter>
-                                    <artifact>com.vaadin:vaadin-internal</artifact>
-                                    <includes>
-                                        <include>vaadin-versions.json</include>
-                                    </includes>
-                                </filter>
                             </filters>
                             <artifactSet>
                                 <includes>
@@ -179,8 +151,6 @@
                                     <include>org.springframework:spring-context</include>
                                     <include>org.springframework:spring-web</include>
                                     <include>org.springframework.data:spring-data-commons</include>
-                                    <include>com.vaadin:vaadin-core-internal</include>
-                                    <include>com.vaadin:vaadin-internal</include>
                                     <include>com.vaadin:vaadin-spring</include>
                                 </includes>
                             </artifactSet>

--- a/commons/runtime/pom.xml
+++ b/commons/runtime/pom.xml
@@ -58,6 +58,10 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-dev-server</artifactId>
             <optional>true</optional>
         </dependency>

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/FrontendVersionCatalogTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/FrontendVersionCatalogTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class FrontendVersionCatalogTest {
+
+    @Test
+    void shouldUseOnlyResolvedVaadinVersionCatalog() throws IOException {
+        assertCatalogCount("vaadin-core-versions.json", 1);
+        assertCatalogCount("vaadin-versions.json", 0);
+    }
+
+    private void assertCatalogCount(String resourceName, int expectedCount) throws IOException {
+        List<URL> catalogs =
+                Collections.list(Thread.currentThread().getContextClassLoader().getResources(resourceName));
+
+        assertEquals(expectedCount, catalogs.size(), () -> "Unexpected " + resourceName + " resources: " + catalogs);
+        assertFalse(
+                catalogs.stream().map(URL::toExternalForm).anyMatch(url -> url.contains("hilla-shaded-deps")),
+                () -> resourceName + " must not be loaded from hilla-shaded-deps: " + catalogs);
+    }
+}


### PR DESCRIPTION
## Summary

- stop embedding `vaadin-core-versions.json` and `vaadin-versions.json` in `hilla-shaded-deps`
- expose `vaadin-core` as a normal BOM-managed runtime dependency
- verify Hilla-only applications get exactly one core catalog, no full-platform catalog, and no catalog from the shaded JAR

## Problem

The shaded JAR freezes frontend dependency metadata to the Vaadin patch used when Quarkus Hilla is released. Application-level Maven dependency management can update Vaadin artifacts, but cannot replace the catalog embedded in `hilla-shaded-deps`. This can make Flow resolve stale npm versions when Quarkus Hilla and Vaadin patch versions differ.

With this change, the consuming application's resolved Vaadin dependency graph supplies the catalogs.

## Verification

- `mvn -pl commons/runtime -am clean verify -DskipITs`
- `mvn -pl commons/hilla-shaded-deps,commons/runtime -am spotless:check -DskipTests`
- inspected built `hilla-shaded-deps` JAR: neither Vaadin catalog is present
- dependency tree: `vaadin-core` is a normal compile dependency and resolves through the Vaadin BOM

A full local reactor run reached 132 tests with no assertion failures, but five unrelated Quarkus tests could not start because port 8081 was occupied by another checkout.

Closes #2262
