### PR TITLE
fix(security): always register Flow access checker

### DIFF
--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
@@ -15,17 +15,11 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.security;
 
-import jakarta.annotation.security.DenyAll;
-import jakarta.annotation.security.PermitAll;
-import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
-import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
-import com.vaadin.flow.server.auth.AnonymousAllowed;
 import com.vaadin.flow.server.auth.DefaultAccessCheckDecisionResolver;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
@@ -37,10 +31,8 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.DotName;
 
 import com.github.mcollovati.quarkus.hilla.security.EndpointUtil;
@@ -124,7 +116,6 @@ class QuarkusHillaSecurityProcessor {
     @BuildStep
     void registerNavigationAccessControl(
             AuthFormBuildItem authFormBuildItem,
-            CombinedIndexBuildItem index,
             BuildProducer<AdditionalBeanBuildItem> beans,
             BuildProducer<NavigationAccessControlBuildItem> accessControlProducer,
             BuildProducer<NavigationAccessCheckerBuildItem> accessCheckerProducer) {
@@ -136,26 +127,13 @@ class QuarkusHillaSecurityProcessor {
                             DefaultAccessCheckDecisionResolver.class)
                     .setUnremovable()
                     .build());
-            if (hasSecuredRoutes(index)) {
-                accessCheckerProducer.produce(
-                        new NavigationAccessCheckerBuildItem(DotName.createSimple(AnnotatedViewAccessChecker.class)));
-            }
+            accessCheckerProducer.produce(
+                    new NavigationAccessCheckerBuildItem(DotName.createSimple(AnnotatedViewAccessChecker.class)));
 
             ConfigProvider.getConfig()
                     .getOptionalValue("quarkus.http.auth.form.login-page", String.class)
                     .map(NavigationAccessControlBuildItem::new)
                     .ifPresent(accessControlProducer::produce);
         }
-    }
-
-    private boolean hasSecuredRoutes(CombinedIndexBuildItem indexBuildItem) {
-        Set<DotName> securityAnnotations = Set.of(
-                DotName.createSimple(DenyAll.class.getName()),
-                DotName.createSimple(AnonymousAllowed.class.getName()),
-                DotName.createSimple(RolesAllowed.class.getName()),
-                DotName.createSimple(PermitAll.class.getName()));
-        return indexBuildItem.getComputingIndex().getAnnotations(DotName.createSimple(Route.class.getName())).stream()
-                .flatMap(route -> route.target().annotations().stream().map(AnnotationInstance::name))
-                .anyMatch(securityAnnotations::contains);
     }
 }

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessorTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessorTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.security;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
+import org.jboss.jandex.DotName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QuarkusHillaSecurityProcessorTest {
+
+    @Test
+    void formAuthentication_registersAnnotatedCheckerForDefaultDeny() {
+        List<NavigationAccessCheckerBuildItem> accessCheckers = new ArrayList<>();
+
+        new QuarkusHillaSecurityProcessor()
+                .registerNavigationAccessControl(
+                        new AuthFormBuildItem(true), ignored -> {}, ignored -> {}, accessCheckers::add);
+
+        assertThat(accessCheckers)
+                .extracting(NavigationAccessCheckerBuildItem::getAccessChecker)
+                .containsExactly(DotName.createSimple(AnnotatedViewAccessChecker.class));
+    }
+}

--- a/integration-tests/security-form-tests/src/main/java/com/example/application/views/FlowDefaultDenyView.java
+++ b/integration-tests/security-form-tests/src/main/java/com/example/application/views/FlowDefaultDenyView.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application.views;
+
+import com.vaadin.flow.router.Route;
+
+@Route("flow-default-deny")
+public class FlowDefaultDenyView extends AbstractFlowView {
+
+    public FlowDefaultDenyView() {
+        super("Flow - Default deny", "This view must not be displayed without an access annotation");
+    }
+}

--- a/integration-tests/security-form-tests/src/test/java/com/example/application/SecurityTest.java
+++ b/integration-tests/security-form-tests/src/test/java/com/example/application/SecurityTest.java
@@ -179,6 +179,17 @@ class SecurityTest extends AbstractTest {
     }
 
     @Test
+    void authenticatedUser_unannotatedFlowView_viewNotDisplayed() {
+        openProtectedPage("flow-protected", true);
+        login("user", "user");
+        openProtectedPage("flow-default-deny", false);
+        $$("div")
+                .filter(Condition.text("Could not navigate to 'flow-default-deny'"))
+                .first()
+                .shouldBe(visible);
+    }
+
+    @Test
     void adminUser_adminHillaView_viewDisplayed() {
         openProtectedPage("flow-protected", true);
         login("admin", "admin");


### PR DESCRIPTION
## Finding

With Quarkus form authentication enabled, the extension registered `AnnotatedViewAccessChecker` only when a build-time Jandex scan found a security annotation directly on an indexed `@Route` class.

That precondition was incomplete. It missed:

- Flow routes without an access annotation, which Vaadin expects to deny by default
- access annotations declared on parent layouts
- programmatically registered route targets without `@Route`

If no indexed route matched the scan, `NavigationAccessControl` received an empty checker list and allowed navigation without evaluating the Flow access annotations. This behavior already exists on `main`; it was found while reviewing #2261 and is independent of that PR.

## Fix

- Always register `AnnotatedViewAccessChecker` when Quarkus form authentication is enabled.
- Remove the incomplete build-time route annotation scan.
- Keep behavior unchanged when form authentication is disabled.

## Compatibility

Form-auth applications with unannotated Flow views will now deny access to those views. This restores Vaadin's secure default. Applications must use an explicit access annotation such as `@AnonymousAllowed`, `@PermitAll`, or `@RolesAllowed` when access should be granted.

## Verification

- `mvn -pl commons/deployment -Dtest=QuarkusHillaSecurityProcessorTest test`
- Full `SecurityTest` browser suite: 13 tests passed, including unannotated default-deny and existing anonymous, authenticated, and role-based cases
- `mvn -pl commons/deployment spotless:check`
