### PR TITLE
ci: skip Dependabot metadata for manual updates

### DIFF
--- a/.github/workflows/prepare-vaadin-npm-deps.yaml
+++ b/.github/workflows/prepare-vaadin-npm-deps.yaml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         if: >-
+          github.actor == 'dependabot[bot]' &&
           github.event.pull_request.user.login == 'dependabot[bot]' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
           startsWith(github.event.pull_request.head.ref, 'dependabot/maven/')


### PR DESCRIPTION
## Summary

- Skip `dependabot/fetch-metadata` when a maintainer synchronizes a Dependabot PR.
- Keep automatic Vaadin/Hilla NPM dependency synchronization for Dependabot-triggered updates.

## Why

`pull_request_target` runs with the maintainer as `github.actor` after a manual branch update. `dependabot/fetch-metadata` rejects that event as non-Dependabot and marks the workflow failed. The new guard lets classification continue with no relevant dependency update, so generation steps remain skipped and the synchronization gate can complete successfully.

## Verification

- YAML parsed successfully.
- `git diff --check` passed.