### PR TITLE
feat(security): allow opting out of navigation access control

### DIFF
--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
@@ -40,7 +40,6 @@ import com.github.mcollovati.quarkus.hilla.security.HillaFormAuthenticationMecha
 import com.github.mcollovati.quarkus.hilla.security.HillaSecurityPolicy;
 import com.github.mcollovati.quarkus.hilla.security.HillaSecurityRecorder;
 import com.github.mcollovati.quarkus.hilla.security.QuarkusNavigationAccessControl;
-import com.github.mcollovati.quarkus.hilla.security.VaadinSecurityConfig;
 
 class QuarkusHillaSecurityProcessor {
 
@@ -117,7 +116,6 @@ class QuarkusHillaSecurityProcessor {
     @BuildStep
     void registerNavigationAccessControl(
             AuthFormBuildItem authFormBuildItem,
-            VaadinSecurityConfig securityConfig,
             BuildProducer<AdditionalBeanBuildItem> beans,
             BuildProducer<NavigationAccessControlBuildItem> accessControlProducer,
             BuildProducer<NavigationAccessCheckerBuildItem> accessCheckerProducer) {
@@ -129,13 +127,8 @@ class QuarkusHillaSecurityProcessor {
                             DefaultAccessCheckDecisionResolver.class)
                     .setUnremovable()
                     .build());
-            // The access control is registered unconditionally because
-            // HillaSecurityPolicy injects it. Without a checker it grants
-            // access to every view.
-            if (securityConfig.navigationAccessControl().enabled()) {
-                accessCheckerProducer.produce(
-                        new NavigationAccessCheckerBuildItem(DotName.createSimple(AnnotatedViewAccessChecker.class)));
-            }
+            accessCheckerProducer.produce(
+                    new NavigationAccessCheckerBuildItem(DotName.createSimple(AnnotatedViewAccessChecker.class)));
 
             ConfigProvider.getConfig()
                     .getOptionalValue("quarkus.http.auth.form.login-page", String.class)

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
@@ -40,6 +40,7 @@ import com.github.mcollovati.quarkus.hilla.security.HillaFormAuthenticationMecha
 import com.github.mcollovati.quarkus.hilla.security.HillaSecurityPolicy;
 import com.github.mcollovati.quarkus.hilla.security.HillaSecurityRecorder;
 import com.github.mcollovati.quarkus.hilla.security.QuarkusNavigationAccessControl;
+import com.github.mcollovati.quarkus.hilla.security.VaadinSecurityConfig;
 
 class QuarkusHillaSecurityProcessor {
 
@@ -116,6 +117,7 @@ class QuarkusHillaSecurityProcessor {
     @BuildStep
     void registerNavigationAccessControl(
             AuthFormBuildItem authFormBuildItem,
+            VaadinSecurityConfig securityConfig,
             BuildProducer<AdditionalBeanBuildItem> beans,
             BuildProducer<NavigationAccessControlBuildItem> accessControlProducer,
             BuildProducer<NavigationAccessCheckerBuildItem> accessCheckerProducer) {
@@ -127,8 +129,14 @@ class QuarkusHillaSecurityProcessor {
                             DefaultAccessCheckDecisionResolver.class)
                     .setUnremovable()
                     .build());
-            accessCheckerProducer.produce(
-                    new NavigationAccessCheckerBuildItem(DotName.createSimple(AnnotatedViewAccessChecker.class)));
+            // Without any access checker the navigation access control grants
+            // access to every view, which is how the opt-out is implemented.
+            // The control itself stays registered because HillaSecurityPolicy
+            // depends on it.
+            if (securityConfig.navigationAccessControl().enabled()) {
+                accessCheckerProducer.produce(
+                        new NavigationAccessCheckerBuildItem(DotName.createSimple(AnnotatedViewAccessChecker.class)));
+            }
 
             ConfigProvider.getConfig()
                     .getOptionalValue("quarkus.http.auth.form.login-page", String.class)

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
@@ -40,6 +40,7 @@ import com.github.mcollovati.quarkus.hilla.security.HillaFormAuthenticationMecha
 import com.github.mcollovati.quarkus.hilla.security.HillaSecurityPolicy;
 import com.github.mcollovati.quarkus.hilla.security.HillaSecurityRecorder;
 import com.github.mcollovati.quarkus.hilla.security.QuarkusNavigationAccessControl;
+import com.github.mcollovati.quarkus.hilla.security.VaadinSecurityConfig;
 
 class QuarkusHillaSecurityProcessor {
 
@@ -93,12 +94,19 @@ class QuarkusHillaSecurityProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void configureNavigationAccessControl(
+            AuthFormBuildItem authFormBuildItem,
+            VaadinSecurityConfig securityConfig,
             HillaSecurityRecorder recorder,
             BeanContainerBuildItem beanContainer,
             Optional<NavigationAccessControlBuildItem> navigationAccessControlBuildItem) {
-        navigationAccessControlBuildItem
-                .map(NavigationAccessControlBuildItem::getLoginPath)
-                .ifPresent(loginPath -> recorder.configureNavigationAccessControl(beanContainer.getValue(), loginPath));
+        if (authFormBuildItem.isEnabled()) {
+            recorder.configureNavigationAccessControl(
+                    beanContainer.getValue(),
+                    navigationAccessControlBuildItem
+                            .map(NavigationAccessControlBuildItem::getLoginPath)
+                            .orElse(null),
+                    securityConfig.navigationAccessControl().enabled());
+        }
     }
 
     @BuildStep

--- a/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
+++ b/commons/deployment/src/main/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessor.java
@@ -129,10 +129,9 @@ class QuarkusHillaSecurityProcessor {
                             DefaultAccessCheckDecisionResolver.class)
                     .setUnremovable()
                     .build());
-            // Without any access checker the navigation access control grants
-            // access to every view, which is how the opt-out is implemented.
-            // The control itself stays registered because HillaSecurityPolicy
-            // depends on it.
+            // The access control is registered unconditionally because
+            // HillaSecurityPolicy injects it. Without a checker it grants
+            // access to every view.
             if (securityConfig.navigationAccessControl().enabled()) {
                 accessCheckerProducer.produce(
                         new NavigationAccessCheckerBuildItem(DotName.createSimple(AnnotatedViewAccessChecker.class)));

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/CustomNavigationAccessControl.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/CustomNavigationAccessControl.java
@@ -33,5 +33,8 @@ public class CustomNavigationAccessControl extends NavigationAccessControl {
 
     public CustomNavigationAccessControl() {
         super(List.of(new AnnotatedViewAccessChecker()), new DefaultAccessCheckDecisionResolver());
+        // NavigationAccessControl.setLoginView refuses a second call, so the
+        // extension must not apply the Quarkus form login page on top of this.
+        setLoginView("/custom-login");
     }
 }

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/CustomNavigationAccessControl.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/CustomNavigationAccessControl.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.security;
+
+import jakarta.inject.Singleton;
+import java.util.List;
+
+import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
+import com.vaadin.flow.server.auth.DefaultAccessCheckDecisionResolver;
+import com.vaadin.flow.server.auth.NavigationAccessControl;
+
+/**
+ * Replaces the extension provided access control and builds its checker
+ * itself, so that the checker is out of reach of the configuration.
+ */
+@Singleton
+public class CustomNavigationAccessControl extends NavigationAccessControl {
+
+    public CustomNavigationAccessControl() {
+        super(List.of(new AnnotatedViewAccessChecker()), new DefaultAccessCheckDecisionResolver());
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/CustomNavigationAccessControl.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/CustomNavigationAccessControl.java
@@ -25,6 +25,8 @@ import com.vaadin.flow.server.auth.NavigationAccessControl;
 /**
  * Replaces the extension provided access control and builds its checker
  * itself, so that the checker is out of reach of the configuration.
+ * <p></p>
+ * Turning the access control off has to work for this bean as well.
  */
 @Singleton
 public class CustomNavigationAccessControl extends NavigationAccessControl {

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlCustomBeanTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlCustomBeanTest.java
@@ -34,6 +34,7 @@ class NavigationAccessControlCustomBeanTest {
             .withConfigurationResource(
                     TestUtils.class.getPackageName().replace('.', '/') + "/test-application.properties")
             .overrideConfigKey("quarkus.http.auth.form.enabled", "true")
+            .overrideConfigKey("quarkus.http.auth.form.login-page", "/login")
             .overrideConfigKey("vaadin.security.navigation-access-control.enabled", "false")
             .overrideConfigKey("quarkus.http.test-port", "0")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlCustomBeanTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlCustomBeanTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.security;
+
+import java.util.logging.Level;
+
+import com.vaadin.flow.server.auth.NavigationAccessControl;
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusExtensionTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.mcollovati.quarkus.hilla.deployment.TestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NavigationAccessControlCustomBeanTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withConfigurationResource(
+                    TestUtils.class.getPackageName().replace('.', '/') + "/test-application.properties")
+            .overrideConfigKey("quarkus.http.auth.form.enabled", "true")
+            .overrideConfigKey("vaadin.security.navigation-access-control.enabled", "false")
+            .overrideConfigKey("quarkus.http.test-port", "0")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestUtils.class, CustomNavigationAccessControl.class))
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
+            .assertLogRecords(records -> assertThat(records)
+                    .as("expected a warning about the checker the setting cannot reach")
+                    .anySatisfy(record -> assertThat(record.getMessage())
+                            .contains("provides an AnnotatedViewAccessChecker of its own")));
+
+    @Test
+    void customAccessControl_replacesTheDefaultBean() {
+        NavigationAccessControl accessControl =
+                Arc.container().instance(NavigationAccessControl.class).get();
+
+        assertThat(accessControl).isInstanceOf(CustomNavigationAccessControl.class);
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlCustomBeanTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlCustomBeanTest.java
@@ -15,8 +15,6 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.security;
 
-import java.util.logging.Level;
-
 import com.vaadin.flow.server.auth.NavigationAccessControl;
 import io.quarkus.arc.Arc;
 import io.quarkus.test.QuarkusExtensionTest;
@@ -39,18 +37,14 @@ class NavigationAccessControlCustomBeanTest {
             .overrideConfigKey("vaadin.security.navigation-access-control.enabled", "false")
             .overrideConfigKey("quarkus.http.test-port", "0")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(TestUtils.class, CustomNavigationAccessControl.class))
-            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
-            .assertLogRecords(records -> assertThat(records)
-                    .as("expected a warning about the checker the setting cannot reach")
-                    .anySatisfy(record -> assertThat(record.getMessage())
-                            .contains("provides an AnnotatedViewAccessChecker of its own")));
+                    .addClasses(TestUtils.class, CustomNavigationAccessControl.class));
 
     @Test
-    void customAccessControl_replacesTheDefaultBean() {
+    void customAccessControl_turnedOffAsWell() {
         NavigationAccessControl accessControl =
                 Arc.container().instance(NavigationAccessControl.class).get();
 
         assertThat(accessControl).isInstanceOf(CustomNavigationAccessControl.class);
+        assertThat(accessControl.isEnabled()).isFalse();
     }
 }

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlDisabledTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlDisabledTest.java
@@ -15,6 +15,8 @@
  */
 package com.github.mcollovati.quarkus.hilla.deployment.security;
 
+import java.util.logging.Level;
+
 import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
 import io.quarkus.arc.Arc;
 import io.quarkus.test.QuarkusExtensionTest;
@@ -37,7 +39,12 @@ class NavigationAccessControlDisabledTest {
             .overrideConfigKey("quarkus.http.auth.form.enabled", "true")
             .overrideConfigKey("vaadin.security.navigation-access-control.enabled", "false")
             .overrideConfigKey("quarkus.http.test-port", "0")
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(TestUtils.class));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(TestUtils.class))
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
+            .assertLogRecords(records -> assertThat(records)
+                    .as("expected a warning that view access checking is off")
+                    .anySatisfy(record ->
+                            assertThat(record.getMessage()).contains("Flow view access checking is turned off")));
 
     @Test
     void navigationAccessControlDisabled_accessControlTurnedOff() {

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlDisabledTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlDisabledTest.java
@@ -40,12 +40,14 @@ class NavigationAccessControlDisabledTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(TestUtils.class));
 
     @Test
-    void navigationAccessControlDisabled_noAnnotatedViewAccessChecker() {
+    void navigationAccessControlDisabled_accessControlTurnedOff() {
         QuarkusNavigationAccessControl accessControl =
                 Arc.container().instance(QuarkusNavigationAccessControl.class).get();
 
         assertThat(accessControl).isNotNull();
+        assertThat(accessControl.isEnabled()).isFalse();
+        // The checker stays registered, only the access control is turned off.
         assertThat(accessControl.hasAccessChecker(AnnotatedViewAccessChecker.class))
-                .isFalse();
+                .isTrue();
     }
 }

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlDisabledTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlDisabledTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.security;
+
+import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusExtensionTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.mcollovati.quarkus.hilla.deployment.TestUtils;
+import com.github.mcollovati.quarkus.hilla.security.QuarkusNavigationAccessControl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NavigationAccessControlDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withConfigurationResource(
+                    TestUtils.class.getPackageName().replace('.', '/') + "/test-application.properties")
+            .overrideConfigKey("quarkus.http.auth.form.enabled", "true")
+            .overrideConfigKey("vaadin.security.navigation-access-control.enabled", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(TestUtils.class));
+
+    @Test
+    void navigationAccessControlDisabled_noAnnotatedViewAccessChecker() {
+        QuarkusNavigationAccessControl accessControl =
+                Arc.container().instance(QuarkusNavigationAccessControl.class).get();
+
+        assertThat(accessControl).isNotNull();
+        assertThat(accessControl.hasAccessChecker(AnnotatedViewAccessChecker.class))
+                .isFalse();
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlDisabledTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlDisabledTest.java
@@ -36,6 +36,7 @@ class NavigationAccessControlDisabledTest {
                     TestUtils.class.getPackageName().replace('.', '/') + "/test-application.properties")
             .overrideConfigKey("quarkus.http.auth.form.enabled", "true")
             .overrideConfigKey("vaadin.security.navigation-access-control.enabled", "false")
+            .overrideConfigKey("quarkus.http.test-port", "0")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(TestUtils.class));
 
     @Test

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlEnabledTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlEnabledTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mcollovati.quarkus.hilla.deployment.security;
+
+import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusExtensionTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.mcollovati.quarkus.hilla.deployment.TestUtils;
+import com.github.mcollovati.quarkus.hilla.security.QuarkusNavigationAccessControl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NavigationAccessControlEnabledTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .withConfigurationResource(
+                    TestUtils.class.getPackageName().replace('.', '/') + "/test-application.properties")
+            .overrideConfigKey("quarkus.http.auth.form.enabled", "true")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(TestUtils.class));
+
+    @Test
+    void formAuthentication_annotatedViewAccessCheckerInstalledByDefault() {
+        QuarkusNavigationAccessControl accessControl =
+                Arc.container().instance(QuarkusNavigationAccessControl.class).get();
+
+        assertThat(accessControl).isNotNull();
+        assertThat(accessControl.hasAccessChecker(AnnotatedViewAccessChecker.class))
+                .isTrue();
+    }
+}

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlEnabledTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlEnabledTest.java
@@ -39,11 +39,12 @@ class NavigationAccessControlEnabledTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(TestUtils.class));
 
     @Test
-    void formAuthentication_annotatedViewAccessCheckerInstalledByDefault() {
+    void formAuthentication_accessControlEnabledByDefault() {
         QuarkusNavigationAccessControl accessControl =
                 Arc.container().instance(QuarkusNavigationAccessControl.class).get();
 
         assertThat(accessControl).isNotNull();
+        assertThat(accessControl.isEnabled()).isTrue();
         assertThat(accessControl.hasAccessChecker(AnnotatedViewAccessChecker.class))
                 .isTrue();
     }

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlEnabledTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/NavigationAccessControlEnabledTest.java
@@ -35,6 +35,7 @@ class NavigationAccessControlEnabledTest {
             .withConfigurationResource(
                     TestUtils.class.getPackageName().replace('.', '/') + "/test-application.properties")
             .overrideConfigKey("quarkus.http.auth.form.enabled", "true")
+            .overrideConfigKey("quarkus.http.test-port", "0")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(TestUtils.class));
 
     @Test

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessorTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessorTest.java
@@ -17,10 +17,15 @@ package com.github.mcollovati.quarkus.hilla.deployment.security;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import org.jboss.jandex.DotName;
 import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.hilla.security.QuarkusNavigationAccessControl;
+import com.github.mcollovati.quarkus.hilla.security.VaadinSecurityConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,13 +34,84 @@ class QuarkusHillaSecurityProcessorTest {
     @Test
     void formAuthentication_registersAnnotatedCheckerForDefaultDeny() {
         List<NavigationAccessCheckerBuildItem> accessCheckers = new ArrayList<>();
+        List<AdditionalBeanBuildItem> beans = new ArrayList<>();
 
         new QuarkusHillaSecurityProcessor()
                 .registerNavigationAccessControl(
-                        new AuthFormBuildItem(true), ignored -> {}, ignored -> {}, accessCheckers::add);
+                        new AuthFormBuildItem(true),
+                        securityConfig(true),
+                        beans::add,
+                        ignored -> {},
+                        accessCheckers::add);
 
         assertThat(accessCheckers)
                 .extracting(NavigationAccessCheckerBuildItem::getAccessChecker)
                 .containsExactly(DotName.createSimple(AnnotatedViewAccessChecker.class));
+        assertThat(beans)
+                .flatExtracting(AdditionalBeanBuildItem::getBeanClasses)
+                .contains(QuarkusNavigationAccessControl.class.getName());
+    }
+
+    @Test
+    void navigationAccessControlDisabled_registersNoCheckerButKeepsAccessControl() {
+        List<NavigationAccessCheckerBuildItem> accessCheckers = new ArrayList<>();
+        List<AdditionalBeanBuildItem> beans = new ArrayList<>();
+
+        new QuarkusHillaSecurityProcessor()
+                .registerNavigationAccessControl(
+                        new AuthFormBuildItem(true),
+                        securityConfig(false),
+                        beans::add,
+                        ignored -> {},
+                        accessCheckers::add);
+
+        assertThat(accessCheckers).isEmpty();
+        // HillaSecurityPolicy injects NavigationAccessControl, so the bean must
+        // stay registered even when access checking is disabled.
+        assertThat(beans)
+                .flatExtracting(AdditionalBeanBuildItem::getBeanClasses)
+                .contains(QuarkusNavigationAccessControl.class.getName());
+    }
+
+    @Test
+    void formAuthenticationDisabled_registersNoChecker() {
+        List<NavigationAccessCheckerBuildItem> accessCheckers = new ArrayList<>();
+        List<AdditionalBeanBuildItem> beans = new ArrayList<>();
+
+        new QuarkusHillaSecurityProcessor()
+                .registerNavigationAccessControl(
+                        new AuthFormBuildItem(false),
+                        securityConfig(true),
+                        beans::add,
+                        ignored -> {},
+                        accessCheckers::add);
+
+        assertThat(accessCheckers).isEmpty();
+        assertThat(beans).isEmpty();
+    }
+
+    private static VaadinSecurityConfig securityConfig(boolean navigationAccessControlEnabled) {
+        return new VaadinSecurityConfig() {
+
+            @Override
+            public String logoutPath() {
+                return "/logout";
+            }
+
+            @Override
+            public Optional<String> postLogoutRedirectUri() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean logoutInvalidateSession() {
+                return true;
+            }
+
+            @Override
+            public NavigationAccessControlConfig navigationAccessControl() {
+                return () -> navigationAccessControlEnabled;
+            }
+        };
     }
 }

--- a/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessorTest.java
+++ b/commons/deployment/src/test/java/com/github/mcollovati/quarkus/hilla/deployment/security/QuarkusHillaSecurityProcessorTest.java
@@ -17,7 +17,6 @@ package com.github.mcollovati.quarkus.hilla.deployment.security;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -25,7 +24,6 @@ import org.jboss.jandex.DotName;
 import org.junit.jupiter.api.Test;
 
 import com.github.mcollovati.quarkus.hilla.security.QuarkusNavigationAccessControl;
-import com.github.mcollovati.quarkus.hilla.security.VaadinSecurityConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,11 +36,7 @@ class QuarkusHillaSecurityProcessorTest {
 
         new QuarkusHillaSecurityProcessor()
                 .registerNavigationAccessControl(
-                        new AuthFormBuildItem(true),
-                        securityConfig(true),
-                        beans::add,
-                        ignored -> {},
-                        accessCheckers::add);
+                        new AuthFormBuildItem(true), beans::add, ignored -> {}, accessCheckers::add);
 
         assertThat(accessCheckers)
                 .extracting(NavigationAccessCheckerBuildItem::getAccessChecker)
@@ -53,65 +47,15 @@ class QuarkusHillaSecurityProcessorTest {
     }
 
     @Test
-    void navigationAccessControlDisabled_registersNoCheckerButKeepsAccessControl() {
+    void formAuthenticationDisabled_registersNothing() {
         List<NavigationAccessCheckerBuildItem> accessCheckers = new ArrayList<>();
         List<AdditionalBeanBuildItem> beans = new ArrayList<>();
 
         new QuarkusHillaSecurityProcessor()
                 .registerNavigationAccessControl(
-                        new AuthFormBuildItem(true),
-                        securityConfig(false),
-                        beans::add,
-                        ignored -> {},
-                        accessCheckers::add);
-
-        assertThat(accessCheckers).isEmpty();
-        // HillaSecurityPolicy injects NavigationAccessControl, so the bean must
-        // stay registered even when access checking is disabled.
-        assertThat(beans)
-                .flatExtracting(AdditionalBeanBuildItem::getBeanClasses)
-                .contains(QuarkusNavigationAccessControl.class.getName());
-    }
-
-    @Test
-    void formAuthenticationDisabled_registersNoChecker() {
-        List<NavigationAccessCheckerBuildItem> accessCheckers = new ArrayList<>();
-        List<AdditionalBeanBuildItem> beans = new ArrayList<>();
-
-        new QuarkusHillaSecurityProcessor()
-                .registerNavigationAccessControl(
-                        new AuthFormBuildItem(false),
-                        securityConfig(true),
-                        beans::add,
-                        ignored -> {},
-                        accessCheckers::add);
+                        new AuthFormBuildItem(false), beans::add, ignored -> {}, accessCheckers::add);
 
         assertThat(accessCheckers).isEmpty();
         assertThat(beans).isEmpty();
-    }
-
-    private static VaadinSecurityConfig securityConfig(boolean navigationAccessControlEnabled) {
-        return new VaadinSecurityConfig() {
-
-            @Override
-            public String logoutPath() {
-                return "/logout";
-            }
-
-            @Override
-            public Optional<String> postLogoutRedirectUri() {
-                return Optional.empty();
-            }
-
-            @Override
-            public boolean logoutInvalidateSession() {
-                return true;
-            }
-
-            @Override
-            public NavigationAccessControlConfig navigationAccessControl() {
-                return () -> navigationAccessControlEnabled;
-            }
-        };
     }
 }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityRecorder.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityRecorder.java
@@ -18,6 +18,7 @@ package com.github.mcollovati.quarkus.hilla.security;
 import java.util.function.Supplier;
 
 import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.server.auth.NavigationAccessControl;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.annotations.Recorder;
@@ -25,6 +26,7 @@ import io.quarkus.vertx.http.runtime.security.FormAuthenticationMechanism;
 import io.smallrye.config.SmallRyeConfig;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.slf4j.LoggerFactory;
 
 import com.github.mcollovati.quarkus.hilla.QuarkusHillaExtension;
 
@@ -56,9 +58,21 @@ public class HillaSecurityRecorder {
         markSecurityPolicyUsed();
     }
 
-    public void configureNavigationAccessControl(BeanContainer container, String loginPath) {
-        QuarkusNavigationAccessControl accessChecker = container.beanInstance(QuarkusNavigationAccessControl.class);
-        accessChecker.setLoginView(loginPath);
+    public void configureNavigationAccessControl(BeanContainer container, String loginPath, boolean enabled) {
+        // Resolved by base type, an application may provide its own bean.
+        NavigationAccessControl accessControl = container.beanInstance(NavigationAccessControl.class);
+        if (loginPath != null) {
+            accessControl.setLoginView(loginPath);
+        }
+        if (!enabled) {
+            // Never turns the access control on, an application disabling its
+            // own bean keeps that state.
+            accessControl.setEnabled(false);
+            LoggerFactory.getLogger(HillaSecurityRecorder.class)
+                    .warn("Flow view access checking is turned off by "
+                            + "vaadin.security.navigation-access-control.enabled=false. Every Flow view is "
+                            + "reachable regardless of its access annotations.");
+        }
     }
 
     /**

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityRecorder.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/HillaSecurityRecorder.java
@@ -62,7 +62,18 @@ public class HillaSecurityRecorder {
         // Resolved by base type, an application may provide its own bean.
         NavigationAccessControl accessControl = container.beanInstance(NavigationAccessControl.class);
         if (loginPath != null) {
-            accessControl.setLoginView(loginPath);
+            // The login view can be set only once and an application bean is
+            // free to set its own, so only ours is configured from the Quarkus
+            // form login settings.
+            if (accessControl instanceof QuarkusNavigationAccessControl) {
+                accessControl.setLoginView(loginPath);
+            } else {
+                LoggerFactory.getLogger(HillaSecurityRecorder.class)
+                        .debug(
+                                "quarkus.http.auth.form.login-page is not applied to {}, an application provided "
+                                        + "navigation access control configures its login view itself.",
+                                accessControl.getClass().getName());
+            }
         }
         if (!enabled) {
             // Never turns the access control on, an application disabling its

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/QuarkusNavigationAccessControl.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/QuarkusNavigationAccessControl.java
@@ -25,14 +25,11 @@ import java.util.function.Predicate;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.auth.AccessCheckDecisionResolver;
-import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
 import com.vaadin.flow.server.auth.NavigationAccessChecker;
 import com.vaadin.flow.server.auth.NavigationAccessControl;
 import io.quarkus.arc.All;
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.security.identity.SecurityIdentity;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Singleton
 @DefaultBean
@@ -77,28 +74,14 @@ public class QuarkusNavigationAccessControl extends NavigationAccessControl {
         }
 
         void installViewAccessChecker(@Observes ServiceInitEvent event) {
-            warnIfAccessCheckCannotBeTurnedOff();
+            // Only ever turns the access control off, so that an application
+            // providing its own NavigationAccessControl keeps whatever it
+            // configured on it.
+            if (!securityConfig.navigationAccessControl().enabled()) {
+                accessControl.setEnabled(false);
+            }
             event.getSource()
                     .addUIInitListener(uiInitEvent -> uiInitEvent.getUI().addBeforeEnterListener(accessControl));
-        }
-
-        private void warnIfAccessCheckCannotBeTurnedOff() {
-            // The setting removes the checker this extension registers. An
-            // application bringing its own NavigationAccessControl may hold a
-            // checker the setting cannot reach.
-            if (!securityConfig.navigationAccessControl().enabled()
-                    && accessControl.hasAccessChecker(AnnotatedViewAccessChecker.class)) {
-                getLogger()
-                        .warn(
-                                "vaadin.security.navigation-access-control.enabled is false, but {} provides an "
-                                        + "AnnotatedViewAccessChecker of its own. Flow views are still checked "
-                                        + "against their access annotations.",
-                                accessControl.getClass().getName());
-            }
-        }
-
-        private Logger getLogger() {
-            return LoggerFactory.getLogger(getClass());
         }
     }
 }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/QuarkusNavigationAccessControl.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/QuarkusNavigationAccessControl.java
@@ -65,21 +65,13 @@ public class QuarkusNavigationAccessControl extends NavigationAccessControl {
     public static class Installer {
 
         private final NavigationAccessControl accessControl;
-        private final VaadinSecurityConfig securityConfig;
 
         @Inject
-        public Installer(NavigationAccessControl accessControl, VaadinSecurityConfig securityConfig) {
+        public Installer(NavigationAccessControl accessControl) {
             this.accessControl = accessControl;
-            this.securityConfig = securityConfig;
         }
 
         void installViewAccessChecker(@Observes ServiceInitEvent event) {
-            // Only ever turns the access control off, so that an application
-            // providing its own NavigationAccessControl keeps whatever it
-            // configured on it.
-            if (!securityConfig.navigationAccessControl().enabled()) {
-                accessControl.setEnabled(false);
-            }
             event.getSource()
                     .addUIInitListener(uiInitEvent -> uiInitEvent.getUI().addBeforeEnterListener(accessControl));
         }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/QuarkusNavigationAccessControl.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/QuarkusNavigationAccessControl.java
@@ -25,11 +25,14 @@ import java.util.function.Predicate;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.auth.AccessCheckDecisionResolver;
+import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
 import com.vaadin.flow.server.auth.NavigationAccessChecker;
 import com.vaadin.flow.server.auth.NavigationAccessControl;
 import io.quarkus.arc.All;
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.security.identity.SecurityIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 @DefaultBean
@@ -65,15 +68,37 @@ public class QuarkusNavigationAccessControl extends NavigationAccessControl {
     public static class Installer {
 
         private final NavigationAccessControl accessControl;
+        private final VaadinSecurityConfig securityConfig;
 
         @Inject
-        public Installer(NavigationAccessControl accessControl) {
+        public Installer(NavigationAccessControl accessControl, VaadinSecurityConfig securityConfig) {
             this.accessControl = accessControl;
+            this.securityConfig = securityConfig;
         }
 
         void installViewAccessChecker(@Observes ServiceInitEvent event) {
+            warnIfAccessCheckCannotBeTurnedOff();
             event.getSource()
                     .addUIInitListener(uiInitEvent -> uiInitEvent.getUI().addBeforeEnterListener(accessControl));
+        }
+
+        private void warnIfAccessCheckCannotBeTurnedOff() {
+            // The setting removes the checker this extension registers. An
+            // application bringing its own NavigationAccessControl may hold a
+            // checker the setting cannot reach.
+            if (!securityConfig.navigationAccessControl().enabled()
+                    && accessControl.hasAccessChecker(AnnotatedViewAccessChecker.class)) {
+                getLogger()
+                        .warn(
+                                "vaadin.security.navigation-access-control.enabled is false, but {} provides an "
+                                        + "AnnotatedViewAccessChecker of its own. Flow views are still checked "
+                                        + "against their access annotations.",
+                                accessControl.getClass().getName());
+            }
+        }
+
+        private Logger getLogger() {
+            return LoggerFactory.getLogger(getClass());
         }
     }
 }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/VaadinSecurityConfig.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/VaadinSecurityConfig.java
@@ -69,27 +69,22 @@ public interface VaadinSecurityConfig {
     interface NavigationAccessControlConfig {
 
         /**
-         * Whether Flow navigation access control is enabled.
+         * Whether access to Flow views is checked.
          * <p></p>
-         * When enabled, Flow views are checked against their access annotations
-         * ({@code @AnonymousAllowed}, {@code @PermitAll}, {@code @RolesAllowed},
-         * {@code @DenyAll}), including annotations inherited from parent layouts.
-         * Following Vaadin defaults, a view without any of these annotations is
-         * denied.
+         * A view is shown when it, or a layout it uses, carries
+         * {@code @AnonymousAllowed}, {@code @PermitAll} or {@code @RolesAllowed}
+         * and the current user matches. A view without any access annotation is
+         * not shown, which is the Vaadin default.
          * <p></p>
-         * Disabling this setting removes navigation access control completely.
-         * Flow views are then reachable regardless of their access annotations,
-         * and only the Quarkus HTTP security policies apply. Those policies
-         * cannot protect client side navigation within the single page
-         * application, so disabling this setting leaves Flow views unprotected.
+         * When set to {@literal false}, every Flow view becomes reachable and
+         * the access annotations stop having any effect. Only use this to buy
+         * time for adding the missing annotations.
          * <p></p>
-         * Access control is only installed when an authentication mechanism is
-         * configured, so this setting has no effect on applications without
-         * security.
+         * Applications without an authentication mechanism are not affected.
          * <p></p>
          * Defaults to {@literal true}.
          *
-         * @return whether navigation access control is enabled.
+         * @return whether access to Flow views is checked.
          */
         @WithDefault("true")
         boolean enabled();

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/VaadinSecurityConfig.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/VaadinSecurityConfig.java
@@ -55,4 +55,43 @@ public interface VaadinSecurityConfig {
      */
     @WithDefault("true")
     boolean logoutInvalidateSession();
+
+    /**
+     * Configuration of the Vaadin navigation access control.
+     *
+     * @return navigation access control configuration.
+     */
+    NavigationAccessControlConfig navigationAccessControl();
+
+    /**
+     * Configuration properties for the Vaadin navigation access control.
+     */
+    interface NavigationAccessControlConfig {
+
+        /**
+         * Whether Flow navigation access control is enabled.
+         * <p></p>
+         * When enabled, Flow views are checked against their access annotations
+         * ({@code @AnonymousAllowed}, {@code @PermitAll}, {@code @RolesAllowed},
+         * {@code @DenyAll}), including annotations inherited from parent layouts.
+         * Following Vaadin defaults, a view without any of these annotations is
+         * denied.
+         * <p></p>
+         * Disabling this setting removes navigation access control completely.
+         * Flow views are then reachable regardless of their access annotations,
+         * and only the Quarkus HTTP security policies apply. Those policies
+         * cannot protect client side navigation within the single page
+         * application, so disabling this setting leaves Flow views unprotected.
+         * <p></p>
+         * Access control is only installed when an authentication mechanism is
+         * configured, so this setting has no effect on applications without
+         * security.
+         * <p></p>
+         * Defaults to {@literal true}.
+         *
+         * @return whether navigation access control is enabled.
+         */
+        @WithDefault("true")
+        boolean enabled();
+    }
 }

--- a/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/VaadinSecurityConfig.java
+++ b/commons/runtime/src/main/java/com/github/mcollovati/quarkus/hilla/security/VaadinSecurityConfig.java
@@ -57,30 +57,33 @@ public interface VaadinSecurityConfig {
     boolean logoutInvalidateSession();
 
     /**
-     * Configuration of the Vaadin navigation access control.
+     * Settings for the access check on Flow views.
      *
-     * @return navigation access control configuration.
+     * @return the navigation access control settings.
      */
     NavigationAccessControlConfig navigationAccessControl();
 
     /**
-     * Configuration properties for the Vaadin navigation access control.
+     * Settings for the access check on Flow views.
      */
     interface NavigationAccessControlConfig {
 
         /**
          * Whether access to Flow views is checked.
          * <p></p>
-         * A view is shown when it, or a layout it uses, carries
-         * {@code @AnonymousAllowed}, {@code @PermitAll} or {@code @RolesAllowed}
-         * and the current user matches. A view without any access annotation is
-         * not shown, which is the Vaadin default.
+         * Each view needs an annotation that says who may open it, either on
+         * the view or on a layout the view uses: {@code @AnonymousAllowed} for
+         * everyone, {@code @PermitAll} for logged-in users,
+         * {@code @RolesAllowed} for the given roles, {@code @DenyAll} for
+         * nobody. A view with no annotation is not shown, which is the Vaadin
+         * default.
          * <p></p>
-         * When set to {@literal false}, every Flow view becomes reachable and
-         * the access annotations stop having any effect. Only use this to buy
-         * time for adding the missing annotations.
+         * Set to {@literal false} to skip the check for all views. Then anyone
+         * who can open the application can open every Flow view, and the
+         * annotations do nothing. Use this while adding the missing
+         * annotations, not as a permanent setting.
          * <p></p>
-         * Applications without an authentication mechanism are not affected.
+         * Applications without authentication are not affected.
          * <p></p>
          * Defaults to {@literal true}.
          *

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,9 +88,9 @@ vaadin.security.navigation-access-control.enabled=false
 > only cover the first page load. After that the browser switches views on its own. Use this
 > while you add the missing annotations, not as a permanent setting.
 
-The setting removes the access checker that this extension registers. An application that
-provides its own `NavigationAccessControl` bean and builds the checker itself keeps checking
-views; a warning is logged at startup when that happens.
+The setting turns off the `NavigationAccessControl` at startup, so it also applies to an
+application that provides its own bean. Nothing is turned on: when the setting is `true`, an
+access control that the application disabled itself stays disabled.
 
 <a id="copilot"></a>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,24 +31,25 @@ See [Endpoints Live Reload](features.md#endpoints-live-reload) for how the featu
 | `vaadin.security.logout-path`                            | String  | `/logout` | Path of the logout HTTP POST endpoint handling logout requests.                                |
 | `vaadin.security.post-logout-redirect-uri`               | String  | -         | URI to redirect to after successful logout.                                                    |
 | `vaadin.security.logout-invalidate-session`              | Boolean | `true`    | Whether HTTP session should be invalidated on logout.                                          |
-| `vaadin.security.navigation-access-control.enabled`      | Boolean | `true`    | Whether Flow navigation access control is enabled. See [Navigation Access Control](#navigation-access-control). |
+| `vaadin.security.navigation-access-control.enabled`      | Boolean | `true`    | Whether access to Flow views is checked. See [Route Security](#route-security).                |
 
-<a id="navigation-access-control"></a>
+<a id="route-security"></a>
 
-### Navigation Access Control
+### Route Security
 
-![Since 25.3.0](https://flat.badgen.net/static/Since/25.3.0/007bff?scale=1.1)
+![Since 25.1.5](https://flat.badgen.net/static/Since/25.1.5/007bff?scale=1.1)
 
-When an authentication mechanism is configured, the extension installs Vaadin's
-`NavigationAccessControl` with the `AnnotatedViewAccessChecker`. Flow views are then checked
-against their access annotations, including annotations inherited from parent layouts:
+Also available in 25.2.2 and 25.3.0 or later.
 
-- `@AnonymousAllowed`, `@PermitAll`, `@RolesAllowed` grant access
-- `@DenyAll` denies access
-- a view **without** any of these annotations is **denied**, following the Vaadin default
+In a secured application, every Flow view has to say who may see it. Add one of these
+annotations to the view, or to a layout it uses:
 
-The last point is what applications usually run into. If a Flow view is unexpectedly
-inaccessible, add an explicit annotation to the view or to its layout:
+| Annotation          | Who gets in            |
+|---------------------|------------------------|
+| `@AnonymousAllowed` | everyone, no login     |
+| `@PermitAll`        | any logged-in user     |
+| `@RolesAllowed`     | users with those roles |
+| `@DenyAll`          | nobody                 |
 
 ```java
 @Route("dashboard")
@@ -57,22 +58,26 @@ public class DashboardView extends VerticalLayout {
 }
 ```
 
-Applications without security are unaffected — access control is only installed when an
-authentication mechanism is configured.
+**A view without any of these annotations is not shown.** This is the Vaadin default: a view
+that never says who may see it is treated as not ready to be public, rather than open to
+everyone. So if a view is unexpectedly unreachable, the usual cause is a missing annotation.
 
-#### Opting out
+Applications without an authentication mechanism are not affected — nothing is checked there.
 
-Set the property to `false` to remove navigation access control completely:
+#### Turning the check off
+
+If adding the annotations takes time, the check can be turned off for the whole application:
 
 ```properties
 vaadin.security.navigation-access-control.enabled=false
 ```
 
 > [!WARNING]
-> Flow views are then reachable regardless of their access annotations. Only the Quarkus HTTP
-> security policies (`quarkus.http.auth.permission.*`) still apply, and those cannot protect
-> client side navigation within the single page application — they only cover the initial page
-> load. Treat this as a temporary migration aid, not a permanent setting.
+> With this setting, every Flow view is reachable by anyone who can reach the application, and
+> `@RolesAllowed` and friends stop having any effect. The `quarkus.http.auth.permission.*`
+> rules still apply, but they only cover the initial page load — once the application is open in
+> the browser, users move between views without them. Use this to buy time for a migration, not
+> as a permanent setting.
 
 <a id="copilot"></a>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,10 +39,10 @@ See [Endpoints Live Reload](features.md#endpoints-live-reload) for how the featu
 
 ![Since 25.1.5](https://flat.badgen.net/static/Since/25.1.5/007bff?scale=1.1)
 
-Also available in 25.2.2 and 25.3.0 or later.
+Also in 25.2.2 and 25.3.0 or later.
 
-In a secured application, every Flow view has to say who may see it. Add one of these
-annotations to the view, or to a layout it uses:
+In a secured application, each Flow view needs an annotation that says who may open it. Put it
+on the view, or on a layout the view uses:
 
 | Annotation          | Who gets in            |
 |---------------------|------------------------|
@@ -58,26 +58,24 @@ public class DashboardView extends VerticalLayout {
 }
 ```
 
-**A view without any of these annotations is not shown.** This is the Vaadin default: a view
-that never says who may see it is treated as not ready to be public, rather than open to
-everyone. So if a view is unexpectedly unreachable, the usual cause is a missing annotation.
+**A view with no annotation is not shown.** That is the Vaadin default. If a view is suddenly
+unreachable, a missing annotation is the most likely cause.
 
-Applications without an authentication mechanism are not affected — nothing is checked there.
+Applications without authentication are not affected. Nothing is checked there.
 
 #### Turning the check off
 
-If adding the annotations takes time, the check can be turned off for the whole application:
+Set the property to `false` to skip the check for all views:
 
 ```properties
 vaadin.security.navigation-access-control.enabled=false
 ```
 
 > [!WARNING]
-> With this setting, every Flow view is reachable by anyone who can reach the application, and
-> `@RolesAllowed` and friends stop having any effect. The `quarkus.http.auth.permission.*`
-> rules still apply, but they only cover the initial page load — once the application is open in
-> the browser, users move between views without them. Use this to buy time for a migration, not
-> as a permanent setting.
+> Then anyone who can open the application can open every Flow view, and `@RolesAllowed` and the
+> other annotations do nothing. The `quarkus.http.auth.permission.*` rules still work, but they
+> only cover the first page load. After that the browser switches views on its own. Use this
+> while you add the missing annotations, not as a permanent setting.
 
 <a id="copilot"></a>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,11 @@ Applications without authentication are not affected. Nothing is checked there.
 
 #### Turning the check off
 
+Views became unreachable after an upgrade to 25.1.4 or 25.2.1? Those releases started checking
+views that were never checked before, so an application that has no access annotations at all
+loses every view at once. Turn the check off to get back to the old behavior, then add the
+annotations and turn it on again.
+
 Set the property to `false` to skip the check for all views:
 
 ```properties

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,6 +88,10 @@ vaadin.security.navigation-access-control.enabled=false
 > only cover the first page load. After that the browser switches views on its own. Use this
 > while you add the missing annotations, not as a permanent setting.
 
+The setting removes the access checker that this extension registers. An application that
+provides its own `NavigationAccessControl` bean and builds the checker itself keeps checking
+views; a warning is logged at startup when that happens.
+
 <a id="copilot"></a>
 
 ## ✨ Copilot

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,11 +26,53 @@ See [Endpoints Live Reload](features.md#endpoints-live-reload) for how the featu
 
 ## 🔒 Security
 
-| Property                                    | Type    | Default   | Description                                                     |
-|---------------------------------------------|---------|-----------|-----------------------------------------------------------------|
-| `vaadin.security.logout-path`               | String  | `/logout` | Path of the logout HTTP POST endpoint handling logout requests. |
-| `vaadin.security.post-logout-redirect-uri`  | String  | -         | URI to redirect to after successful logout.                     |
-| `vaadin.security.logout-invalidate-session` | Boolean | `true`    | Whether HTTP session should be invalidated on logout.           |
+| Property                                                 | Type    | Default   | Description                                                                                    |
+|----------------------------------------------------------|---------|-----------|--------------------------------------------------------------------------------------------------|
+| `vaadin.security.logout-path`                            | String  | `/logout` | Path of the logout HTTP POST endpoint handling logout requests.                                |
+| `vaadin.security.post-logout-redirect-uri`               | String  | -         | URI to redirect to after successful logout.                                                    |
+| `vaadin.security.logout-invalidate-session`              | Boolean | `true`    | Whether HTTP session should be invalidated on logout.                                          |
+| `vaadin.security.navigation-access-control.enabled`      | Boolean | `true`    | Whether Flow navigation access control is enabled. See [Navigation Access Control](#navigation-access-control). |
+
+<a id="navigation-access-control"></a>
+
+### Navigation Access Control
+
+![Since 25.3.0](https://flat.badgen.net/static/Since/25.3.0/007bff?scale=1.1)
+
+When an authentication mechanism is configured, the extension installs Vaadin's
+`NavigationAccessControl` with the `AnnotatedViewAccessChecker`. Flow views are then checked
+against their access annotations, including annotations inherited from parent layouts:
+
+- `@AnonymousAllowed`, `@PermitAll`, `@RolesAllowed` grant access
+- `@DenyAll` denies access
+- a view **without** any of these annotations is **denied**, following the Vaadin default
+
+The last point is what applications usually run into. If a Flow view is unexpectedly
+inaccessible, add an explicit annotation to the view or to its layout:
+
+```java
+@Route("dashboard")
+@PermitAll
+public class DashboardView extends VerticalLayout {
+}
+```
+
+Applications without security are unaffected — access control is only installed when an
+authentication mechanism is configured.
+
+#### Opting out
+
+Set the property to `false` to remove navigation access control completely:
+
+```properties
+vaadin.security.navigation-access-control.enabled=false
+```
+
+> [!WARNING]
+> Flow views are then reachable regardless of their access annotations. Only the Quarkus HTTP
+> security policies (`quarkus.http.auth.permission.*`) still apply, and those cannot protect
+> client side navigation within the single page application — they only cover the initial page
+> load. Treat this as a temporary migration aid, not a permanent setting.
 
 <a id="copilot"></a>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,9 +76,7 @@ Applications without authentication are not affected. Nothing is checked there.
 > annotations at all loses every view at once. Turn the check off to get back to the old
 > behavior, then add the annotations and turn it on again.
 
-Set the property to `false` to skip the check for all views, then rebuild — like every setting
-here, this one is read at build time and cannot be flipped on an application that is already
-built:
+Set the property to `false` to skip the check for all views, then rebuild:
 
 ```properties
 vaadin.security.navigation-access-control.enabled=false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,10 +65,11 @@ Applications without authentication are not affected. Nothing is checked there.
 
 #### Turning the check off
 
-Views became unreachable after an upgrade to 25.1.4 or 25.2.1? Those releases started checking
-views that were never checked before, so an application that has no access annotations at all
-loses every view at once. Turn the check off to get back to the old behavior, then add the
-annotations and turn it on again.
+> [!IMPORTANT]
+> **Views became unreachable after an upgrade to 25.1.4 or 25.2.1?** Those releases started
+> checking views that were never checked before, so an application that has no access
+> annotations at all loses every view at once. Turn the check off to get back to the old
+> behavior, then add the annotations and turn it on again.
 
 Set the property to `false` to skip the check for all views:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,8 +38,8 @@ See [Endpoints Live Reload](features.md#endpoints-live-reload) for how the featu
 ### Route Security
 
 ![Since 25.1.5](https://flat.badgen.net/static/Since/25.1.5/007bff?scale=1.1)
-
-Also in 25.2.2 and 25.3.0 or later.
+![Since 25.2.2](https://flat.badgen.net/static/Since/25.2.2/007bff?scale=1.1)
+![Since 25.3.0](https://flat.badgen.net/static/Since/25.3.0/007bff?scale=1.1)
 
 In a secured application, each Flow view needs an annotation that says who may open it. Put it
 on the view, or on a layout the view uses:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,11 @@
 
 All Quarkus-Hilla settings go in `application.properties`.
 
+> [!NOTE]
+> Every setting on this page is **fixed at build time**. Changing one means rebuilding the
+> application — setting it as a system property or environment variable on an existing build has
+> no effect. Quarkus keeps the value that was in place when the application was built.
+
 <a id="live-reload"></a>
 
 ## 🔄 Live Reload
@@ -71,7 +76,9 @@ Applications without authentication are not affected. Nothing is checked there.
 > annotations at all loses every view at once. Turn the check off to get back to the old
 > behavior, then add the annotations and turn it on again.
 
-Set the property to `false` to skip the check for all views:
+Set the property to `false` to skip the check for all views, then rebuild — like every setting
+here, this one is read at build time and cannot be flipped on an application that is already
+built:
 
 ```properties
 vaadin.security.navigation-access-control.enabled=false

--- a/integration-tests/security-form-tests/src/test/java/com/example/application/NavigationAccessControlDisabledTest.java
+++ b/integration-tests/security-form-tests/src/test/java/com/example/application/NavigationAccessControlDisabledTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.application;
+
+import java.util.Map;
+
+import com.codeborne.selenide.WebDriverRunner;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.mcollovati.quarkus.testing.AbstractTest;
+
+import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+
+/**
+ * Verifies that Flow views become reachable regardless of their access
+ * annotations when the navigation access control is turned off.
+ */
+@QuarkusTest
+@TestProfile(NavigationAccessControlDisabledTest.DisabledProfile.class)
+class NavigationAccessControlDisabledTest extends AbstractTest {
+
+    public static class DisabledProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("vaadin.security.navigation-access-control.enabled", "false");
+        }
+    }
+
+    @AfterEach
+    void clearBrowser() {
+        WebDriverRunner.clearBrowserCache();
+    }
+
+    @Test
+    void accessControlDisabled_unannotatedFlowView_viewDisplayed() {
+        openAndWait(getTestUrl() + "flow-default-deny", () -> $("vaadin-app-layout"));
+
+        $("vaadin-app-layout").$("h2").shouldHave(text("Flow - Default deny")).shouldBe(visible);
+    }
+
+    @Test
+    void accessControlDisabled_protectedFlowView_viewDisplayedWithoutLogin() {
+        openAndWait(getTestUrl() + "flow-protected", () -> $("vaadin-app-layout"));
+
+        $("vaadin-login-overlay").shouldNot(exist);
+    }
+}


### PR DESCRIPTION
## Context

#2264 removed the incomplete build-time route annotation scan and always registers
`AnnotatedViewAccessChecker` when an authentication mechanism is configured. That restores
Vaadin's default-deny behavior for Flow views and matches `vaadin-spring`, where
`VaadinSecurityConfigurer` installs the same checker and `DefaultAccessCheckDecisionResolver`
denies when all checkers are neutral.

The change shipped in 25.1.4 and 25.2.1. Applications that previously had **no** security
annotation on any `@Route` class kept an empty checker list and were never checked. Those
applications now lose access to every Flow view and have no way to postpone the migration.

## Change

Adds an opt-out:

```properties
vaadin.security.navigation-access-control.enabled=false
```

- default `true` — the strict behavior introduced by #2264 stays the default
- when `false`, the `NavigationAccessControl` is turned off in
  `HillaSecurityRecorder.configureNavigationAccessControl`, next to `setLoginView`, the same way
  `NavigationAccessControlConfigurer.disabled()` works in vaadin-spring
- the checkers stay registered either way, only the access control is switched
- the switch is one-directional: nothing is ever turned on, so an application that disabled its
  own access control keeps that state
- a warning is logged once at startup while view access checking is off

The recorder now resolves the access control by its base type, so both settings also reach a
bean provided by the application. `setLoginView` never reached such a bean before, since our own
bean is a `@DefaultBean` and steps aside.

No behavior change for applications that do not set the property.

The setting is fixed at build time, so turning the check off requires a rebuild. A runtime
variant was attempted — `ConfigPhase.RUN_TIME` plus `setEnabled(false)` on the access control —
but the mapping is not registered in the runtime config (`SRCFG00027: Could not find a mapping
for ...`), with both a nested group and a separate config root, and with an unrelated prefix.
All existing config roots of this extension are `BUILD_AND_RUN_TIME_FIXED`. Worth a separate
look, also because #2207 moves `VaadinSecurityConfig` to `ConfigPhase.RUN_TIME`.

## Why opt-out and not a mode enum

The previous behavior is not worth preserving as a named mode. The build-time scan only
looked at annotations placed directly on indexed `@Route` classes, so it missed:

- access annotations on parent layouts, which `AnnotatedViewAccessChecker` does evaluate
- programmatically registered route targets without `@Route`

In both cases the developer had expressed an access rule and it was silently ignored. It also
behaved as a project-wide toggle: the first annotation anywhere enabled checking for all views,
the last one removed opened all of them.

The property is therefore a migration aid, not a supported alternative behavior.

## Scope

Not included, deliberately:

- decoupling access control from `quarkus.http.auth.form.enabled`, so that OIDC, JWT and Basic
  applications also get navigation access control — that is #2276

The strict behavior stays as it is on 25.1 and 25.2; it is announced as a behavior change in the
release notes. This PR is backported to both branches, so the setting arrives in 25.1.5 and
25.2.2.

## Verification

- `mvn -pl commons/deployment test` — 174 tests, 0 failures
  - `NavigationAccessControlEnabledTest` / `NavigationAccessControlDisabledTest` boot the
    extension and assert `isEnabled()` plus the presence of the checker; the disabled case also
    asserts the warning
  - `NavigationAccessControlCustomBeanTest` replaces the access control with an application
    provided bean that builds its checker itself, and asserts that it is turned off as well
  - `QuarkusHillaSecurityProcessorTest` covers the build step with and without form
    authentication
- `mvn -Pit-tests,production -Dquarkus-hilla.test-mode=production -Dtest='NavigationAccessControlDisabledTest,SecurityTest' test`
  in `integration-tests/security-form-tests` — 15 tests, 0 failures. The new class reuses
  `FlowDefaultDenyView` from #2264 and asserts the opposite direction: with the check off the
  unannotated view is displayed, and `flow-protected` opens without a login. `SecurityTest`
  covers the login flow, which the change to `setLoginView` touches.
- `mvn -pl commons/runtime,commons/deployment spotless:apply`


🤖 Generated with [Claude Code](https://claude.com/claude-code)
