### PR TITLE
feat(security): add Basic, OIDC, and JWT support

### DIFF
--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/HillaSecurityBuildItem.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/HillaSecurityBuildItem.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.security;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+final class HillaSecurityBuildItem extends SimpleBuildItem {
+
+    private final SecurityModel securityModel;
+
+    HillaSecurityBuildItem(SecurityModel securityModel) {
+        this.securityModel = securityModel;
+    }
+
+    SecurityModel securityModel() {
+        return securityModel;
+    }
+
+    boolean isEnabled() {
+        return securityModel != SecurityModel.NONE;
+    }
+
+    boolean isFormAuthentication() {
+        return securityModel == SecurityModel.FORM;
+    }
+
+    enum SecurityModel {
+        NONE,
+        FORM,
+        OIDC,
+        JWT
+    }
+}

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/HillaSecurityBuildItem.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/HillaSecurityBuildItem.java
@@ -40,6 +40,7 @@ final class HillaSecurityBuildItem extends SimpleBuildItem {
     enum SecurityModel {
         NONE,
         FORM,
+        BASIC,
         OIDC,
         JWT
     }

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
@@ -36,6 +36,7 @@ import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.vertx.http.deployment.SecurityInformationBuildItem;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.DotName;
@@ -50,8 +51,10 @@ class QuarkusHillaSecurityProcessor {
 
     @BuildStep
     FileRoutesManifestBuildItem fileRoutesManifestExpected(
-            AuthFormBuildItem authForm, VaadinBuildTimeConfig vaadinConfig, CurateOutcomeBuildItem curateOutcome) {
-        if (!authForm.isEnabled()) {
+            HillaSecurityBuildItem hillaSecurity,
+            VaadinBuildTimeConfig vaadinConfig,
+            CurateOutcomeBuildItem curateOutcome) {
+        if (!hillaSecurity.isEnabled()) {
             return new FileRoutesManifestBuildItem(false);
         }
         var applicationModule = curateOutcome.getApplicationModel().getApplicationModule();
@@ -81,16 +84,25 @@ class QuarkusHillaSecurityProcessor {
     }
 
     @BuildStep
-    AuthFormBuildItem authFormEnabledBuildItem() {
+    HillaSecurityBuildItem hillaSecurityBuildItem(List<SecurityInformationBuildItem> securityInformation) {
         boolean authFormEnabled = ConfigProvider.getConfig()
                 .getOptionalValue("quarkus.http.auth.form.enabled", Boolean.class)
                 .orElse(false);
-        return new AuthFormBuildItem(authFormEnabled);
+        if (authFormEnabled) {
+            return new HillaSecurityBuildItem(HillaSecurityBuildItem.SecurityModel.FORM);
+        }
+        HillaSecurityBuildItem.SecurityModel securityModel = securityInformation.stream()
+                .map(QuarkusHillaSecurityProcessor::toSecurityModel)
+                .filter(model -> model != HillaSecurityBuildItem.SecurityModel.NONE)
+                .findFirst()
+                .orElse(HillaSecurityBuildItem.SecurityModel.NONE);
+        return new HillaSecurityBuildItem(securityModel);
     }
 
     @BuildStep
-    void registerHillaSecurityPolicy(AuthFormBuildItem authFormEnabled, BuildProducer<AdditionalBeanBuildItem> beans) {
-        if (authFormEnabled.isEnabled()) {
+    void registerHillaSecurityPolicy(
+            HillaSecurityBuildItem hillaSecurity, BuildProducer<AdditionalBeanBuildItem> beans) {
+        if (hillaSecurity.isEnabled()) {
             beans.produce(AdditionalBeanBuildItem.builder()
                     .addBeanClasses(HillaSecurityPolicy.class, EndpointUtil.class)
                     .setDefaultScope(DotNames.APPLICATION_SCOPED)
@@ -102,10 +114,10 @@ class QuarkusHillaSecurityProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void registerHillaFormAuthenticationMechanism(
-            AuthFormBuildItem authFormBuildItem,
+            HillaSecurityBuildItem hillaSecurity,
             HillaSecurityRecorder recorder,
             BuildProducer<SyntheticBeanBuildItem> producer) {
-        if (authFormBuildItem.isEnabled()) {
+        if (hillaSecurity.isFormAuthentication()) {
             producer.produce(SyntheticBeanBuildItem.configure(HillaFormAuthenticationMechanism.class)
                     .types(HttpAuthenticationMechanism.class)
                     .setRuntimeInit()
@@ -121,12 +133,13 @@ class QuarkusHillaSecurityProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
     void configureHillaSecurityComponents(
-            AuthFormBuildItem authFormBuildItem,
+            HillaSecurityBuildItem hillaSecurity,
             FileRoutesManifestBuildItem fileRoutesManifest,
             HillaSecurityRecorder recorder,
             BeanContainerBuildItem beanContainer) {
-        if (authFormBuildItem.isEnabled()) {
-            recorder.configureHttpSecurityPolicy(beanContainer.getValue(), fileRoutesManifest.isExpected());
+        if (hillaSecurity.isEnabled()) {
+            recorder.configureHttpSecurityPolicy(
+                    beanContainer.getValue(), fileRoutesManifest.isExpected(), hillaSecurity.isFormAuthentication());
         }
     }
 
@@ -155,11 +168,11 @@ class QuarkusHillaSecurityProcessor {
 
     @BuildStep
     void registerNavigationAccessControl(
-            AuthFormBuildItem authFormBuildItem,
+            HillaSecurityBuildItem hillaSecurity,
             BuildProducer<AdditionalBeanBuildItem> beans,
             BuildProducer<NavigationAccessControlBuildItem> accessControlProducer,
             BuildProducer<NavigationAccessCheckerBuildItem> accessCheckerProducer) {
-        if (authFormBuildItem.isEnabled()) {
+        if (hillaSecurity.isEnabled()) {
             beans.produce(AdditionalBeanBuildItem.builder()
                     .addBeanClasses(
                             QuarkusNavigationAccessControl.class,
@@ -170,10 +183,21 @@ class QuarkusHillaSecurityProcessor {
             accessCheckerProducer.produce(
                     new NavigationAccessCheckerBuildItem(DotName.createSimple(AnnotatedViewAccessChecker.class)));
 
-            ConfigProvider.getConfig()
-                    .getOptionalValue("quarkus.http.auth.form.login-page", String.class)
-                    .map(NavigationAccessControlBuildItem::new)
-                    .ifPresent(accessControlProducer::produce);
+            if (hillaSecurity.isFormAuthentication()) {
+                ConfigProvider.getConfig()
+                        .getOptionalValue("quarkus.http.auth.form.login-page", String.class)
+                        .map(NavigationAccessControlBuildItem::new)
+                        .ifPresent(accessControlProducer::produce);
+            }
         }
+    }
+
+    private static HillaSecurityBuildItem.SecurityModel toSecurityModel(
+            SecurityInformationBuildItem securityInformation) {
+        return switch (securityInformation.getSecurityModel()) {
+            case oidc -> HillaSecurityBuildItem.SecurityModel.OIDC;
+            case jwt -> HillaSecurityBuildItem.SecurityModel.JWT;
+            case basic, oauth2 -> HillaSecurityBuildItem.SecurityModel.NONE;
+        };
     }
 }

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
@@ -195,9 +195,10 @@ class QuarkusHillaSecurityProcessor {
     private static HillaSecurityBuildItem.SecurityModel toSecurityModel(
             SecurityInformationBuildItem securityInformation) {
         return switch (securityInformation.getSecurityModel()) {
+            case basic -> HillaSecurityBuildItem.SecurityModel.BASIC;
             case oidc -> HillaSecurityBuildItem.SecurityModel.OIDC;
             case jwt -> HillaSecurityBuildItem.SecurityModel.JWT;
-            case basic, oauth2 -> HillaSecurityBuildItem.SecurityModel.NONE;
+            case oauth2 -> HillaSecurityBuildItem.SecurityModel.NONE;
         };
     }
 }

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessorTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessorTest.java
@@ -110,11 +110,11 @@ class QuarkusHillaSecurityProcessorTest {
     }
 
     @Test
-    void unsupportedSecurityInformation_doesNotActivateHillaSecurity() {
+    void basicSecurityInformation_activatesBasicModel() {
         HillaSecurityBuildItem result = new QuarkusHillaSecurityProcessor()
                 .hillaSecurityBuildItem(List.of(SecurityInformationBuildItem.BASIC()));
 
-        assertThat(result.securityModel()).isEqualTo(HillaSecurityBuildItem.SecurityModel.NONE);
+        assertThat(result.securityModel()).isEqualTo(HillaSecurityBuildItem.SecurityModel.BASIC);
     }
 
     @Test

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessorTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessorTest.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
 import io.quarkus.bootstrap.model.ApplicationModelBuilder;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
+import io.quarkus.vertx.http.deployment.SecurityInformationBuildItem;
 import org.jboss.jandex.DotName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -47,7 +48,7 @@ class QuarkusHillaSecurityProcessorTest {
         CurateOutcomeBuildItem curateOutcome = new CurateOutcomeBuildItem(applicationModel);
 
         FileRoutesManifestBuildItem result = new QuarkusHillaSecurityProcessor()
-                .fileRoutesManifestExpected(new AuthFormBuildItem(true), null, curateOutcome);
+                .fileRoutesManifestExpected(security(HillaSecurityBuildItem.SecurityModel.FORM), null, curateOutcome);
 
         assertThat(result.isExpected()).isTrue();
     }
@@ -55,7 +56,7 @@ class QuarkusHillaSecurityProcessorTest {
     @Test
     void disabledFormAuthenticationSkipsManifestClassification() {
         FileRoutesManifestBuildItem result = new QuarkusHillaSecurityProcessor()
-                .fileRoutesManifestExpected(new AuthFormBuildItem(false), null, null);
+                .fileRoutesManifestExpected(security(HillaSecurityBuildItem.SecurityModel.NONE), null, null);
 
         assertThat(result.isExpected()).isFalse();
     }
@@ -66,11 +67,54 @@ class QuarkusHillaSecurityProcessorTest {
 
         new QuarkusHillaSecurityProcessor()
                 .registerNavigationAccessControl(
-                        new AuthFormBuildItem(true), ignored -> {}, ignored -> {}, accessCheckers::add);
+                        security(HillaSecurityBuildItem.SecurityModel.FORM),
+                        ignored -> {},
+                        ignored -> {},
+                        accessCheckers::add);
 
         assertThat(accessCheckers)
                 .extracting(NavigationAccessCheckerBuildItem::getAccessChecker)
                 .containsExactly(DotName.createSimple(AnnotatedViewAccessChecker.class));
+    }
+
+    @Test
+    void oidcSecurity_registersAnnotatedCheckerForDefaultDeny() {
+        List<NavigationAccessCheckerBuildItem> accessCheckers = new ArrayList<>();
+
+        new QuarkusHillaSecurityProcessor()
+                .registerNavigationAccessControl(
+                        security(HillaSecurityBuildItem.SecurityModel.OIDC),
+                        ignored -> {},
+                        ignored -> {},
+                        accessCheckers::add);
+
+        assertThat(accessCheckers)
+                .extracting(NavigationAccessCheckerBuildItem::getAccessChecker)
+                .containsExactly(DotName.createSimple(AnnotatedViewAccessChecker.class));
+    }
+
+    @Test
+    void oidcSecurityInformation_activatesOidcModel() {
+        HillaSecurityBuildItem result = new QuarkusHillaSecurityProcessor()
+                .hillaSecurityBuildItem(List.of(SecurityInformationBuildItem.OPENIDCONNECT("/q/oidc")));
+
+        assertThat(result.securityModel()).isEqualTo(HillaSecurityBuildItem.SecurityModel.OIDC);
+    }
+
+    @Test
+    void jwtSecurityInformation_activatesJwtModel() {
+        HillaSecurityBuildItem result =
+                new QuarkusHillaSecurityProcessor().hillaSecurityBuildItem(List.of(SecurityInformationBuildItem.JWT()));
+
+        assertThat(result.securityModel()).isEqualTo(HillaSecurityBuildItem.SecurityModel.JWT);
+    }
+
+    @Test
+    void unsupportedSecurityInformation_doesNotActivateHillaSecurity() {
+        HillaSecurityBuildItem result = new QuarkusHillaSecurityProcessor()
+                .hillaSecurityBuildItem(List.of(SecurityInformationBuildItem.BASIC()));
+
+        assertThat(result.securityModel()).isEqualTo(HillaSecurityBuildItem.SecurityModel.NONE);
     }
 
     @Test
@@ -112,5 +156,9 @@ class QuarkusHillaSecurityProcessorTest {
                 QuarkusHillaSecurityProcessor.resolveFrontendDirectory(moduleDirectory, absoluteFrontend.toFile());
 
         assertThat(resolved.toPath()).isEqualTo(absoluteFrontend);
+    }
+
+    private static HillaSecurityBuildItem security(HillaSecurityBuildItem.SecurityModel model) {
+        return new HillaSecurityBuildItem(model);
     }
 }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityRecorder.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityRecorder.java
@@ -49,10 +49,12 @@ public class HillaSecurityRecorder {
         };
     }
 
-    public void configureHttpSecurityPolicy(BeanContainer container, boolean fileRoutesManifestExpected) {
-        Config config = ConfigProvider.getConfig();
+    public void configureHttpSecurityPolicy(
+            BeanContainer container, boolean fileRoutesManifestExpected, boolean formAuthentication) {
         HillaSecurityPolicy policy = container.beanInstance(HillaSecurityPolicy.class);
-        policy.withFormLogin(config);
+        if (formAuthentication) {
+            policy.withFormLogin(ConfigProvider.getConfig());
+        }
         policy.setFileRoutesManifestExpected(fileRoutesManifestExpected);
         markSecurityPolicyUsed();
     }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/QuarkusNavigationAccessControl.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/QuarkusNavigationAccessControl.java
@@ -48,17 +48,26 @@ public class QuarkusNavigationAccessControl extends NavigationAccessControl {
     @Override
     protected Principal getPrincipal(VaadinRequest request) {
         if (request == null) {
-            return securityIdentity.getPrincipal();
+            return securityIdentity.isAnonymous() ? null : securityIdentity.getPrincipal();
         }
-        return super.getPrincipal(request);
+        Principal requestPrincipal = super.getPrincipal(request);
+        if (requestPrincipal != null) {
+            return requestPrincipal;
+        }
+        return securityIdentity.isAnonymous() ? null : securityIdentity.getPrincipal();
     }
 
     @Override
     protected Predicate<String> getRolesChecker(VaadinRequest request) {
         if (request == null) {
-            return securityIdentity::hasRole;
+            return this::hasRole;
         }
-        return super.getRolesChecker(request);
+        Predicate<String> requestRolesChecker = super.getRolesChecker(request);
+        return role -> requestRolesChecker.test(role) || hasRole(role);
+    }
+
+    private boolean hasRole(String role) {
+        return role != null && !securityIdentity.isAnonymous() && securityIdentity.hasRole(role);
     }
 
     @Singleton

--- a/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/QuarkusNavigationAccessControlTest.java
+++ b/commons/runtime/src/test/java/com/github/mcollovati/quarkus/hilla/security/QuarkusNavigationAccessControlTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.security;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.function.Predicate;
+
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.auth.AccessCheckDecisionResolver;
+import io.quarkus.security.identity.SecurityIdentity;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class QuarkusNavigationAccessControlTest {
+
+    @Test
+    void authenticatedIdentity_suppliesPrincipalWhenRequestHasNone() {
+        SecurityIdentity identity = identity("oidc-user", "USER");
+        TestAccessControl accessControl = accessControl(identity);
+        VaadinRequest request = mock(VaadinRequest.class);
+
+        assertEquals("oidc-user", accessControl.principal(request).getName());
+    }
+
+    @Test
+    void authenticatedIdentity_suppliesRolesWhenRequestHasNone() {
+        SecurityIdentity identity = identity("oidc-user", "USER");
+        TestAccessControl accessControl = accessControl(identity);
+        VaadinRequest request = mock(VaadinRequest.class);
+
+        Predicate<String> roles = accessControl.roles(request);
+
+        assertTrue(roles.test("USER"));
+        assertFalse(roles.test("ADMIN"));
+    }
+
+    @Test
+    void requestSecurity_remainsAvailableWhenIdentityIsAnonymous() {
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        when(identity.isAnonymous()).thenReturn(true);
+        TestAccessControl accessControl = accessControl(identity);
+        VaadinRequest request = mock(VaadinRequest.class);
+        Principal principal = () -> "form-user";
+        when(request.getUserPrincipal()).thenReturn(principal);
+        when(request.isUserInRole("USER")).thenReturn(true);
+
+        assertEquals(principal, accessControl.principal(request));
+        assertTrue(accessControl.roles(request).test("USER"));
+    }
+
+    @Test
+    void anonymousIdentity_withoutRequestSecurityHasNoAccess() {
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        when(identity.isAnonymous()).thenReturn(true);
+        TestAccessControl accessControl = accessControl(identity);
+
+        assertNull(accessControl.principal(null));
+        assertFalse(accessControl.roles(null).test("USER"));
+    }
+
+    private static TestAccessControl accessControl(SecurityIdentity identity) {
+        return new TestAccessControl(identity);
+    }
+
+    private static SecurityIdentity identity(String name, String... roles) {
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        when(identity.isAnonymous()).thenReturn(false);
+        when(identity.getPrincipal()).thenReturn((Principal) () -> name);
+        for (String role : roles) {
+            when(identity.hasRole(role)).thenReturn(true);
+        }
+        return identity;
+    }
+
+    private static final class TestAccessControl extends QuarkusNavigationAccessControl {
+
+        private TestAccessControl(SecurityIdentity identity) {
+            super(List.of(), mock(AccessCheckDecisionResolver.class), identity);
+        }
+
+        private Principal principal(VaadinRequest request) {
+            return getPrincipal(request);
+        }
+
+        private Predicate<String> roles(VaadinRequest request) {
+            return getRolesChecker(request);
+        }
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -361,6 +361,7 @@
         <!--
         -->
         <module>security-form-tests</module>
+        <module>security-oidc-tests</module>
         <module>codestart-tests</module>
     </modules>
 </project>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -361,6 +361,7 @@
         <!--
         -->
         <module>security-form-tests</module>
+        <module>security-basic-tests</module>
         <module>security-oidc-tests</module>
         <module>codestart-tests</module>
     </modules>

--- a/integration-tests/security-basic-tests/pom.xml
+++ b/integration-tests/security-basic-tests/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.github.mcollovati</groupId>
+        <artifactId>quarkus-hilla-tests</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-hilla-security-basic-tests</artifactId>
+    <name>Quarkus - Hilla - Basic security tests</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.mcollovati</groupId>
+            <artifactId>quarkus-hilla</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/security-basic-tests/src/main/java/com/example/application/VaadinServiceHolder.java
+++ b/integration-tests/security-basic-tests/src/main/java/com/example/application/VaadinServiceHolder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinService;
+
+@ApplicationScoped
+public class VaadinServiceHolder {
+
+    private VaadinService vaadinService;
+
+    void initialize(@Observes ServiceInitEvent event) {
+        vaadinService = event.getSource();
+    }
+
+    public VaadinService get() {
+        return vaadinService;
+    }
+}

--- a/integration-tests/security-basic-tests/src/main/java/com/example/application/services/BasicSecurityService.java
+++ b/integration-tests/security-basic-tests/src/main/java/com/example/application/services/BasicSecurityService.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application.services;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+
+import com.example.application.VaadinServiceHolder;
+import com.example.application.views.FlowAdminView;
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+import com.vaadin.flow.server.auth.NavigationAccessControl;
+import com.vaadin.hilla.BrowserCallable;
+import io.quarkus.security.identity.SecurityIdentity;
+
+@BrowserCallable
+public class BasicSecurityService {
+
+    private final SecurityIdentity securityIdentity;
+    private final NavigationAccessControl navigationAccessControl;
+    private final VaadinServiceHolder vaadinServiceHolder;
+
+    public BasicSecurityService(
+            SecurityIdentity securityIdentity,
+            NavigationAccessControl navigationAccessControl,
+            VaadinServiceHolder vaadinServiceHolder) {
+        this.securityIdentity = securityIdentity;
+        this.navigationAccessControl = navigationAccessControl;
+        this.vaadinServiceHolder = vaadinServiceHolder;
+    }
+
+    @AnonymousAllowed
+    public String anonymous() {
+        return "ANONYMOUS";
+    }
+
+    @PermitAll
+    public String authenticated() {
+        return "AUTHENTICATED:" + securityIdentity.getPrincipal().getName();
+    }
+
+    @RolesAllowed("USER")
+    public String userOnly() {
+        return "USER";
+    }
+
+    @RolesAllowed("ADMIN")
+    public String adminOnly() {
+        return "ADMIN";
+    }
+
+    @PermitAll
+    public String adminNavigationDecision() {
+        var context = navigationAccessControl.createNavigationContext(
+                FlowAdminView.class, "flow-admin", vaadinServiceHolder.get(), null);
+        return navigationAccessControl.checkAccess(context, false).decision().name();
+    }
+}

--- a/integration-tests/security-basic-tests/src/main/java/com/example/application/views/FlowAdminView.java
+++ b/integration-tests/security-basic-tests/src/main/java/com/example/application/views/FlowAdminView.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application.views;
+
+import jakarta.annotation.security.RolesAllowed;
+
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.router.Route;
+
+@Route("flow-admin")
+@RolesAllowed("ADMIN")
+public class FlowAdminView extends H2 {
+
+    public FlowAdminView() {
+        setText("Admin");
+    }
+}

--- a/integration-tests/security-basic-tests/src/main/resources/application.properties
+++ b/integration-tests/security-basic-tests/src/main/resources/application.properties
@@ -1,0 +1,22 @@
+#
+# Copyright 2026 Marco Collovati, Dario Götze
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+quarkus.http.auth.basic=true
+quarkus.security.users.file.enabled=true
+quarkus.security.users.file.users=test-users.properties
+quarkus.security.users.file.roles=test-roles.properties
+quarkus.security.users.file.realm-name=BasicSecurityTest
+quarkus.security.users.file.plain-text=true

--- a/integration-tests/security-basic-tests/src/main/resources/test-roles.properties
+++ b/integration-tests/security-basic-tests/src/main/resources/test-roles.properties
@@ -1,0 +1,2 @@
+user=USER
+admin=USER,ADMIN

--- a/integration-tests/security-basic-tests/src/main/resources/test-users.properties
+++ b/integration-tests/security-basic-tests/src/main/resources/test-users.properties
@@ -1,0 +1,2 @@
+user=user-password
+admin=admin-password

--- a/integration-tests/security-basic-tests/src/test/java/com/example/application/BasicSecurityTest.java
+++ b/integration-tests/security-basic-tests/src/test/java/com/example/application/BasicSecurityTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.util.List;
+
+import com.vaadin.flow.server.auth.NavigationAccessControl;
+import io.quarkus.arc.All;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.hilla.security.HillaFormAuthenticationMechanism;
+import com.github.mcollovati.quarkus.hilla.security.HillaSecurityPolicy;
+import com.github.mcollovati.quarkus.hilla.security.QuarkusNavigationAccessControl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+@QuarkusTest
+class BasicSecurityTest {
+
+    private static final String ENDPOINT = "BasicSecurityService";
+
+    @Inject
+    Instance<HillaSecurityPolicy> hillaSecurityPolicy;
+
+    @Inject
+    NavigationAccessControl navigationAccessControl;
+
+    @Inject
+    @All
+    List<HttpAuthenticationMechanism> authenticationMechanisms;
+
+    @Test
+    void basicSecurityModel_registersSharedHillaSecurityWithoutFormMechanism() {
+        assertThat(hillaSecurityPolicy.isResolvable()).isTrue();
+        assertThat(navigationAccessControl).isInstanceOf(QuarkusNavigationAccessControl.class);
+        assertThat(authenticationMechanisms).noneMatch(HillaFormAuthenticationMechanism.class::isInstance);
+    }
+
+    @Test
+    void browserCallable_anonymousAllowed_withoutIdentity() {
+        endpointRequest("anonymous").then().statusCode(200).body(equalTo("\"ANONYMOUS\""));
+    }
+
+    @Test
+    void browserCallable_permitAll_withoutIdentityIsDenied() {
+        endpointRequest("authenticated").then().statusCode(401);
+    }
+
+    @Test
+    void browserCallable_permitAll_usesBasicIdentity() {
+        endpointRequest("authenticated", "user", "user-password")
+                .then()
+                .statusCode(200)
+                .body(equalTo("\"AUTHENTICATED:user\""));
+    }
+
+    @Test
+    void browserCallable_invalidBasicCredentialsAreDenied() {
+        endpointRequest("authenticated", "user", "wrong-password").then().statusCode(401);
+    }
+
+    @Test
+    void browserCallable_rolesAllowed_matchingRoleIsAllowed() {
+        endpointRequest("userOnly", "user", "user-password")
+                .then()
+                .statusCode(200)
+                .body(equalTo("\"USER\""));
+    }
+
+    @Test
+    void browserCallable_rolesAllowed_wrongRoleIsDenied() {
+        endpointRequest("adminOnly", "user", "user-password").then().statusCode(403);
+    }
+
+    @Test
+    void browserCallable_rolesAllowed_adminRoleIsAllowed() {
+        endpointRequest("adminOnly", "admin", "admin-password")
+                .then()
+                .statusCode(200)
+                .body(equalTo("\"ADMIN\""));
+    }
+
+    @Test
+    void navigation_rolesAllowed_wrongRoleIsDenied() {
+        endpointRequest("adminNavigationDecision", "user", "user-password")
+                .then()
+                .statusCode(200)
+                .body(equalTo("\"DENY\""));
+    }
+
+    @Test
+    void navigation_rolesAllowed_adminRoleIsAllowed() {
+        endpointRequest("adminNavigationDecision", "admin", "admin-password")
+                .then()
+                .statusCode(200)
+                .body(equalTo("\"ALLOW\""));
+    }
+
+    private Response endpointRequest(String methodName) {
+        return request().when().post("{endpointName}/{methodName}", ENDPOINT, methodName);
+    }
+
+    private Response endpointRequest(String methodName, String username, String password) {
+        return request()
+                .auth()
+                .preemptive()
+                .basic(username, password)
+                .when()
+                .post("{endpointName}/{methodName}", ENDPOINT, methodName);
+    }
+
+    private io.restassured.specification.RequestSpecification request() {
+        return RestAssured.given()
+                .contentType(ContentType.JSON)
+                .cookie("csrfToken", "CSRF_TOKEN")
+                .header("X-CSRF-Token", "CSRF_TOKEN")
+                .body("{}")
+                .basePath("/connect");
+    }
+}

--- a/integration-tests/security-oidc-tests/pom.xml
+++ b/integration-tests/security-oidc-tests/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.github.mcollovati</groupId>
+        <artifactId>quarkus-hilla-tests</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-hilla-security-oidc-tests</artifactId>
+    <name>Quarkus - Hilla - OIDC security tests</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.mcollovati</groupId>
+            <artifactId>quarkus-hilla</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-security</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-security-oidc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/security-oidc-tests/src/main/java/com/example/application/VaadinServiceHolder.java
+++ b/integration-tests/security-oidc-tests/src/main/java/com/example/application/VaadinServiceHolder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinService;
+
+@ApplicationScoped
+public class VaadinServiceHolder {
+
+    private VaadinService service;
+
+    void onServiceInit(@Observes ServiceInitEvent event) {
+        service = event.getSource();
+    }
+
+    VaadinService get() {
+        return service;
+    }
+}

--- a/integration-tests/security-oidc-tests/src/main/java/com/example/application/services/OidcSecurityService.java
+++ b/integration-tests/security-oidc-tests/src/main/java/com/example/application/services/OidcSecurityService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application.services;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+import com.vaadin.hilla.BrowserCallable;
+import io.quarkus.security.identity.SecurityIdentity;
+
+@BrowserCallable
+public class OidcSecurityService {
+
+    private final SecurityIdentity securityIdentity;
+
+    public OidcSecurityService(SecurityIdentity securityIdentity) {
+        this.securityIdentity = securityIdentity;
+    }
+
+    @AnonymousAllowed
+    public String anonymous() {
+        return "ANONYMOUS";
+    }
+
+    @PermitAll
+    public String authenticated() {
+        return "AUTHENTICATED:" + securityIdentity.getPrincipal().getName();
+    }
+
+    @RolesAllowed("USER")
+    public String userOnly() {
+        return "USER";
+    }
+
+    @RolesAllowed("ADMIN")
+    public String adminOnly() {
+        return "ADMIN";
+    }
+}

--- a/integration-tests/security-oidc-tests/src/main/java/com/example/application/views/FlowAdminView.java
+++ b/integration-tests/security-oidc-tests/src/main/java/com/example/application/views/FlowAdminView.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application.views;
+
+import jakarta.annotation.security.RolesAllowed;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("flow-admin")
+@RolesAllowed("ADMIN")
+public class FlowAdminView extends Div {
+
+    public FlowAdminView() {
+        setText("Admin");
+    }
+}

--- a/integration-tests/security-oidc-tests/src/main/java/com/example/application/views/FlowAuthenticatedView.java
+++ b/integration-tests/security-oidc-tests/src/main/java/com/example/application/views/FlowAuthenticatedView.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application.views;
+
+import jakarta.annotation.security.PermitAll;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("flow-authenticated")
+@PermitAll
+public class FlowAuthenticatedView extends Div {
+
+    public FlowAuthenticatedView() {
+        setText("Authenticated");
+    }
+}

--- a/integration-tests/security-oidc-tests/src/main/java/com/example/application/views/FlowPublicView.java
+++ b/integration-tests/security-oidc-tests/src/main/java/com/example/application/views/FlowPublicView.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application.views;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+
+@Route("flow-public")
+@AnonymousAllowed
+public class FlowPublicView extends Div {
+
+    public FlowPublicView() {
+        setText("Public");
+    }
+}

--- a/integration-tests/security-oidc-tests/src/main/resources/application.properties
+++ b/integration-tests/security-oidc-tests/src/main/resources/application.properties
@@ -1,0 +1,22 @@
+#
+# Copyright 2026 Marco Collovati, Dario Götze
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+quarkus.oidc.application-type=service
+quarkus.oidc.auth-server-url=http://localhost:8180/realms/quarkus
+quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.credentials.secret=secret
+quarkus.oidc.discovery-enabled=false
+quarkus.oidc.introspection-path=/protocol/openid-connect/token/introspect

--- a/integration-tests/security-oidc-tests/src/test/java/com/example/application/OidcSecurityTest.java
+++ b/integration-tests/security-oidc-tests/src/test/java/com/example/application/OidcSecurityTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.util.List;
+
+import com.example.application.views.FlowAdminView;
+import com.example.application.views.FlowAuthenticatedView;
+import com.example.application.views.FlowPublicView;
+import com.vaadin.flow.server.auth.AccessCheckDecision;
+import com.vaadin.flow.server.auth.NavigationAccessControl;
+import com.vaadin.flow.server.auth.NavigationContext;
+import io.quarkus.arc.All;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.oidc.OidcSecurity;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.hilla.security.HillaFormAuthenticationMechanism;
+import com.github.mcollovati.quarkus.hilla.security.HillaSecurityPolicy;
+import com.github.mcollovati.quarkus.hilla.security.QuarkusNavigationAccessControl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+@QuarkusTest
+class OidcSecurityTest {
+
+    private static final String ENDPOINT = "OidcSecurityService";
+
+    @Inject
+    Instance<HillaSecurityPolicy> hillaSecurityPolicy;
+
+    @Inject
+    NavigationAccessControl navigationAccessControl;
+
+    @Inject
+    VaadinServiceHolder vaadinServiceHolder;
+
+    @Inject
+    @All
+    List<HttpAuthenticationMechanism> authenticationMechanisms;
+
+    @Test
+    void oidcSecurityModel_registersSharedHillaSecurityWithoutFormMechanism() {
+        assertThat(hillaSecurityPolicy.isResolvable()).isTrue();
+        assertThat(navigationAccessControl).isInstanceOf(QuarkusNavigationAccessControl.class);
+        assertThat(authenticationMechanisms).noneMatch(HillaFormAuthenticationMechanism.class::isInstance);
+    }
+
+    @Test
+    void browserCallable_anonymousAllowed_withoutIdentity() {
+        endpointRequest("anonymous").then().statusCode(200).body(equalTo("\"ANONYMOUS\""));
+    }
+
+    @Test
+    void browserCallable_permitAll_withoutIdentityIsDenied() {
+        endpointRequest("authenticated").then().statusCode(401);
+    }
+
+    @Test
+    @TestSecurity(user = "user", roles = "USER")
+    @OidcSecurity
+    void browserCallable_permitAll_usesQuarkusIdentity() {
+        endpointRequest("authenticated").then().statusCode(200).body(equalTo("\"AUTHENTICATED:user\""));
+    }
+
+    @Test
+    @TestSecurity(user = "user", roles = "USER")
+    @OidcSecurity
+    void browserCallable_rolesAllowed_matchingRoleIsAllowed() {
+        endpointRequest("userOnly").then().statusCode(200).body(equalTo("\"USER\""));
+    }
+
+    @Test
+    @TestSecurity(user = "user", roles = "USER")
+    @OidcSecurity
+    void browserCallable_rolesAllowed_wrongRoleIsDenied() {
+        endpointRequest("adminOnly").then().statusCode(403);
+    }
+
+    @Test
+    @TestSecurity(
+            user = "admin",
+            roles = {"USER", "ADMIN"})
+    @OidcSecurity
+    void browserCallable_rolesAllowed_adminRoleIsAllowed() {
+        endpointRequest("adminOnly").then().statusCode(200).body(equalTo("\"ADMIN\""));
+    }
+
+    @Test
+    void navigation_anonymousAllowed_withoutIdentity() {
+        assertNavigationDecision(FlowPublicView.class, "flow-public", AccessCheckDecision.ALLOW);
+    }
+
+    @Test
+    void navigation_permitAll_withoutIdentityIsDenied() {
+        assertNavigationDecision(FlowAuthenticatedView.class, "flow-authenticated", AccessCheckDecision.DENY);
+    }
+
+    @Test
+    @TestSecurity(user = "user", roles = "USER")
+    @OidcSecurity
+    void navigation_permitAll_usesQuarkusIdentity() {
+        assertNavigationDecision(FlowAuthenticatedView.class, "flow-authenticated", AccessCheckDecision.ALLOW);
+    }
+
+    @Test
+    @TestSecurity(user = "user", roles = "USER")
+    @OidcSecurity
+    void navigation_rolesAllowed_wrongRoleIsDenied() {
+        assertNavigationDecision(FlowAdminView.class, "flow-admin", AccessCheckDecision.DENY);
+    }
+
+    @Test
+    @TestSecurity(
+            user = "admin",
+            roles = {"USER", "ADMIN"})
+    @OidcSecurity
+    void navigation_rolesAllowed_adminRoleIsAllowed() {
+        assertNavigationDecision(FlowAdminView.class, "flow-admin", AccessCheckDecision.ALLOW);
+    }
+
+    private Response endpointRequest(String methodName) {
+        return RestAssured.given()
+                .contentType(ContentType.JSON)
+                .cookie("csrfToken", "CSRF_TOKEN")
+                .header("X-CSRF-Token", "CSRF_TOKEN")
+                .body("{}")
+                .basePath("/connect")
+                .when()
+                .post("{endpointName}/{methodName}", ENDPOINT, methodName);
+    }
+
+    private void assertNavigationDecision(Class<?> route, String path, AccessCheckDecision expectedDecision) {
+        NavigationContext context =
+                navigationAccessControl.createNavigationContext(route, path, vaadinServiceHolder.get(), null);
+
+        assertThat(navigationAccessControl.checkAccess(context, false).decision())
+                .isEqualTo(expectedDecision);
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on #2275, this PR adds basic Quarkus authentication-model integration for issue #30:

- detects explicitly enabled Quarkus Basic authentication
- detects active Quarkus OIDC and JWT security models
- activates existing Hilla and Flow security integration for those models
- uses Quarkus `SecurityIdentity` for existing `@AnonymousAllowed`, `@PermitAll`, and `@RolesAllowed` checks
- adds small Basic and OIDC/JWT integration applications covering endpoint and navigation decisions

## Supported activation

- Form authentication remains supported.
- Basic authentication is supported when `quarkus.http.auth.basic=true` is explicitly configured.
- OIDC and JWT activate from Quarkus security build information.

Quarkus fallback Basic authentication and programmatic `HttpSecurity.basic(...)` are not detected automatically. Applications using those forms should explicitly enable Basic authentication through configuration.

Provider redirects, token acquisition, refresh, logout, tenant selection, role mapping, and credential validation remain Quarkus responsibilities. Applications should still run an end-to-end test with their selected external OIDC provider.

## Scope

Included:

- authentication-model activation
- current `SecurityIdentity` propagation
- Hilla BrowserCallable annotation checks
- Flow navigation annotation checks
- focused Basic and OIDC/JWT integration coverage

Not included:

- synthetic target authentication
- replay of Quarkus path policies
- OIDC tenant re-selection
- annotation/configuration mismatch diagnostics
- policy-result caching
- provider-specific login implementations
- broad Flow fixture expansion

This keeps initial OIDC/JWT and Basic support useful without introducing a Quarkus HTTP-policy simulator.